### PR TITLE
Fix issues #29 and #30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.pch.*
 *.gch
 *.aps
+*.vscode
 
 Debug
 Release
@@ -32,3 +33,5 @@ vcc/disk11.rom
 *.opendb
 *.db
 *.user
+*.*~
+*~

--- a/Vcc.c
+++ b/Vcc.c
@@ -59,7 +59,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "throttle.h"
 #include "DirectDrawInterface.h"
 
-#include "CommandLine.h" //EJJ
+#include "CommandLine.h"
 //#include "logger.h"
 
 static HANDLE hout=NULL;
@@ -124,13 +124,12 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	OleInitialize(NULL); //Work around fixs app crashing in "Open file" system dialogs (related to Adobe acrobat 7+
 	LoadString(hInstance, IDS_APP_TITLE,g_szAppName, MAX_LOADSTRING);
 
-	GetCmdLineArgs(lpCmdLine);                   //EJJ parse command line
-//	PrintLogC("VCC Startup\n");
+	GetCmdLineArgs(lpCmdLine);                   //Parse command line
 
-	if ( strlen(CmdArg.QLoadFile) !=0)           //EJJ was lpCmdLine
+	if ( strlen(CmdArg.QLoadFile) !=0)
 	{
-		strcpy(QuickLoadFile, CmdArg.QLoadFile); //EJJ was lpCmdLine
-		strcpy(temp1, CmdArg.QLoadFile);         //EJJ was lpCmdLine
+		strcpy(QuickLoadFile, CmdArg.QLoadFile);
+		strcpy(temp1, CmdArg.QLoadFile);
 		PathStripPath(temp1);
 		_strlwr(temp1);
 		temp1[0]=toupper(temp1[0]);
@@ -739,10 +738,10 @@ void SaveConfig(void) {
     if ( GetOpenFileName (&ofn) ) {
         if (ofn.nFileExtension == 0) strcat(newini, ".ini");  //Add extension if none
         WriteIniFile();                                       // Flush current config
-        if (strcmp(curini,newini) != 0) {
+        if (_stricmp(curini,newini) != 0) {
             if (! CopyFile(curini,newini,false) ) {           // Copy it to new file
-                MessageBox(0,"Config save failed","error",0);
-            }
+                MessageBox(0,"Copy config failed","error",0);
+			}
         }
     }
     return;

--- a/logger.c
+++ b/logger.c
@@ -20,38 +20,45 @@ This file is part of VCC (Virtual Color Computer).
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>  // EJJ for PrintLogC
-#include "tcc1014mmu.h"	//Need memread for CpuDump
+#include <stdarg.h>		// For PrintLogC
+#include "tcc1014mmu.h"	// Need memread for CpuDump
 #include "logger.h"
+
+static FILE  *fLogOut=NULL;
+static HANDLE hLog_Out=NULL;
 
 void WriteLog(char *Message,unsigned char Type)
 {
-	static HANDLE hout=NULL;
-	static FILE  *disk_handle=NULL;
+	static int newconsole=0;
 	unsigned long dummy;
 	switch (Type)
 	{
 	case TOCONS:
-		if (hout==NULL)
-		{
-			AllocConsole();
-			hout=GetStdHandle(STD_OUTPUT_HANDLE);
-			SetConsoleTitle("Logging Window"); 
+		if (hLog_Out==NULL) {
+			// Write existing console. Create a new one if that fails
+			hLog_Out=GetStdHandle(STD_OUTPUT_HANDLE);
+			char heading[]="\n -- Vcc Log --\n";
+			if (!WriteFile(hLog_Out,heading,strlen(heading),&dummy,0)) {
+				AllocConsole();
+				hLog_Out=GetStdHandle(STD_OUTPUT_HANDLE);
+				SetConsoleTitle("Logging Window");
+				newconsole = 1;
+			}
 		}
-		WriteConsole(hout,Message,strlen(Message),&dummy,0);
+		if (newconsole) {
+			WriteConsole(hLog_Out,Message,strlen(Message),&dummy,0);
+		} else {
+			WriteFile(hLog_Out,Message,strlen(Message),&dummy,0);
+		}
 		break;
 
 	case TOFILE:
-	if (disk_handle ==NULL)
-		disk_handle=fopen("c:\\VccLog.txt","w");
-
-	fprintf(disk_handle,"%s\r\n",Message);
-	fflush(disk_handle);
-	break;
+		if (fLogOut ==NULL) fLogOut=fopen("c:\\VccLog.txt","w");
+		fprintf(fLogOut,"%s\r\n",Message);
+		fflush(fLogOut);
+		break;
 	}
-
 }
-
 
 void CpuDump(void)
 {
@@ -65,7 +72,7 @@ void CpuDump(void)
 	return;
 }
 
-//<EJJ> Added PrintLogC - Put formatted string to the console
+// PrintLogC - Put formatted string to the console
 void PrintLogC(const void * fmt, ...)
 {
 	va_list args;
@@ -74,4 +81,11 @@ void PrintLogC(const void * fmt, ...)
 	vsnprintf(str, 512, (char *)fmt, args);
 	va_end(args);
 	WriteLog(str, TOCONS);
+}
+
+// OpenLogFile - open non-default file for logging
+void OpenLogFile(char * logfile)
+{
+	if (fLogOut == NULL) fclose(fLogOut);
+	fLogOut=fopen(logfile,"wb");
 }

--- a/logger.h
+++ b/logger.h
@@ -20,9 +20,8 @@ This file is part of VCC (Virtual Color Computer).
 
 void WriteLog(char *,unsigned char);
 void CpuDump(void);
-
-//EJJ added formatted print to console
 void PrintLogC(const void * fmt, ...);
+void OpenLogFile(char * filename);
 
 #define TOCONS	0
 #define TOFILE	1


### PR DESCRIPTION
Fix issues VCCE#29 and VCCE#30

29: Modified SaveConfig() in Vcc.c to use case insensitive compare to
detect attempt to copy ini file to it'self
30: Modified LoadConfig() in config.c to actually open or create ini
file and abort program if this can not be done.

Following only affects developers:
Use existing console for logging if launched from working console.
Add .vscode and vim style backup files '*~' to .gitignore.
Cleanup some comment clutter.