### PR TITLE
Fix disassembly error with indexed addressing

### DIFF
--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -142,7 +142,9 @@ namespace VCC { namespace Debugger
 		unsigned short PC = state.PC;
 
 		// Get the post byte.
-		unsigned char postbyte = DbgRead8(state.phyAddr,state.block,++PC);
+		PC += opcode.oplen;
+		unsigned char postbyte = DbgRead8(state.phyAddr,state.block,PC);
+
 		trace.bytes.push_back(postbyte);
 
 		// Determine various indexing modes.


### PR DESCRIPTION
When decoding indexed addressing for two byte opcodes the wrong byte was used to determine the index register and operand size.