### PR TITLE
Allow physical addressing in disassembly window

### DIFF
--- a/DebuggerUtils.cpp
+++ b/DebuggerUtils.cpp
@@ -93,15 +93,11 @@ namespace VCC { namespace Debugger
 
 		return numToRound - remainder;
 	}
-    // Get memory for Decode, CPU address or Physical Block + Address	
-	unsigned char DbgRead8(bool phyAddr, unsigned char block,unsigned short PC) {
 
-//unsigned int NumBlocks[4] = {0x2,0x8,0x20,0x80};
-//maxblock = EmuState.RamSize / 0x2000;
-//unsigned short GetMem(long address) {
-
+	// Get memory for Decode, CPU address or Physical Block + Address
+	unsigned char DbgRead8(bool phyAddr, unsigned short block, unsigned short PC) {
 		if (phyAddr) {
-			long addr = PC + block * 0x2000;
+			unsigned long addr = PC + block * 0x2000;
 			return (unsigned char) GetMem(addr);
 		} else {
 			return MemRead8(PC);

--- a/DebuggerUtils.cpp
+++ b/DebuggerUtils.cpp
@@ -17,11 +17,12 @@
 //		Debugger Utilities - Part of the Debugger package for VCC
 //		Author: Chet Simpson
 #include "Debugger.h"
+#include "tcc1014mmu.h"
 #include <sstream>
 #include <iomanip>
 #include <stdarg.h>
 #include <memory>
-
+#include "defines.h"
 
 namespace VCC { namespace Debugger
 {
@@ -91,6 +92,20 @@ namespace VCC { namespace Debugger
 			return numToRound;
 
 		return numToRound - remainder;
+	}
+    // Get memory for Decode, CPU address or Physical Block + Address	
+	unsigned char DbgRead8(bool phyAddr, unsigned char block,unsigned short PC) {
+
+//unsigned int NumBlocks[4] = {0x2,0x8,0x20,0x80};
+//maxblock = EmuState.RamSize / 0x2000;
+//unsigned short GetMem(long address) {
+
+		if (phyAddr) {
+			long addr = PC + block * 0x2000;
+			return (unsigned char) GetMem(addr);
+		} else {
+			return MemRead8(PC);
+		}
 	}
 	
 } }

--- a/DebuggerUtils.h
+++ b/DebuggerUtils.h
@@ -106,7 +106,7 @@ namespace VCC { namespace Debugger
 	bool replace(std::string& str, const std::string& from, const std::string& to);
 	int roundUp(int numToRound, int multiple);
 	int roundDn(int numToRound, int multiple);
-
+	unsigned char DbgRead8(bool phyAddr, unsigned char block, unsigned short PC);
 } }
 
 namespace VCC { namespace Debugger { namespace UI

--- a/DebuggerUtils.h
+++ b/DebuggerUtils.h
@@ -106,7 +106,7 @@ namespace VCC { namespace Debugger
 	bool replace(std::string& str, const std::string& from, const std::string& to);
 	int roundUp(int numToRound, int multiple);
 	int roundDn(int numToRound, int multiple);
-	unsigned char DbgRead8(bool phyAddr, unsigned char block, unsigned short PC);
+	unsigned char DbgRead8(bool phyAddr, unsigned short block, unsigned short PC);
 } }
 
 namespace VCC { namespace Debugger { namespace UI

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -185,7 +185,7 @@ void DisAsmFromTo()
     UsePhyAdr = (ret == BST_CHECKED) ? TRUE : FALSE;
 
     // If not using physical addressing disallow access I/O ports
-    MaxAdr = UsePhyAdr? 0xFFFF: 0xFF00
+    MaxAdr = UsePhyAdr? 0xFFFF: 0xFF00;
 
     GetWindowText(GetDlgItem(hDismDlg,IDC_EDIT_BLOCK), buf, 8);
     int blk = ConvertHexAddress(buf);

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -92,8 +92,8 @@ INT_PTR CALLBACK DisassemblerDlgProc
         // Hook the address dialogs to capture those keystrokes
         AddrDlgProc = (WNDPROC) SetControlHook(hEdtAddr,(LONG_PTR) SubAddrDlgProc);
         LastDlgProc = (WNDPROC) SetControlHook(hEdtLast,(LONG_PTR) SubLastDlgProc);
-
-    SetWindowTextA(hDisText,"");
+        // Clear the output text
+        SetWindowTextA(hDisText,"");
         // Set focus to the first edit box
         SetDialogFocus(hEdtAddr);
         break;
@@ -217,8 +217,11 @@ void Disassemble(UINT16 FromAdr, UINT16 ToAdr)
     std::string lines = {};
     UINT16 PC = FromAdr;
 
+
     while (PC < ToAdr) {
         state.PC = PC;
+state.phyAddr=TRUE; // Decode using block relative addressing
+state.block=0x3E;   // Physical address = PC + block * 0x2000
         trace = {};
         Decoder->DecodeInstruction(state,trace);
 

--- a/MachineDefs.h
+++ b/MachineDefs.h
@@ -26,7 +26,7 @@ namespace VCC
 		//
 		bool IsNative6309;
 		bool phyAddr;               // Decode using block relative addressing
-		unsigned char block;        // Physical address = PC + block * 0x2000
+		unsigned short block;       // Physical address = PC + block * 0x2000
 	};
 
 	// Trace Events

--- a/MachineDefs.h
+++ b/MachineDefs.h
@@ -25,6 +25,8 @@ namespace VCC
 		unsigned short V;
 		//
 		bool IsNative6309;
+		bool phyAddr;               // Decode using block relative addressing
+		unsigned char block;        // Physical address = PC + block * 0x2000
 	};
 
 	// Trace Events

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -74,11 +74,13 @@ namespace VCC { namespace Debugger
 		// Skip past opcode bytes
 		PC += opcode.oplen;
 
+// DbgRead8(trace->phyAddr,trace->block,PC)
+
 		// Number of bytes for the operand.
 		int operandLen = opcode.numbytes - opcode.oplen;
 		for (int n = 0; n < operandLen; n++)
 		{
-			trace.bytes.push_back(MemRead8(PC++));
+			trace.bytes.push_back(DbgRead8(state.phyAddr,state.block,PC++));
 		}
 
 		int operand = 0;
@@ -140,7 +142,7 @@ namespace VCC { namespace Debugger
 		unsigned short PC = state.PC;
 
 		// Get the post byte.
-		unsigned char postbyte = MemRead8(++PC);
+		unsigned char postbyte = DbgRead8(state.phyAddr,state.block,++PC);
 		trace.bytes.push_back(postbyte);
 
 		// Determine various indexing modes.
@@ -154,7 +156,7 @@ namespace VCC { namespace Debugger
 		// One byte offset?
 		if (mode.numbytes == 1)
 		{
-			unsigned char b = MemRead8(++PC);
+			unsigned char b = DbgRead8(state.phyAddr,state.block,++PC);
 			trace.bytes.push_back(b);
 			std::int32_t offset = b;
 			offset = (offset << 24) >> 24;
@@ -164,9 +166,9 @@ namespace VCC { namespace Debugger
 		// Two byte offset?
 		if (mode.numbytes == 2)
 		{
-			unsigned char b1 = MemRead8(++PC);
+			unsigned char b1 = DbgRead8(state.phyAddr,state.block,++PC);
 			trace.bytes.push_back(b1);
-			unsigned char b2 = MemRead8(++PC);
+			unsigned char b2 = DbgRead8(state.phyAddr,state.block,++PC);
 			trace.bytes.push_back(b2);
 			std::int32_t offset = (b1 << 8) + b2;
 			// Extended Indirect?
@@ -255,7 +257,7 @@ namespace VCC { namespace Debugger
 		unsigned short PC = state.PC;
 
 		// Get the post byte.
-		unsigned char postbyte = MemRead8(++PC);
+		unsigned char postbyte = DbgRead8(state.phyAddr,state.block,++PC);
 		trace.bytes.push_back(postbyte);
 
 		// Count the number of registers set in post byte.
@@ -298,7 +300,7 @@ namespace VCC { namespace Debugger
 		int operandLen = opcode.numbytes - opcode.oplen;
 		for (int n = 0; n < operandLen; n++)
 		{
-			trace.bytes.push_back(MemRead8(PC++));
+			trace.bytes.push_back(DbgRead8(state.phyAddr,state.block,PC++));
 		}
 
 		// All long branches are relative.
@@ -378,7 +380,7 @@ namespace VCC { namespace Debugger
 		unsigned short PC = state.PC;
 
 		// Get the post byte.
-		unsigned char postbyte = MemRead8(++PC);
+		unsigned char postbyte = DbgRead8(state.phyAddr,state.block,++PC);
 		trace.bytes.push_back(postbyte);
 
 		// Get source and destination registers 
@@ -424,15 +426,15 @@ namespace VCC { namespace Debugger
 		int divisor;
 		if (wide)
 		{
-			unsigned char b1 = MemRead8(++PC);
+			unsigned char b1 = DbgRead8(state.phyAddr,state.block,++PC);
 			trace.bytes.push_back(b1);
-			unsigned char b2 = MemRead8(++PC);
+			unsigned char b2 = DbgRead8(state.phyAddr,state.block,++PC);
 			trace.bytes.push_back(b2);
 			divisor = (b1 << 8) + b2;
 		}
 		else
 		{
-			unsigned char b1 = MemRead8(++PC);
+			unsigned char b1 = DbgRead8(state.phyAddr,state.block,++PC);
 			trace.bytes.push_back(b1);
 			divisor = b1;
 		}

--- a/OpDecoder.cpp
+++ b/OpDecoder.cpp
@@ -222,7 +222,7 @@ namespace VCC { namespace Debugger
 		unsigned short PC = state.PC;
 
 		// Get the Op Code.
-		unsigned char Op1 = MemRead8(PC);
+		unsigned char Op1 = DbgRead8(state.phyAddr,state.block,PC);
 
 		// Save it.
 		trace.bytes.push_back(Op1);
@@ -254,7 +254,7 @@ namespace VCC { namespace Debugger
 	bool OpDecoder::DecodePage2Instruction(unsigned short PC, CPUState state, CPUTrace& trace)
 	{
 		// Get the extended Op Code.
-		unsigned char Op2 = MemRead8(PC);
+		unsigned char Op2 = DbgRead8(state.phyAddr,state.block,PC);
 
 		// Save it.
 		trace.bytes.push_back(Op2);
@@ -274,7 +274,7 @@ namespace VCC { namespace Debugger
 	bool OpDecoder::DecodePage3Instruction(unsigned short PC, CPUState state, CPUTrace& trace)
 	{
 		// Get the extended Op Code.
-		unsigned char Op3 = MemRead8(PC);
+		unsigned char Op3 = DbgRead8(state.phyAddr,state.block,PC);
 
 		// Save it.
 		trace.bytes.push_back(Op3);

--- a/Vcc.rc
+++ b/Vcc.rc
@@ -509,17 +509,17 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Disassembly Window"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    LTEXT           "Addresses in hex. Max range 4k. (0x1000)" IDC_ERROR_TEXT, 12, 0, 180, 10
+    LTEXT           "" IDC_ERROR_TEXT,    12,  0,  180, 10
+    LTEXT           "From:", IDC_STATIC,  12,  13,  18,  9
+    EDITTEXT        IDC_EDIT_PC_ADDR,     32,  13,  24, 10, WS_TABSTOP
+    LTEXT           "Lines:", IDC_STATIC, 68,  13,  20,  9
+    EDITTEXT        IDC_EDIT_PC_LCNT,     90,  13,  24, 10, WS_TABSTOP
+    DEFPUSHBUTTON   "Fetch", IDAPPLY,    134,  12,  36, 13
 
-    LTEXT           "From:", IDC_STATIC, 12,  13,  18,  9
-    EDITTEXT        IDC_EDIT_PC_ADDR,    32,  13,  30, 10, WS_TABSTOP
-    LTEXT           "To:", IDC_STATIC,   70,  13,  12,  9
-    EDITTEXT        IDC_EDIT_PC_LAST,    84,  13,  30, 10, WS_TABSTOP
-    DEFPUSHBUTTON   "Fetch", IDAPPLY,   128,  12,  36, 13
+    LTEXT           "Start block:",IDC_STATIC, 82, 29, 40, 9
+    EDITTEXT        IDC_EDIT_BLOCK,           120, 29, 20, 10, WS_TABSTOP
 
     CONTROL         "Physical Memory",IDC_PHYS_MEM,"Button",BS_AUTOCHECKBOX,12,28,70,10
-    LTEXT           "Start block:",IDC_STATIC, 82, 29, 40, 9
-    EDITTEXT        IDC_EDIT_BLOCK,     120, 29, 20, 10
 
     CONTROL         "", IDC_DISASSEMBLY_TEXT, "RichEdit20A", ES_MULTILINE | ES_READONLY | WS_VSCROLL , 5, 42, 192, 305
 END

--- a/Vcc.rc
+++ b/Vcc.rc
@@ -504,18 +504,24 @@ BEGIN
     PUSHBUTTON      "Close", IDCLOSE, 6, 280, 36, 14
 END
 
-IDD_DISASSEMBLER DIALOGEX -50, -50, 200, 335
+IDD_DISASSEMBLER DIALOGEX -50, -50, 200, 350
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Disassembly Window"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    LTEXT           "From:", IDC_STATIC, 12,  4,  18,  9
-    EDITTEXT        IDC_EDIT_PC_ADDR,    32,  4,  30, 10, ES_AUTOHSCROLL | WS_GROUP | WS_TABSTOP
-    LTEXT           "To:", IDC_STATIC,   70,  4,  12,  9
-    EDITTEXT        IDC_EDIT_PC_LAST,    84,  4,  30, 10, ES_AUTOHSCROLL | WS_TABSTOP
-    DEFPUSHBUTTON   "Apply", IDAPPLY,   128,  3,  36, 13, WS_TABSTOP
-    LTEXT           "Addresses is hex. Max range 4k." IDC_ERROR_TEXT,   15, 15, 110, 10
-    CONTROL         "", IDC_DISASSEMBLY_TEXT, "RichEdit20A", ES_MULTILINE | ES_READONLY | WS_VSCROLL , 5, 24, 190, 305
+    LTEXT           "Addresses in hex. Max range 4k. (0x1000)" IDC_ERROR_TEXT, 12, 0, 180, 10
+
+    LTEXT           "From:", IDC_STATIC, 12,  13,  18,  9
+    EDITTEXT        IDC_EDIT_PC_ADDR,    32,  13,  30, 10, WS_TABSTOP
+    LTEXT           "To:", IDC_STATIC,   70,  13,  12,  9
+    EDITTEXT        IDC_EDIT_PC_LAST,    84,  13,  30, 10, WS_TABSTOP
+    DEFPUSHBUTTON   "Fetch", IDAPPLY,   128,  12,  36, 13
+
+    CONTROL         "Physical Memory",IDC_PHYS_MEM,"Button",BS_AUTOCHECKBOX,12,28,70,10
+    LTEXT           "Start block:",IDC_STATIC, 82, 29, 40, 9
+    EDITTEXT        IDC_EDIT_BLOCK,     120, 29, 20, 10
+
+    CONTROL         "", IDC_DISASSEMBLY_TEXT, "RichEdit20A", ES_MULTILINE | ES_READONLY | WS_VSCROLL , 5, 42, 192, 305
 END
 
 /////////////////////////////////////////////////////////////////////////////

--- a/resource.h
+++ b/resource.h
@@ -374,7 +374,7 @@
 #define IDC_SHOW_SCN_TRACE              2131
 #define IDC_BTN_SET_PC                  2132
 #define IDC_EDIT_PC_ADDR                2133
-#define IDC_EDIT_PC_LAST                2134
+#define IDC_EDIT_PC_LCNT                2134
 #define IDC_ERROR_TEXT                  2135
 #define IDC_DISASSEMBLY_TEXT            2136
 #define IDC_PHYS_MEM                    2137

--- a/resource.h
+++ b/resource.h
@@ -377,6 +377,8 @@
 #define IDC_EDIT_PC_LAST                2134
 #define IDC_ERROR_TEXT                  2135
 #define IDC_DISASSEMBLY_TEXT            2136
+#define IDC_PHYS_MEM                    2137
+#define IDC_EDIT_BLOCK                  2138
 
 #define IDM_USER_WIKI                   40001
 #define ID_FILE_EXIT                    40002

--- a/tcc1014mmu.c
+++ b/tcc1014mmu.c
@@ -49,6 +49,7 @@ static unsigned char VectorMaska[4]={12,60,60,60};
 static unsigned int VidMask[4]={0x1FFFF,0x7FFFF,0x1FFFFF,0x7FFFFF};
 static unsigned char CurrentRamConfig=1;
 static unsigned short MmuPrefix=0;
+static unsigned int RamSize=0;
 
 void UpdateMmuArray(void);
 /*****************************************************************************************
@@ -58,7 +59,7 @@ void UpdateMmuArray(void);
 *****************************************************************************************/
 unsigned char * MmuInit(unsigned char RamConfig)
 {
-	unsigned int RamSize=0;
+//	unsigned int RamSize=0;
 	unsigned int Index1=0;
 	RamSize=MemConfig[RamConfig];
 	CurrentRamConfig=RamConfig;
@@ -66,8 +67,11 @@ unsigned char * MmuInit(unsigned char RamConfig)
 		free(memory);
 
 	memory=(unsigned char *)malloc(RamSize);
-	if (memory==NULL)
+	if (memory==NULL) {
+		RamSize = 0;
 		return(NULL);
+	}
+
 	for (Index1=0;Index1<RamSize;Index1++)
 	{
 		if (Index1 & 1)
@@ -361,11 +365,15 @@ void MemWrite16(unsigned short data,unsigned short addr)
 	return;
 }
 
-unsigned short GetMem(long address) {
-	return(memory[address]);
+unsigned short GetMem(unsigned long address) {
+	if (address < RamSize)
+		return(memory[address]);
+	else
+		return(0xFF);
 }
-void SetMem(long address, unsigned short data) {
-	memory[address] = (unsigned char) data;
+void SetMem(unsigned long address, unsigned short data) {
+	if (address < RamSize)
+		memory[address] = (unsigned char) data;
 }
 
 void SetDistoRamBank(unsigned char data)

--- a/tcc1014mmu.h
+++ b/tcc1014mmu.h
@@ -50,8 +50,8 @@ unsigned char SafeMemRead8(short unsigned int);
 unsigned char * MmuInit(unsigned char);
 unsigned char *	Getint_rom_pointer(void);
 unsigned char * Getext_rom_pointer(void);
-unsigned short GetMem(long);
-void SetMem(long, unsigned short);
+unsigned short GetMem(unsigned long);
+void SetMem(unsigned long, unsigned short);
 
 void __fastcall fMemWrite8(unsigned char,unsigned short );
 unsigned char __fastcall fMemRead8(short unsigned int);


### PR DESCRIPTION
Added "Physical Memory" checkbox and "Start Block" fields to the Disassembly window.
When checkbox is checked dissasembly starts at the block specified and offset by the value in the "From" box.  This allows disassembly of any physical address enabled in VCC, upto 8192K (block 3FF).
This change makes it easy to disassemble memory resident Nitros9 modules using the block and Offset fields from the `mdir -e` command.
Also the "To" address field was changed to a line count to make usage easier.