### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -443,8 +443,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 				if ( LOWORD(wParam) == INSERTBTN[Temp] )
 				{
 					LoadCartDLL(Temp,ModulePaths[Temp]);
-					for (Temp=0;Temp<4;Temp++)
-						SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,strlen(SlotLabel[Temp]),(LPARAM)(LPCSTR)SlotLabel[Temp] );
+					SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,strlen(SlotLabel[Temp]),(LPARAM)(LPCSTR)SlotLabel[Temp] );
 				}
 			}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V535 The variable 'Temp' is being used for this loop and for the outer loop. Check lines: 441, 446. mpi.cpp 446