### PR TITLE
Comment out redundant LoadConfig in Vcc.c

### DIFF
--- a/Vcc.c
+++ b/Vcc.c
@@ -154,7 +154,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
 	EmuState.WindowSize.x=640;
 	EmuState.WindowSize.y=480;
-	LoadConfig(&EmuState);
+	//LoadConfig(&EmuState);
 	InitInstance(hInstance, nCmdShow);
 	if (!CreateDDWindow(&EmuState))
 	{


### PR DESCRIPTION
Discovered an extra call to LoadConfig in Vcc WinMain.  This comments out the first one.