### PR TITLE
Fixed border color bug

### DIFF
--- a/tcc1014graphics.c
+++ b/tcc1014graphics.c
@@ -9659,7 +9659,11 @@ void SetupDisplay(void)
 
 		if (GraphicsMode)
 		{
-			CC3BoarderColor=63;
+			ColorSet = (CC2VDGPiaMode & 1);
+			if (ColorSet == 0)
+				CC3BoarderColor = 18; //18 Bright Green
+			else
+				CC3BoarderColor = 63; //63 White 
 			BoarderChange=3;
 			Bpp=CC2Bpp[ (CC2VDGPiaMode & 15) >>1 ];
 			BytesperRow=CC2BytesperRow[ (CC2VDGPiaMode & 15) >>1 ];
@@ -9940,7 +9944,6 @@ unsigned char SetMonitorType(unsigned char Type)
 	return(MonType);
 }
 void SetPaletteType() {
-	 
 	int tmp = CC3BoarderColor;
 	SetGimeBoarderColor(0);
 	MakeCMPpalette();


### PR DESCRIPTION
VCC now chooses the border color based on the chosen color set in the video register ($FF22). This should resolve issue #67.
