### PR TITLE
move cassette files into the cassette code and retain for future (Issue #36)

### DIFF
--- a/Cassette.h
+++ b/Cassette.h
@@ -26,8 +26,6 @@ This file is part of VCC (Virtual Color Computer).
 #define WAV 0
 #define WRITEBUFFERSIZE	0x1FFFF
 
-extern char LastCassPath[MAX_PATH];
-
 unsigned int GetTapeCounter(void);
 unsigned int LoadTape(void);
 void SetTapeCounter(unsigned int);
@@ -35,6 +33,14 @@ void SetTapeMode(unsigned char);
 void Motor(unsigned char);
 void LoadCassetteBuffer(unsigned char *);
 void FlushCassetteBuffer(unsigned char *,unsigned int);
-void GetTapeName(char *);
+
+void setTapeName(const char* const name);
+
+namespace Cassette 
+{
+	void writeConfig(const char* const path);
+	void readConfig(const char* const path);
+	const char* getTapeName();
+};
 
 #endif


### PR DESCRIPTION
This moves the cassette filenames into the cassette.c code (as well as writing the config of it) and retains the loaded cassette across restarts.