### PR TITLE
Fix hires display garbled by db514e6 Gime timer enhancements

### DIFF
--- a/coco3.cpp
+++ b/coco3.cpp
@@ -482,9 +482,8 @@ void SetMasterTickCounter(void)
 {
 	// Rate = { 63613.2315, 279.265 };
 	double Rate[2]={NANOSECOND/(TARGETFRAMERATE*LINESPERSCREEN),NANOSECOND/COLORBURST};
-	// When set master count must contain atleast one tick. EJJ 25oct24
-	UnxlatedTickCounter = (UnxlatedTickCounter==0) ? 1:UnxlatedTickCounter;
-	MasterTickCounter = UnxlatedTickCounter * Rate[TimerClockRate];
+	// Master count contains at least one tick. EJJ 10mar25
+	MasterTickCounter = (UnxlatedTickCounter+1) * Rate[TimerClockRate];
 	if (MasterTickCounter != OldMaster)  
 	{
 		OldMaster=MasterTickCounter;


### PR DESCRIPTION
Gime timer fix for game sounds messed up hirez display a bit

This change fixes hirez at slight cost to some game sounds.