### PR TITLE
Establish custom keymap filename sooner in config

### DIFF
--- a/config.c
+++ b/config.c
@@ -324,7 +324,12 @@ unsigned char ReadIniFile(void)
 	if (CurrentConfig.KeyMap>3)
 		CurrentConfig.KeyMap=0;	//Default to DECB Mapping
 
-	if (CurrentConfig.KeyMap == kKBLayoutCustom) LoadCustomKeyMap(GetKeyMapFilePath());
+	GetPrivateProfileString("Misc","CustomKeyMapFile","",KeyMapFilePath,MAX_PATH,IniFilePath);
+	if (*KeyMapFilePath == '\0') {
+		strcpy(KeyMapFilePath, AppDataPath);
+		strcat(KeyMapFilePath, "\\custom.keymap");
+	}
+	if (CurrentConfig.KeyMap == kKBLayoutCustom) LoadCustomKeyMap(KeyMapFilePath);
 	vccKeyboardBuildRuntimeTable((keyboardlayout_e)CurrentConfig.KeyMap);
 
 	CheckPath(CurrentConfig.ModulePath);
@@ -352,15 +357,6 @@ unsigned char ReadIniFile(void)
 	GetPrivateProfileString("DefaultPaths", "CassPath", "", CurrentConfig.CassPath, MAX_PATH, IniFilePath);
 	GetPrivateProfileString("DefaultPaths", "FloppyPath", "", CurrentConfig.FloppyPath, MAX_PATH, IniFilePath);
 	GetPrivateProfileString("DefaultPaths", "COCO3ROMPath", "", CurrentConfig.COCO3ROMPath, MAX_PATH, IniFilePath);
-
-//  Establish custom keymap file path
-	GetPrivateProfileString("Misc","CustomKeyMapFile","",KeyMapFilePath,MAX_PATH,IniFilePath);
-	if (*KeyMapFilePath == '\0') {
-	    strcpy(KeyMapFilePath, AppDataPath);
-		strcat(KeyMapFilePath, "\\");
-		strcat(KeyMapFilePath, "custom.keymap");
-	}
-
 
 	for (Index = 0; Index < NumberOfSoundCards; Index++)
 	{


### PR DESCRIPTION
Config was attempting to load the custom keymap file before it's name was established.  Previous to commit 1a21cea LoadConfig was being called twice. The extra call hid the keymap issue.