### PR TITLE
Fix oddities with disassembler stat line and mode switches

### DIFF
--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -245,6 +245,9 @@ INT_PTR CALLBACK DisassemblerDlgProc
 
         SetInfoStat();
 
+        // Number of lines in disassembly;
+        NumDisLines = 0;
+
         // Start a timer for showing current status
         SetTimer(hDlg, IDT_BRKP_TIMER, 250, (TIMERPROC) NULL);
 


### PR DESCRIPTION
Fixed disassembler status could get confused switching to real mode when tracking the PC.  Fixed errors on status line being overwritten before they could be read.  Info line now mentions use of block number and offset when in read addressing mode.
