### PR TITLE
ifdef _WIN32 missing from acia.rc

### DIFF
--- a/acia/acia.rc
+++ b/acia/acia.rc
@@ -16,8 +16,10 @@
 // English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
+#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
ACIA not building on newer versions of VS this should fix that..
