### PR TITLE
Tweaks to improve Disassembly Window

### DIFF
--- a/Vcc.rc
+++ b/Vcc.rc
@@ -515,7 +515,7 @@ BEGIN
     LTEXT           "Block:",IDC_STATIC,    70,  4,  20, 9
     EDITTEXT        IDC_EDIT_BLOCK,         92,  3,  20, 10, WS_TABSTOP
     DEFPUSHBUTTON   "Decode", IDAPPLY,     130,  6,  40, 16
-    LTEXT           "Address:", IDC_STATIC, 10, 17,  30,  9
+    LTEXT           "Address:", IDC_ADRTXT, 10, 17,  30,  9
     EDITTEXT        IDC_EDIT_PC_ADDR,       40, 17,  24, 10, WS_TABSTOP
     LTEXT           "Lines:", IDC_STATIC,   70, 17,  20,  9
     EDITTEXT        IDC_EDIT_PC_LCNT,       92, 17,  24, 10, WS_TABSTOP

--- a/resource.h
+++ b/resource.h
@@ -379,6 +379,7 @@
 #define IDC_DISASSEMBLY_TEXT            2136
 #define IDC_PHYS_MEM                    2137
 #define IDC_EDIT_BLOCK                  2138
+#define IDC_ADRTXT                      2139
 
 #define IDM_USER_WIKI                   40001
 #define ID_FILE_EXIT                    40002


### PR DESCRIPTION
Camel case module header comments.

Use Fixed font for disassembly text. Tabs replaced with padding spaces.

Changed "Address" to "Offset" when Phys Mem is checked.

Attempt to detect module headers even if they do not start at specified Block and Offset.  This works if PC lands on block header after disassembling previous stuff.

Up/Down arrows scroll disassembly window line at a time. Page Up/Down scroll disassembly by pages.

Improve movement of focus within dialog.