### PR TITLE
Support MAC/OS9 text paste (CR line endings)

### DIFF
--- a/SourceDebug.cpp
+++ b/SourceDebug.cpp
@@ -533,7 +533,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		return CallWindowProc(oldEditProc, wnd, msg, wParam, lParam);
 	}
 
-	INT_PTR CALLBACK BreakpointsDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+	INT_PTR CALLBACK SourceDebugDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 	{
 		switch (message)
 		{
@@ -635,7 +635,7 @@ void VCC::Debugger::UI::OpenSourceDebugWindow(HINSTANCE instance, HWND parent)
 			instance,
 			MAKEINTRESOURCE(IDD_BREAKPOINTS),
 			parent,
-			BreakpointsDlgProc);
+			SourceDebugDlgProc);
 
 		ShowWindow(SourceDebugWindow, SW_SHOWNORMAL);
 	}

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -630,9 +630,21 @@ void PasteText() {
 
 	cliptxt = GetClipboardText().c_str();
 	if (PasteWithNew) { cliptxt = "NEW\n" + cliptxt; }
+	char prvchr = '\0';
 	for (size_t t = 0; t < cliptxt.length(); t++) {
 		char tmp = cliptxt[t];
-		if ( tmp != (char)'\n') {
+		bool eol;                   //EJJ CRLF,LFCR,CR,LF eol logic
+		if (tmp == '\x0A') {        //LF
+			if (prvchr == '\x0D') continue;
+			eol = TRUE;
+		} else if (tmp == '\x0D') { //CR
+			if (prvchr == '\x0A') continue;
+			eol = TRUE;
+		} else {
+			eol = FALSE;
+		}
+		prvchr = tmp;
+		if (! eol) {
 			lines += tmp;
 		}
 		else  { //...the character is a <CR>


### PR DESCRIPTION
When pasting text CRLF, CR, or LF are now accepted as line endings.

also rename BreakpointsDlgProc to SourceDebugDlgProc in SourceDebug.cpp