### PR TITLE
Use the correct RAM address for reading the interrupt vectors.

### DIFF
--- a/tcc1014registers.c
+++ b/tcc1014registers.c
@@ -346,7 +346,7 @@ unsigned char sam_read(unsigned char port) //SAM don't talk much :)
 {
 	
 	if ( (port>=0xF0) & (port <=0xFF)) //IRQ vectors from rom
-		return( rom[0x3F00 + port]);
+		return( rom[0x7F00 + port]);
 
 	return(0);
 }


### PR DESCRIPTION
Use the correct RAM address for reading the interrupt vectors. The 6809 doesn't define any use for $FFF0 and $FFF1, but the 6309 uses this for trapping illegal instructions and division by zero. In the CoCo3 ROM, the vector addresses are defined in two locations: $3FF0 and $7FF0.

$3FF0: A6 81 FE EE FE F1 FE F4 FE F7 FE FA FE FD 8C 1B

$7FF0: 00 00 FE EE FE F1 FE F4 FE F7 FE FA FE FD 8C 1B

These addresses all match except for the first one, and so when using a 6809 processor, either one will work. In practice, the CoCo3 actually uses $7FF0 (tested on real hardware), and so when using a 6309 the trap location should be address $0000. Any 6309 code running in VCC which is using the trap feature should expect the same behavior.