### PR TITLE
Restore IRQWaiter function

### DIFF
--- a/hd6309.c
+++ b/hd6309.c
@@ -7002,10 +7002,10 @@ int HD6309Exec(int CycleFor)
 
 			if (PendingInterupts & 1)
 			{
-//				if (IRQWaiter == 0)	// This is needed to fix a subtle timming problem
+				if (IRQWaiter == 0)	// This is needed to fix a subtle timming problem
 					cpu_irq();		// It allows the CPU to see $FF03 bit 7 high before
-//				else				// The IRQ is asserted.
-//					IRQWaiter -= 1;
+				else				// The IRQ is asserted.
+					IRQWaiter -= 1;
 			}
 		}
 

--- a/mc6809.c
+++ b/mc6809.c
@@ -176,10 +176,10 @@ while (CycleCounter<CycleFor) {
 
 		if (PendingInterupts & 1)
 		{
-//			if (IRQWaiter==0)	// This is needed to fix a subtle timming problem
+			if (IRQWaiter==0)	// This is needed to fix a subtle timming problem
 				cpu_irq();		// It allows the CPU to see $FF03 bit 7 high before
-//			else				// The IRQ is asserted.
-//				IRQWaiter-=1;
+			else				// The IRQ is asserted.
+				IRQWaiter-=1;
 		}
 	}
 


### PR DESCRIPTION
PR#16 (Execution Trace) commented out the IRQWaiter function in mc6809.c and hc6309.c which broke the shanghai game.  This change reverts to the original IRQWaiter code,