### PR TITLE
Fixed Clipboard Paste Feature

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -82,30 +82,27 @@ namespace VCC { namespace Debugger
 
 	void Debugger::Halt()
 	{
-		SectionLocker lock(Section_);
-
 		ExecutionMode_ = ExecutionMode::Halt;
 	}
 
 
 	bool Debugger::IsHalted() const
 	{
-		SectionLocker lock(Section_);
-
 		return ExecutionMode_ == ExecutionMode::Halt;
 	}
 
 
 	bool Debugger::IsHalted(unsigned short& returnPc) const
 	{
-		SectionLocker lock(Section_);
-
 		if (ExecutionMode_ != ExecutionMode::Halt)
 		{
 			return false;
 		}
 
-		returnPc = ProcessorState_.PC;
+		{
+			SectionLocker lock(Section_);
+			returnPc = ProcessorState_.PC;
+		}
 
 		return true;
 	}
@@ -113,11 +110,8 @@ namespace VCC { namespace Debugger
 
 	bool Debugger::IsStepping() const
 	{
-		SectionLocker lock(Section_);
-
 		return ExecutionMode_ == ExecutionMode::Step;
 	}
-
 
 
 
@@ -159,15 +153,11 @@ namespace VCC { namespace Debugger
 
 	bool Debugger::IsTracingEnabled() const
 	{
-		SectionLocker lock(Section_);
-
 		return TraceEnabled_;
 	}
 
 	bool Debugger::IsTracing() const
 	{
-		SectionLocker lock(Section_);
-
 		return TraceRunning_;
 	}
 
@@ -209,8 +199,6 @@ namespace VCC { namespace Debugger
 
 	void Debugger::CheckStopTrace(CPUState state)
 	{
-		SectionLocker lock(Section_);
-
 		if (!TraceRunning_)
 		{
 			return;
@@ -237,8 +225,6 @@ namespace VCC { namespace Debugger
 
 	void Debugger::TraceCaptureScreenEvent(TraceEvent evt, double cycles)
 	{
-		SectionLocker lock(Section_);
-
 		if (!TraceRunning_ || !TraceScreen_)
 		{
 			return;
@@ -249,8 +235,6 @@ namespace VCC { namespace Debugger
 
 	void Debugger::TraceEmulatorCycle(TraceEvent evt, int state, double lineNS, double irqNS, double soundNS, double cycles, double drift)
 	{
-		SectionLocker lock(Section_);
-
 		if (!TraceRunning_ || !TraceEmulation_)
 		{
 			return;
@@ -261,40 +245,33 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceEnable()
 	{
-		SectionLocker lock(Section_);
-
 		TraceEnabled_ = true;
 	}
 
 	void Debugger::SetTraceDisable()
 	{
-		SectionLocker lock(Section_);
-
 		TraceEnabled_ = false;
 	}
 
 	void Debugger::TraceStart()
 	{
-		SectionLocker lock(Section_);
-
 		TraceRunning_ = true;
 	}
 
 	void Debugger::TraceStop()
 	{
-		SectionLocker lock(Section_);
-
 		TraceRunning_ = false;
 		TraceEnabled_ = false;
 	}
 
 	void Debugger::ResetTrace()
 	{
-		SectionLocker lock(Section_);
-
 		TraceEnabled_ = false;
 		TraceRunning_ = false;
-		Decoder_->Reset(TraceMaxSamples_);
+		{
+			SectionLocker lock(Section_);
+			Decoder_->Reset(TraceMaxSamples_);
+		}
 	}
 
 	void Debugger::SetTraceMaxSamples(long samples)

--- a/Debugger.h
+++ b/Debugger.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <atomic>
 #include <Windows.h>
 #include "OpDecoder.h"
 
@@ -137,14 +138,14 @@ namespace VCC { namespace Debugger
 		bool							BreakpointsChanged_ = false;
 		CPUState						ProcessorState_;
 		std::map<HWND, std::unique_ptr<Client>>	RegisteredClients_;
-		ExecutionMode					ExecutionMode_ = ExecutionMode::Run;
+		std::atomic<ExecutionMode>		ExecutionMode_ = ExecutionMode::Run;
 		//
 		bool							HasPendingWrite_ = false;
 		PendingWrite					PendingWrite_;
 		//
 		std::unique_ptr<OpDecoder>		Decoder_;
-		bool							TraceEnabled_ = false;
-		bool							TraceRunning_ = false;
+		std::atomic<bool>				TraceEnabled_ = false;
+		std::atomic<bool>				TraceRunning_ = false;
 		size_t							TraceMaxSamples_ = 500000;
 		long							TraceSamplesCollected_ = 0;
 		bool							TraceEmulation_ = false;

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -49,6 +49,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	enum class TraceStatus
 	{
 		Empty,
+		Enabled,
 		Collecting,
 		LoadPage,
 		Loaded
@@ -189,7 +190,8 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		HWND hCtl = GetDlgItem(hWndExecutionTrace, IDC_TRACE_STATUS);
 		SetWindowText(hCtl, "Trace is running");
 
-		RECT rect = *clientRect;
+		RECT rect;
+		GetClientRect(hWndTrace, &rect);
 
 		HFONT hFont = CreateFont(24, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
 			CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, FIXED_PITCH, TEXT("Consolas"));
@@ -224,8 +226,10 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		DeleteObject(hFont);
 	}
 
-	void DrawSamples(HDC hdc, LPRECT clientRect, long samples)
+	void DrawSamples(HDC hdc, LPRECT clientRect)
 	{
+		long samples = EmuState.Debugger.GetTraceSamples();
+
 		// Nothing collected yet?
 		if (samples == 0)
 		{
@@ -233,25 +237,20 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 			return;
 		}
 
-		// Collection finished?
-		if (status == TraceStatus::Collecting || status == TraceStatus::Loaded)
-		{
-			status = TraceStatus::LoadPage;
+		// Indicate what we collected.
+		std::stringstream ss;
+		ss << samples << " collected";
 
-			std::stringstream ss;
-			ss << samples << " collected";
+		HWND hCtl = GetDlgItem(hWndExecutionTrace, IDC_TRACE_STATUS);
+		SetWindowText(hCtl, ss.str().c_str());
 
-			HWND hCtl = GetDlgItem(hWndExecutionTrace, IDC_TRACE_STATUS);
-			SetWindowText(hCtl, ss.str().c_str());
-
-			// Adjust Vertical Scrollbar based on samples collected.
-			SCROLLINFO si;
-			si.cbSize = sizeof(si);
-			si.fMask = SIF_ALL;
-			GetScrollInfo(hWndVScrollBar, SB_CTL, &si);
-			si.nMax = samples;
-			SetScrollInfo(hWndVScrollBar, SB_CTL, &si, TRUE);
-		}
+		// Adjust Vertical Scrollbar based on samples collected.
+		SCROLLINFO si;
+		si.cbSize = sizeof(si);
+		si.fMask = SIF_ALL;
+		GetScrollInfo(hWndVScrollBar, SB_CTL, &si);
+		si.nMax = samples;
+		SetScrollInfo(hWndVScrollBar, SB_CTL, &si, TRUE);
 
 		// Draw the collection.
 		RECT rect = *clientRect;
@@ -264,7 +263,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		SelectObject(hdc, pen);
 
 		// Load page?
-		if (status == TraceStatus::LoadPage)
+		if (currentTrace.size() == 0 || status == TraceStatus::LoadPage)
 		{
 			EmuState.Debugger.GetTraceResult(currentTrace, traceOffset, tracePage);
 			status = TraceStatus::Loaded;
@@ -615,7 +614,6 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 
 		// Get tracing status.
 		bool tracing = EmuState.Debugger.IsTracing();
-		long samples = EmuState.Debugger.GetTraceSamples();
 
 		// Show tracing is in progress.
 		if (tracing)
@@ -624,7 +622,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 			return;
 		}
 
-		DrawSamples(hdc, clientRect, samples);
+		DrawSamples(hdc, clientRect);
 	}
 
 	void ResizeWindow(int width, int height)
@@ -906,6 +904,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		EmuState.Debugger.SetTraceEnable();
 		HWND hCtl = GetDlgItem(hWndExecutionTrace, IDC_TRACE_STATUS);
 		SetWindowText(hCtl, "Trace is running");
+		status == TraceStatus::Enabled;
 	}
 
 	void StopTrace()

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -904,7 +904,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		EmuState.Debugger.SetTraceEnable();
 		HWND hCtl = GetDlgItem(hWndExecutionTrace, IDC_TRACE_STATUS);
 		SetWindowText(hCtl, "Trace is running");
-		status == TraceStatus::Enabled;
+		status = TraceStatus::Enabled;
 	}
 
 	void StopTrace()

--- a/OpDecoder.cpp
+++ b/OpDecoder.cpp
@@ -120,7 +120,7 @@ namespace VCC { namespace Debugger
 			}
 			trace.push_back(TraceCaptured_[n]);
 		}
-		return trace.size();;
+		return trace.size();
 	}
 
 	size_t OpDecoder::GetSampleCount() const

--- a/keyboard.c
+++ b/keyboard.c
@@ -72,7 +72,8 @@ bool GetNextScanInPasteQueue(unsigned char col);
 std::queue<unsigned char> PasteInputQueue;
 LARGE_INTEGER Frequency;
 LARGE_INTEGER LastAdvance;
-double PasteDelay = 0.005;
+double PasteDelay = 0.008;		// This is the interkey delay in seconds - it sets the time between KEYDOWN and KEYUP
+
 int CurrentThrottle = 0;
 
 enum PasteState

--- a/keyboard.h
+++ b/keyboard.h
@@ -20,6 +20,8 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 /*****************************************************************************/
+#include <string>
+
 
 typedef enum keyevent_e
 {
@@ -85,3 +87,4 @@ extern "C"
 
 bool GetPaste();
 void SetPaste(bool);
+void PasteIntoQueue(std::string txt);


### PR DESCRIPTION
Fixed the Clipboard Paste feature and reduced the Frame Loading by ExecutionTrace

* Changed out the CriticalSections to std::atomic<bool> for certain bools used by the CPUs - this provided a good frame boost.
* Fixed the clipboard paste to use an independent paste timer for more reliable pasting.
* Cleaned up some Execution Trace logic to handle conditions when the trace collects samples so fast that the Execution Trace Window doesn't realize it has completed.