### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -35,7 +35,7 @@ This file is part of VCC (Virtual Color Computer).
 #define COLORBURST (double)3579545 
 #define AUDIOBUFFERS 12
 //Misc
-#define MAX_LOADSTRING 100
+#define MAX_LOADSTRING 260
 #define QUERY 255
 #define INDEXTIME ((LINESPERSCREEN * TARGETFRAMERATE)/5)
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V512 A call of the 'sprintf' function will lead to overflow of the buffer 'Temp'. pakinterface.c 258