### PR TITLE
Add NTSC 5bit color simulation

### DIFF
--- a/Vcc.rc
+++ b/Vcc.rc
@@ -187,12 +187,13 @@ BEGIN
     CONTROL         "Scan Lines",IDC_SCANLINES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,128,51,10
     CONTROL         "Force Aspect",IDC_ASPECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,141,58,10
     CONTROL         "Remember Screen Size",IDC_REMEMBER_SIZE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,77,128,94,10
-    GROUPBOX        "[F6] Monitor Type",IDC_STATIC,14,12,112,63,BS_CENTER
+    GROUPBOX        "[F6] Monitor Type",IDC_STATIC,14,12,112,65,BS_CENTER
     ICON            "",IDC_MONTYPE,96,23,21,20
     RADIOBUTTON     "RGB",IDC_RGB,21,23,31,10
     RADIOBUTTON     "Composite",IDC_COMPOSITE,21,37,49,10
     RADIOBUTTON     "Updated Palette",IDC_UPD_PALETTE,31,46,70,11
     RADIOBUTTON     "Original Palette",IDC_ORG_PALETTE,31,55,70,11
+    RADIOBUTTON     "NTSC Palette", IDC_NTSC5_PALETTE, 31, 64, 70, 11
     CONTROL         "[F8] Throttle Speed",IDC_THROTTLE,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,77,141,77,10
     CTEXT           "WARNING: Unchecking the ""Throttle Speed"" can greatly affect many functions of the VCC emulation including keyboard operation. Use with CAUTION! Please use ""Over-Clocking"" instead",IDC_STATIC,16,160,220,28,SS_SUNKEN,WS_EX_STATICEDGE
     DEFPUSHBUTTON   "OK",IDOK,80,200,36,14

--- a/config.c
+++ b/config.c
@@ -835,7 +835,7 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 {
 	static bool isRGB;
 	short int Monchoice[2] = { IDC_COMPOSITE, IDC_RGB };
-    short int PaletteChoice[2] = { IDC_ORG_PALETTE, IDC_UPD_PALETTE };
+    short int PaletteChoice[3] = { IDC_ORG_PALETTE, IDC_UPD_PALETTE, IDC_NTSC5_PALETTE };
 	static STRConfig tmpcfg;
 	switch (message) {
 	case WM_INITDIALOG:
@@ -859,12 +859,14 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 			isRGB = TRUE;
 			SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETSTATE, 1, 0);
 			SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETSTATE, 1, 0);
+			SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETSTATE, 1, 0);
 			SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETDONTCLICK, 1, 0);
 			SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETDONTCLICK, 1, 0);
+			SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETDONTCLICK, 1, 0);
 		}
 		SendDlgItemMessage(hDlg,IDC_MONTYPE,
 				STM_SETIMAGE,(WPARAM)IMAGE_ICON,(LPARAM)MonIcons[tmpcfg.MonitorType]);
-		for (temp = 0; temp <= 1; temp++)
+		for (temp = 0; temp < sizeof(PaletteChoice) / sizeof(*PaletteChoice); ++temp)
 			SendDlgItemMessage(hDlg,PaletteChoice[temp],BM_SETCHECK,(temp==tmpcfg.PaletteType),0);
 		break;
 
@@ -930,6 +932,7 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 				STM_SETIMAGE,(WPARAM)IMAGE_ICON,(LPARAM)MonIcons[tmpcfg.MonitorType]);
 			SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETSTATE, 0, 0);
 			SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETSTATE, 0, 0);
+			SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETSTATE, 0, 0);
 			break;
 
 		case IDC_RGB:
@@ -948,15 +951,18 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 			//If RGB is chosen, disable palette buttons.
 			SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETSTATE, 1, 0);
 			SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETSTATE, 1, 0);
+			SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETSTATE, 1, 0);
 			SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETDONTCLICK, 1, 0);
 			SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETDONTCLICK, 1, 0);
+			SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETDONTCLICK, 1, 0);
 			break;
 
 		case IDC_ORG_PALETTE:
 			if (!isRGB) {
 				//Original Composite palette
-				SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETCHECK, 1, 0);
 				SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETCHECK, 0, 0);
+				SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETCHECK, 1, 0);
+				SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETCHECK, 0, 0);
 				tmpcfg.PaletteType = 0;
 			} else {
 				SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETSTATE, 1, 0);
@@ -968,8 +974,22 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 				//New Composite palette
 				SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETCHECK, 1, 0);
 				SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETCHECK, 0, 0);
+				SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETCHECK, 0, 0);
 				tmpcfg.PaletteType = 1;
 			} else {
+				SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETSTATE, 1, 0);
+			}
+			break;
+
+		case IDC_NTSC5_PALETTE:
+			if (!isRGB) {
+				//New Composite palette
+				SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETCHECK, 0, 0);
+				SendDlgItemMessage(hDlg, IDC_ORG_PALETTE, BM_SETCHECK, 0, 0);
+				SendDlgItemMessage(hDlg, IDC_NTSC5_PALETTE, BM_SETCHECK, 1, 0);
+				tmpcfg.PaletteType = 2;
+			}
+			else {
 				SendDlgItemMessage(hDlg, IDC_UPD_PALETTE, BM_SETSTATE, 1, 0);
 			}
 			break;

