### PR TITLE
Further improvements to Disassembler

### DIFF
--- a/DebuggerUtils.cpp
+++ b/DebuggerUtils.cpp
@@ -100,7 +100,7 @@ namespace VCC { namespace Debugger
 			unsigned long addr = PC + block * 0x2000;
 			return (unsigned char) GetMem(addr);
 		} else {
-			return MemRead8(PC);
+			return SafeMemRead8(PC);
 		}
 	}
 	

--- a/Vcc.rc
+++ b/Vcc.rc
@@ -509,18 +509,20 @@ STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Disassembly Window"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    CONTROL         "Phys Mem",IDC_PHYS_MEM,"Button",BS_AUTOCHECKBOX,13,3,50,10
-    LTEXT           "Block:",IDC_STATIC,70,4,20,9
-    EDITTEXT        IDC_EDIT_BLOCK,92,3,20,10
-    DEFPUSHBUTTON   "Decode",IDAPPLY,130,6,40,16
-    LTEXT           "Address:",IDC_ADRTXT,10,17,30,9
-    EDITTEXT        IDC_EDIT_PC_ADDR,40,17,24,10
-    LTEXT           "Lines:",IDC_STATIC,70,17,20,9
-    EDITTEXT        IDC_EDIT_PC_LCNT,92,17,24,10
-    LTEXT           "",IDC_ERROR_TEXT,10,30,180,10
-    CONTROL         "",IDC_DISASSEMBLY_TEXT,"RichEdit20A",ES_MULTILINE | ES_READONLY | WS_VSCROLL,5,42,205,345
+    CONTROL         "Os9 code",IDC_BTN_OS9, "Button",BS_AUTOCHECKBOX,12,18,50,10
+    CONTROL         "Real Mem",IDC_PHYS_MEM,"Button",BS_AUTOCHECKBOX,72,18,50,10
+    DEFPUSHBUTTON   "Decode",IDAPPLY,     166,10,36,20
+    LTEXT           "Address:",IDC_ADRTXT,  8,4,30,9
+    EDITTEXT        IDC_EDIT_PC_ADDR,      38,4,24,10
+    LTEXT           "Block:",IDC_STATIC,   67,4,20,9
+    EDITTEXT        IDC_EDIT_BLOCK,        90,4,18,10
+    LTEXT           "Lines:",IDC_STATIC,  113,4,20,9
+    EDITTEXT        IDC_EDIT_PC_LCNT,     134,4,24,10
+    LTEXT           "",IDC_ERROR_TEXT,     10,31,180,10
+    CONTROL         "",IDC_DISASSEMBLY_TEXT,"RichEdit20A",ES_MULTILINE|ES_READONLY|WS_VSCROLL,5,43,205,344
 END
 
+#define IDC_BTN_OS9                     2140
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/resource.h
+++ b/resource.h
@@ -380,6 +380,7 @@
 #define IDC_PHYS_MEM                    2137
 #define IDC_EDIT_BLOCK                  2138
 #define IDC_ADRTXT                      2139
+#define IDC_BTN_OS9                     2140
 
 #define IDM_USER_WIKI                   40001
 #define ID_FILE_EXIT                    40002
@@ -431,7 +432,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        176
 #define _APS_NEXT_COMMAND_VALUE         40047
-#define _APS_NEXT_CONTROL_VALUE         2140
+#define _APS_NEXT_CONTROL_VALUE         2142
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
Added checkbox for Os9 decoding (Mod headers,OS9 instruction)

Changed "Phys Mem" to "Real Mem"

Modified decode of Mod headers to use cpu memory when decoding with "Os9 Code" checked but "Real Mem" unchecked.