### PR TITLE
Add support for using OpenGL on windows 7

### DIFF
--- a/OpenGL.cpp
+++ b/OpenGL.cpp
@@ -199,19 +199,23 @@ namespace VCC
 			memset(&pfd, 0, sizeof(pfd));
 			pfd.nSize = sizeof(pfd);
 			pfd.nVersion = 1;
-			pfd.dwFlags = PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+			pfd.dwFlags = PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER | PFD_DRAW_TO_WINDOW;
 			pfd.cColorBits = 24;
-			pfd.cDepthBits = 24;
 			pfd.iPixelType = PFD_TYPE_RGBA;
 			pfd.iLayerType = PFD_MAIN_PLANE;
 
-			
 			int iPF;
-			if ((!(iPF = ChoosePixelFormat(hTempDC, &pfd)) || !SetPixelFormat(hTempDC, iPF, &pfd)) ||
-				(!(hTempRC = wglCreateContext(hTempDC)) || !wglMakeCurrent(hTempDC, hTempRC)))
-			{
-				return Result(cleanupTempWindow(ERR_CREATECONTEXT));
-			}
+			if (!(iPF = ChoosePixelFormat(hTempDC, &pfd)))
+				return Result(cleanupTempWindow(ERR_TMPCHOOSEFORMAT));
+
+			if (!SetPixelFormat(hTempDC, iPF, &pfd))
+				return Result(cleanupTempWindow(ERR_TMPSETPIXELFORMAT));
+
+			if (!(hTempRC = wglCreateContext(hTempDC)))
+				return Result(cleanupTempWindow(ERR_TMPCREATECONTEXT));
+
+			if (!wglMakeCurrent(hTempDC, hTempRC))
+				return Result(cleanupTempWindow(ERR_TMPMAKECONTEXT));
 
 			// Function pointers returned by wglGetProcAddress are tied to the render context they were obtained with.
 			wglprocCreateContextAttribsARB wglCreateContextAttribsARB = (wglprocCreateContextAttribsARB)wglGetProcAddress("wglCreateContextAttribsARB");

--- a/OpenGL.h
+++ b/OpenGL.h
@@ -29,7 +29,7 @@ namespace VCC
 {
 	struct OpenGL : public IDisplay
 	{
-		enum // result codes
+		enum // result codes - NOTE: don't reorder this pls, only append.
 		{
 			OK,						// no error
 			ERR_INITIALIZED,		// already initialized
@@ -40,7 +40,7 @@ namespace VCC
 			ERR_REGISTERCLASS,		// unable to register gl class
 			ERR_CREATEWINDOW,		// unable to create gl window
 			ERR_GETDC,				// unable to get gl window device context
-			ERR_CREATECONTEXT,		// unable to create open gl context
+			ERR_TMPCREATECONTEXT,	// unable to create open gl context
 			ERR_SETPIXELFORMAT,		// unable to configure pixel format
 			ERR_MISSINGAPIS,		// unable to get open gl apis
 			ERR_GLVERSION,			// unable to get open gl version
@@ -49,6 +49,9 @@ namespace VCC
 			ERR_FONTDC,				// unable to create device context for font
 			ERR_FONTGETDIBITS,		// unable to get font bitmap bits
 			ERR_FONTTEXIMAGE2D,		// unable to upload font to texture
+			ERR_TMPCHOOSEFORMAT,	// unable to choose pixel format
+			ERR_TMPSETPIXELFORMAT,	// unable to set pixel format
+			ERR_TMPMAKECONTEXT,		// unable to set context
 		};
 
 		enum // flagOption


### PR DESCRIPTION
- Adds some fixes to make OpenGL work windows 7.
- Under VM: requires [MESA opengl32.dll](https://fdossena.com/?p=mesa/index.frag) added to the VCC directory, tested with 32 bit MESA v20.1.8, and VM with graphics acceleration enabled.