### PR TITLE
Permit extended keyboard arrow keys to be used for keyboard joystick

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -675,6 +675,9 @@ char SetMouseStatus(char ScanCode,unsigned char Phase)
 {
 	char ReturnValue=ScanCode;
 
+	// Allow extended keyboard arrow keys
+	ScanCode = ScanCode & 0x7F;
+
 	switch (Phase)
 	{
 	case 0:


### PR DESCRIPTION
Note: While keys are mapped to joystick(s) the keypad 4,8,6,
and 2 keys will also be mapped as arrow keys.  Keys mapped to the
joystick(s) will no longer have their normal function.