### PR TITLE
Reinstate Fix blinking text in 40 and 80 text modes

### DIFF
--- a/coco3.cpp
+++ b/coco3.cpp
@@ -42,6 +42,8 @@ This file is part of VCC (Virtual Color Computer).
 
 //int CPUExeca(int);
 
+#define RENDERS_PER_BLINK_TOGGLE 16
+
 //****************************************
 	static double SoundInterupt=0;
 	static double NanosToSoundSample=SoundInterupt;
@@ -102,7 +104,12 @@ float RenderFrame (SystemState *RFState)
 	static unsigned short FrameCounter=0;
 
 //********************************Start of frame Render*****************************************************
-	SetBlinkState(BlinkPhase);
+
+	// Blink state toggle
+	if (BlinkPhase++ > RENDERS_PER_BLINK_TOGGLE) {
+		TogBlinkState();
+		BlinkPhase = 0;
+	}
 
 	// VSYNC goes Low
 	VSYNC(0);

--- a/tcc1014graphics.c
+++ b/tcc1014graphics.c
@@ -9511,9 +9511,9 @@ void DrawBottomBoarder32(SystemState *DTState)
 	return;
 }
 
-void SetBlinkState(unsigned char Tmp)
+void TogBlinkState()
 {
-	BlinkState=Tmp;
+	BlinkState = BlinkState ^ 1;
 	return;
 }
 

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -65,7 +65,7 @@ int GetGraphicsMode();
 
 //void Cls(unsigned int);
 unsigned char SetScanLines(unsigned char);
-void SetBlinkState(unsigned char);
+void TogBlinkState();
 static unsigned char Lpf[4]={192,199,225,225}; // 2 is really undefined but I gotta put something here.
 static unsigned char VcenterTable[4]={29,23,12,12};
 static unsigned char TopOffScreenTable[4] = { 11,14,11,11 };


### PR DESCRIPTION
Further testing revealed problem was with Nitros9 version used