### PR TITLE
Autopaste

### DIFF
--- a/CommandLine.h
+++ b/CommandLine.h
@@ -21,9 +21,11 @@ This file is part of VCC (Virtual Color Computer).
 
 // Declare global variables defined by GetCmdLineArgs
 #define CL_MAX_PATH 256
+#define CL_MAX_PASTE 256
 struct CmdLineArguments {
 	char QLoadFile[CL_MAX_PATH];
 	char IniFile[CL_MAX_PATH];
+	char PasteText[CL_MAX_PASTE];
 	int  Logging;
 };
 extern struct CmdLineArguments CmdArg;

--- a/Vcc.c
+++ b/Vcc.c
@@ -75,6 +75,7 @@ static bool DialogOpen=false;
 static unsigned char Throttle=0;
 static unsigned char AutoStart=1;
 static unsigned char Qflag=0;
+static unsigned char Pflag=0;
 static char CpuName[20]="CPUNAME";
 
 char QuickLoadFile[256];         // No real purpose
@@ -174,6 +175,11 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	SetClockSpeed(1);	//Default clock speed .89 MHZ	
 	BinaryRunning = true;
 	EmuState.EmulationRunning=AutoStart;
+
+	if (strlen(CmdArg.PasteText)!=0) {
+		Pflag=255;
+	}
+
 	if (strlen(CmdArg.QLoadFile)!=0)
 	{
 		Qflag=255;
@@ -928,10 +934,16 @@ unsigned __stdcall EmuLoop(void *Dummy)
 				Sleep(1);
 		}
 		FPS=0;
-		if ((Qflag==255) & (FrameCounter==30))
+
+		if ((Qflag==255) && (FrameCounter==32))
 		{
 			Qflag=0;
 			QuickLoad(CmdArg.QLoadFile);
+		}
+
+		if ((Pflag==255) && (FrameCounter==32)) {
+			Pflag=0;
+			QueueText(CmdArg.PasteText);
 		}
 
 		StartRender();

--- a/Vcc.c
+++ b/Vcc.c
@@ -78,8 +78,6 @@ static unsigned char Qflag=0;
 static unsigned char Pflag=0;
 static char CpuName[20]="CPUNAME";
 
-char QuickLoadFile[256];         // No real purpose
-
 /***Forward declarations of functions included in this code module*****/
 BOOL				InitInstance	(HINSTANCE, int);
 LRESULT CALLBACK	About			(HWND, UINT, WPARAM, LPARAM);
@@ -142,20 +140,6 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	// Parse command line
 	memset(&CmdArg,0,sizeof(CmdArg));
 	if (strlen(lpCmdLine)>0) GetCmdLineArgs(lpCmdLine);
-
-	if ( strlen(CmdArg.QLoadFile) !=0)
-	{
-		strncpy(QuickLoadFile, CmdArg.QLoadFile, CL_MAX_PATH);
-		QuickLoadFile[CL_MAX_PATH-1]=0;
-		// Rest of this does not accomplish much
-		strcpy(temp1, CmdArg.QLoadFile);
-		PathStripPath(temp1);
-		_strlwr(temp1);
-		temp1[0]=toupper(temp1[0]);
-		strcat (temp1,temp2);
-		strcat(temp1,g_szAppName);
-		strcpy(g_szAppName,temp1);
-	}
 
 	EmuState.WindowSize.x=640;
 	EmuState.WindowSize.y=480;

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -94,6 +94,7 @@ std::string GetClipboardText();
 void HLINE(void);
 void VSYNC(unsigned char level);
 void HSYNC(unsigned char level);
+string CvtStrToSC(string);
 
 using namespace std;
 
@@ -620,11 +621,7 @@ unsigned char SetSndOutMode(unsigned char Mode)  //0 = Speaker 1= Cassette Out 2
 void PasteText() {
 	using namespace std;
 	std::string tmp;
-	string cliptxt, clipparse, lines, out, debugout;
-	char sc;
-	char letter;
-	bool CSHIFT;
-	bool LCNTRL;
+	string cliptxt, clipparse, lines, debugout;
 	int GraphicsMode = GetGraphicsMode();
 	if (GraphicsMode != 0) {
 		int tmp = MessageBox(0, "Warning: You are not in text mode. Continue Pasting?", "Clipboard", MB_YESNO);
@@ -670,8 +667,22 @@ void PasteText() {
 			clipparse += lines;
 		}
 	}
-	cliptxt = clipparse; 
+	PasteIntoQueue(CvtStrToSC(clipparse));
+}
 
+void QueueText(char * text) {
+	using namespace std;
+	std::string str(text);
+	PasteIntoQueue(CvtStrToSC(str));
+}
+
+std::string CvtStrToSC(string cliptxt)
+{
+	std::string out;
+	char sc;
+	char letter;
+	bool CSHIFT;
+	bool LCNTRL;
 	for (size_t pp = 0; pp <= cliptxt.size(); pp++) {
 		sc = 0;
 		CSHIFT = FALSE;
@@ -776,15 +787,13 @@ void PasteText() {
 		case '~': sc = 0x29; CSHIFT = TRUE; break;
 		case '_': sc = 0x0C; CSHIFT = TRUE; break;
 		case 0x09: sc = 0x39; break; // TAB
-		default: sc = static_cast<char>(0xFF);	break;
+		default: sc = -1; break;
 		}
 		if (CSHIFT) { out += 0x36; CSHIFT = FALSE; }
 		if (LCNTRL) { out += 0x1D; LCNTRL = FALSE; }
 		out += sc;
-
 	}
-
-	PasteIntoQueue(out);
+	return out;
 }
 
 std::string GetClipboardText()

--- a/coco3.h
+++ b/coco3.h
@@ -46,6 +46,7 @@ void MiscReset(void);
 void PasteBASICWithNew();
 void PasteBASIC();
 void PasteText();
+void QueueText(char *);
 void CopyText();
 void FlipArtifacts();
 unsigned short SetAudioRate (unsigned short);

--- a/config.c
+++ b/config.c
@@ -41,7 +41,9 @@ This file is part of VCC (Virtual Color Computer).
 #include "keyboardEdit.h"
 #include "fileops.h"
 #include "Cassette.h"
+#pragma warning(disable:4091)
 #include "shlobj.h"
+#pragma warning(default:4091)
 #include "CommandLine.h"
 #include "logger.h"
 #include <assert.h>


### PR DESCRIPTION
Adds autopaste argument for command line.

This impliments an enhancement mentioned in issue #149
Example usage, autostart nitros9 using nitros.ini for settings:
   C> vcc -i nitros.ini -p dos

Also corrects a bug that caused config dialog to become unresponsive when cartridge is quick loaded from the command line.
