### PR TITLE
Disassembler decode mod header

### DIFF
--- a/Vcc.rc
+++ b/Vcc.rc
@@ -509,18 +509,15 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Disassembly Window"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    LTEXT           "" IDC_ERROR_TEXT,    12,  0,  180, 10
-    LTEXT           "From:", IDC_STATIC,  12,  13,  18,  9
-    EDITTEXT        IDC_EDIT_PC_ADDR,     32,  13,  24, 10, WS_TABSTOP
-    LTEXT           "Lines:", IDC_STATIC, 68,  13,  20,  9
-    EDITTEXT        IDC_EDIT_PC_LCNT,     90,  13,  24, 10, WS_TABSTOP
-    DEFPUSHBUTTON   "Fetch", IDAPPLY,    134,  12,  36, 13
-
-    LTEXT           "Start block:",IDC_STATIC, 82, 29, 40, 9
-    EDITTEXT        IDC_EDIT_BLOCK,           120, 29, 20, 10, WS_TABSTOP
-
-    CONTROL         "Physical Memory",IDC_PHYS_MEM,"Button",BS_AUTOCHECKBOX,12,28,70,10
-
+    CONTROL         "Phys Mem",IDC_PHYS_MEM,"Button",BS_AUTOCHECKBOX,13,3,50,10
+    LTEXT           "Block:",IDC_STATIC,    70,  4,  20, 9
+    EDITTEXT        IDC_EDIT_BLOCK,         92,  3,  20, 10, WS_TABSTOP
+    DEFPUSHBUTTON   "Decode", IDAPPLY,     130,  6,  40, 16
+    LTEXT           "Address:", IDC_STATIC, 10, 17,  30,  9
+    EDITTEXT        IDC_EDIT_PC_ADDR,       40, 17,  24, 10, WS_TABSTOP
+    LTEXT           "Lines:", IDC_STATIC,   70, 17,  20,  9
+    EDITTEXT        IDC_EDIT_PC_LCNT,       92, 17,  24, 10, WS_TABSTOP
+    LTEXT           "" IDC_ERROR_TEXT,      10, 30, 180, 10
     CONTROL         "", IDC_DISASSEMBLY_TEXT, "RichEdit20A", ES_MULTILINE | ES_READONLY | WS_VSCROLL , 5, 42, 192, 305
 END
 


### PR DESCRIPTION
If "Phys Mem" is checked and first decoded address is the start of an os9 module header the header is decoded using FDB and FCB lines.  Also any "SWI2" encountered is converted to "OS9 <operand>"