### PR TITLE
MAX-10 fix

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,9 +1,10 @@
 
 Vcc v2.1.0.8 April/2023
+  o Increase VSYNC IRQ delay so MAX-10 sees keystrokes.
   o Added RS232 Pak emulation (acia.dll) - EJ Jaquay
   o Added pause function - James Rye
   o Added execution trace feature to Vcc Debugger - Mike Rojas
-  o Fixed PMODE 4 color - James Rye
+  o Fixed PMODE 4 color - James Rye, Mike Rojas
   o Improved windows mouse cursor position when shown - Chet Simpson  
   o Minor Bug fixes
   o Updated Manual
@@ -16,7 +17,7 @@ VCC 2.1.0.6  May/2022
   o Added "Show Windows Mouse Pointer checkbox" to the "Joystick" menu.
     When unchecked the Windows mouse pointer is hidden from the VCC screen
   o Several bug fixes in keymap editor
-  o Fixed a bug that could error copies from VHD 0 to VHD 1
+  o Fixed a bug that prevented formating empty VHD files.
   o Add RS & CocoMax3 Hirez interfaces (FINALLY!)
   o Added feature to Hard Drive Insert mode to create a new VHD
   o Fixed a keyboard bug which was affecting the play of Tetris.

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 
 Vcc v2.1.0.8 April/2023
   o Increase VSYNC IRQ delay so MAX-10 sees keystrokes.
+  o Corrected some 6309 register instruction issues found by Wally Z.
   o Added RS232 Pak emulation (acia.dll) - EJ Jaquay
   o Added pause function - James Rye
   o Added execution trace feature to Vcc Debugger - Mike Rojas

--- a/joystickinput.c
+++ b/joystickinput.c
@@ -16,7 +16,6 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define DIRECTINPUT_VERSION 0x0800
 
 #include <windows.h>
 #include "defines.h"

--- a/joystickinput.h
+++ b/joystickinput.h
@@ -18,6 +18,7 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 #include "mc6821.h"
 #define MAXSTICKS 10

--- a/mc6821.c
+++ b/mc6821.c
@@ -350,8 +350,7 @@ void irq_fs(int phase)	//60HZ Vertical sync pulse 16.667 mS
 		if ( (rega[3] & 2)==0 ) //IRQ on High to low transition
 			rega[3]=(rega[3] | 128);
 		if (rega[3] & 1)
-			CPUAssertInterupt(IRQ,1);
-
+			CPUAssertInterupt(IRQ,4);
 		return;
 	break;
 


### PR DESCRIPTION
Additional delay for IRQ on VSYNC High to Low transition.  MAX-10 uses the IRQ to check PIA0 for keyboard and mouse button presses but was not catching the interupts soon enough.  CPUAssertInterupt(IRQ,1) changed to CPUAssertInterupt(IRQ,4).   This addresses issue #132.