### PR TITLE
Correct 6309 band and related instructions

### DIFF
--- a/hd6309.c
+++ b/hd6309.c
@@ -2256,16 +2256,16 @@ void Band(void)
 
 	if ((temp8 & (1 << Source)) == 0)
 	{
-    switch (postbyte)
-    {
-    case 0 : // A Reg
-    case 1 : // B Reg
-      *ureg8[postbyte] &= ~(1 << Dest);
-      break;
-    case 2 : // CC Reg
-      setcc(getcc() & ~(1 << Dest));
-      break;
-    }
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() & ~(1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] &= ~(1 << Dest);
+            break;
+        }
 	}
 	// Else nothing changes
 	CycleCounter+=NatEmuCycles76;
@@ -2287,16 +2287,16 @@ void Biand(void)
 
 	if ((temp8 & (1 << Source)) != 0)
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] &= ~(1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() & ~(1 << Dest));
-      break;
-    }
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() & ~(1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] &= ~(1 << Dest);
+            break;
+        }
   }
 	// Else do nothing
 	CycleCounter+=NatEmuCycles76;
@@ -2318,16 +2318,16 @@ void Bor(void)
 
 	if ((temp8 & (1 << Source)) != 0)
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] |= (1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() | (1 << Dest));
-      break;
-    }
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() | (1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] |= (1 << Dest);
+            break;
+        }
 	}
 	// Else do nothing
 	CycleCounter+=NatEmuCycles76;
@@ -2349,16 +2349,16 @@ void Bior(void)
 
 	if ((temp8 & (1 << Source)) == 0)
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] |= (1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() | (1 << Dest));
-      break;
-    }
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() | (1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] |= (1 << Dest);
+            break;
+        }
   }
 	// Else do nothing
 	CycleCounter+=NatEmuCycles76;
@@ -2380,16 +2380,16 @@ void Beor(void)
 
 	if ((temp8 & (1 << Source)) != 0)
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] ^= (1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() ^ (1 << Dest));
-      break;
-    }
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() ^ (1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] ^= (1 << Dest);
+            break;
+        }
 	}
 	CycleCounter+=NatEmuCycles76;
 }
@@ -2410,17 +2410,17 @@ void Bieor(void)
 
 	if ((temp8 & (1 << Source)) == 0)
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] ^= (1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() ^ (1 << Dest));
-      break;
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() ^ (1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] ^= (1 << Dest);
+            break;
+        }
     }
-  }
 	CycleCounter+=NatEmuCycles76;
 }
 
@@ -2440,29 +2440,29 @@ void Ldbt(void)
 
 	if ((temp8 & (1 << Source)) != 0)
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] |= (1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() | (1 << Dest));
-      break;
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() | (1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] |= ~(1 << Dest);
+            break;
+        }
     }
-  }
 	else
 	{
-    switch (postbyte)
-    {
-    case 0: // A Reg
-    case 1: // B Reg
-      *ureg8[postbyte] &= ~(1 << Dest);
-      break;
-    case 2: // CC Reg
-      setcc(getcc() & ~(1 << Dest));
-      break;
-    }
+        switch (postbyte)
+        {
+        case 0 : // CC Reg
+            setcc(getcc() & ~(1 << Dest));
+            break;
+        case 1 : // A Reg
+        case 2 : // B Reg
+            *ureg8[postbyte-1] &= ~(1 << Dest);
+            break;
+        }
 	}
 	CycleCounter+=NatEmuCycles76;
 }
@@ -2482,16 +2482,16 @@ void Stbt(void)
 		return;
 	}
 
-  switch (postbyte)
-  {
-  case 0: // A Reg
-  case 1: // B Reg
-    postbyte = *ureg8[postbyte];
-    break;
-  case 2: // CC Reg
-    postbyte = getcc();
-    break;
-  }
+    switch (postbyte)
+    {
+    case 0: // CC Reg
+        postbyte = getcc();
+        break;
+    case 1: // A Reg
+    case 2: // B Reg
+        postbyte = *ureg8[postbyte-1];
+        break;
+    }
 
 	if ((postbyte & (1 << Source)) != 0)
 	{


### PR DESCRIPTION
Wally Zambotti discovered an issue with 6309 band, biand, bor, bior, beor, bieor, stbt, and ldbt in hd6309.c where the incorrect registers were being used.  This patch corrects the issue and matches the same corrections Wally recently made to OVCC.