### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -266,7 +266,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 			SendDlgItemMessage(hDlg,IDC_KBLEDS,BM_SETCHECK,UseKeyboardLeds(QUERY),0);
 			SendDlgItemMessage(hDlg,IDC_TURBO,BM_SETCHECK,SetTurboDisk(QUERY),0);
 			SendDlgItemMessage(hDlg,IDC_PERSIST,BM_SETCHECK,PersistDisks,0);
-			for (temp=0;temp<=3;temp++)
+			for (temp=0;temp<3;temp++)
 				SendDlgItemMessage(hDlg,ChipChoice[temp],BM_SETCHECK,(temp==TempSelectRom),0);
 			for (temp=0;temp<2;temp++)
 				for (temp2=0;temp2<5;temp2++)
@@ -325,10 +325,10 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 				case IDC_EXTROM:
 				case IDC_TRSDOS:
 				case IDC_RGB:
-					for (temp=0;temp<=3;temp++)
+					for (temp=0;temp<3;temp++)
 						if (LOWORD(wParam)==ChipChoice[temp])
 						{
-							for (temp2=0;temp2<=3;temp2++)
+							for (temp2=0;temp2<3;temp2++)
 								SendDlgItemMessage(hDlg,ChipChoice[temp2],BM_SETCHECK,0,0);
 							SendDlgItemMessage(hDlg,ChipChoice[temp],BM_SETCHECK,1,0);
 							TempSelectRom=temp;
@@ -497,7 +497,7 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 		case WM_INITDIALOG:
 			for (temp=0;temp<=2;temp++)
 				SendDlgItemMessage(hDlg,DiskType[temp],BM_SETCHECK,(temp==NewDiskType),0);
-			for (temp=0;temp<=3;temp++)
+			for (temp=0;temp<3;temp++)
 				SendDlgItemMessage(hDlg,DiskTracks[temp],BM_SETCHECK,(temp==NewDiskTracks),0);
 			SendDlgItemMessage(hDlg,IDC_DBLSIDE,BM_SETCHECK,DblSided,0);
 			strcpy(Dummy,TempFileName);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V557 Array overrun is possible. The value of 'temp' index could reach 3. fd502.cpp