--- a/resource.h
+++ b/resource.h
@@ -334,6 +334,7 @@
 
 #define IDC_ORG_PALETTE                 1191
 #define IDC_UPD_PALETTE                 1192
+#define IDC_NTSC5_PALETTE               1193
 
 #define IDC_MEM_VSCROLLBAR              2001
 #define IDT_MEM_TIMER                   2002

--- a/tcc1014graphics.c
+++ b/tcc1014graphics.c
@@ -35,6 +35,8 @@ void MakeRGBPalette (void);
 void MakeCMPpalette(void);
 bool  DDFailedCheck(HRESULT hr, char *szMessage);
 char *DDErrorString(HRESULT hr);
+void RenderPMODE4NTSC(unsigned int* surfaceDest, int XpitchDest, const unsigned char* cocoSrc, char scanLines);
+
 //extern STRConfig CurrentConfig;
 static unsigned char ColorValues[4]={0,85,170,255};
 static unsigned char ColorTable16Bit[4]={0,10,21,31};	//Color brightness at 0 1 2 and 3 (2 bits)
@@ -47,6 +49,54 @@ static unsigned char  Pallete[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};		//Coco 3 6
 static unsigned char  Pallete8Bit[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static unsigned short Pallete16Bit[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};	//Color values translated to 16bit 32BIT
 static unsigned int   Pallete32Bit[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};	//Color values translated to 24/32 bits
+
+static unsigned int ArtifactsNTSC[2][16] = {
+	//rrggbb - normal blue/red colors
+	0x000000, // black
+	0x004000, // dark green
+	0x300030, // dark purple
+	0xc0e0c0, // light green
+	0xeec8ee, // light purple
+	0x0020a0, // dark blue
+	0xc03c1e, // dark red
+	0x618cff, // light blue
+	0xff8f48, // light red
+	0xff7800, // red
+	0x0080ff, // blue
+	0x64f0ff, // cyan
+	0xfff0c8, // yellow
+	0x00003c, // dark dark blue
+	0x3c0000, // dark dark red
+	0xffffff,  // white
+	//rrggbb - alternate red/blue colors (but not green/purple - see To Preseve Quandric)
+	0x000000, // black
+	0x004000, // dark green
+	0x300030, // dark purple
+	0xc0e0c0, // light green
+	0xeec8ee, // light purple
+	0xc03c1e, // dark red
+	0x0020a0, // dark blue
+	0xff8f48, // light red
+	0x618cff, // light blue
+	0x0080ff, // blue
+	0xff7800, // red
+	0xfff0c8, // yellow
+	0x64f0ff, // cyan
+	0x3c0000, // dark dark red
+	0x00003c, // dark dark blue
+	0xffffff  // white
+};
+
+// mapping of bit pattern to palette color above
+// [---2bit---][---2bit---][---2bit---][-1-]
+// [prev pixel][curr pixel][next pixel][o/e]
+static unsigned char ArtifactsNTSCIndex[128] = {
+	0, 0, 0, 0, 0, 6, 0, 2, 5, 7, 5, 7, 1, 3, 1, 11, 8, 6, 8, 14, 8, 9, 8, 9, 4, 4, 4, 15, 12, 12,
+	12, 15, 5, 13, 5, 13, 13, 0, 13, 2, 10, 10, 10, 10, 10, 15, 10, 11, 3, 1, 3, 1, 15, 9, 15, 9,
+	11, 11, 11, 11, 15, 15, 15, 15, 14, 0, 14, 0, 14, 6, 14, 2, 0, 7, 0, 7, 1, 3, 1, 11, 9, 6, 9,
+	14, 9, 9, 9, 9, 15, 4, 15, 15, 12, 12, 12, 15, 2, 13, 2, 13, 2, 0, 2, 2, 10, 10, 10, 10, 10, 15,
+	10, 11, 12, 1, 12, 1, 12, 9, 12, 9, 15, 11, 15, 11, 15, 15, 15, 15
+};
 
 static unsigned int VidMask=0x1FFFF;
 static unsigned char VresIndex=0;
@@ -73,7 +123,6 @@ static unsigned char LowerCase=0,InvertAll=0,ExtendedText=1;
 static unsigned char HorzOffsetReg=0;
 static unsigned char Hoffset=0;
 static unsigned short TagY=0;
-static unsigned short HorzBeam=0;
 static unsigned int BoarderColor32=0;
 static unsigned short BoarderColor16=0;
 static unsigned char BoarderColor8=0;
@@ -88,6 +137,7 @@ static unsigned int last_mmode = 0;
 // BEGIN of 8 Bit render loop *****************************************************************************************
 void UpdateScreen8 (SystemState *US8State)
 {
+	unsigned short HorzBeam = 0;
 	register unsigned int YStride=0;
 	unsigned char Pixel=0;
 	unsigned char Character=0,Attributes=0;
@@ -3181,6 +3231,7 @@ case 192+63: //Bpp=3 Sr=15
 // BEGIN of 16 Bit render loop *****************************************************************************************
 void UpdateScreen16 (SystemState *USState16)
 {
+	unsigned short HorzBeam = 0;
 	register unsigned int YStride=0;
 	static unsigned int TextColor=0;
 	static unsigned char Pixel=0;
@@ -6284,6 +6335,7 @@ void UpdateScreen24 (SystemState *USState24)
 // BEGIN of 32 Bit render loop *****************************************************************************************
 void UpdateScreen32(SystemState *USState32)
 {
+	unsigned short HorzBeam = 0;
 	register unsigned int YStride = 0;
 	//	unsigned int TextColor=0;
 	unsigned char Pixel = 0;
@@ -8199,6 +8251,18 @@ break;
 case 192+1: //Bpp=0 Sr=1 1BPP Stretch=2
 case 192+2:	//Bpp=0 Sr=2 
 	curr_gmode = "gmode19 (PMODE4)";
+
+	if (!MonType && BoarderColor32 == 0xFFFFFF && GetPaletteType() == 2)
+	{
+		// byte pointer to ram
+		unsigned char* cocoRam = (unsigned char*)WideBuffer;
+		// destination screen (less 2 pixels for bleed)
+		unsigned int* surfaceDest = szSurface32 + (((y + VertCenter) * 2) * Xpitch) + HorzCenter - 2;
+		// source coco screens
+		unsigned char* cocoSrc = cocoRam + (VidMask & (Start + (unsigned char)Hoffset));
+		RenderPMODE4NTSC(surfaceDest, Xpitch, cocoSrc, USState32->ScanLines);
+	}
+	else
 	for (HorzBeam=0;HorzBeam<BytesperRow;HorzBeam+=2) //1bbp Stretch=2
 	{
 		WidePixel=WideBuffer[(VidMask & ( Start+(unsigned char)(Hoffset+HorzBeam) ))>>1];
@@ -10032,4 +10096,54 @@ unsigned char SetColorInvert(unsigned char Tmp)
 }
 */
 
+// Render even/odd 2x2 ntsc pixels
+void RenderNTSCPixel2x2(unsigned int* surfaceDest, int XpitchDest, char colorIndex, char scanLines)
+{
+	colorIndex <<= 1;
+	unsigned int colorEven = ArtifactsNTSC[ColorInvert][ArtifactsNTSCIndex[colorIndex]];
+	unsigned int colorOdd = ArtifactsNTSC[ColorInvert][ArtifactsNTSCIndex[colorIndex + 1]];
+	// render even pixel
+	*surfaceDest = colorEven;
+	*(surfaceDest + 1) = colorEven;
+	if (!scanLines) *(surfaceDest + XpitchDest) = colorEven;
+	if (!scanLines) *(surfaceDest + XpitchDest + 1) = colorEven;
+	surfaceDest += 2;
+	// render odd pixel
+	*surfaceDest = colorOdd;
+	*(surfaceDest + 1) = colorOdd;
+	if (scanLines) return;
+	*(surfaceDest + XpitchDest) = colorOdd;
+	*(surfaceDest + XpitchDest + 1) = colorOdd;
+}
 
+// Render one raster line to surface 1bbp Stretch=2
+void RenderPMODE4NTSC(unsigned int* surfaceDest, int XpitchDest, const unsigned char* cocoSrc, char scanLines)
+{
+	const char cocoBorderPixel = 3; // white
+
+	// left edge bleed
+	unsigned char bitPattern = (cocoBorderPixel << 2) + cocoBorderPixel;
+	unsigned short HorzBeam = 0;
+
+	// for each coco byte
+	for (; HorzBeam < BytesperRow; ++HorzBeam) 
+	{
+		unsigned char cocoByte = *cocoSrc++;
+		for (int i = 0; i < 4; ++i)
+		{
+			unsigned char nextCocoPixel = (cocoByte >> 6) & 0x3;
+			// roll in next pixel
+			bitPattern = ((bitPattern << 2) + nextCocoPixel) & 0x3F;
+			cocoByte <<= 2;
+			RenderNTSCPixel2x2(surfaceDest, XpitchDest, bitPattern, scanLines);
+			surfaceDest += 4;
+		}
+	}
+
+	// end of line pixels (ntsc bleed with border)
+	bitPattern = ((bitPattern << 2) + cocoBorderPixel) & 0x3F;
+	RenderNTSCPixel2x2(surfaceDest, XpitchDest, bitPattern, scanLines);
+	surfaceDest += 4;
+	bitPattern = ((bitPattern << 2) + cocoBorderPixel) & 0x3F;
+	RenderNTSCPixel2x2(surfaceDest, XpitchDest, bitPattern, scanLines);
+}


### PR DESCRIPTION
Adds NTSC 5bit color simulation for PMODE4.
- checked MD adventures, To Preserve Quandric, Dallas Quest.