### PR TITLE
Clean up COCO3.ROM load code

### DIFF
--- a/Vcc.c
+++ b/Vcc.c
@@ -789,7 +789,7 @@ void SoftReset(void)
 	CPUReset();
 	GimeReset();
 	MmuReset();
-	CopyRom();
+	LoadRom();
 	ResetBus();
 	EmuState.TurboSpeedFlag=1;
 	return;

--- a/config.c
+++ b/config.c
@@ -100,12 +100,10 @@ typedef struct  {
 	unsigned char	KeyMap;
 	char			SoundCardName[64];
 	unsigned short	AudioRate;	// 0 = Mute
-	char			ExternalBasicImage[MAX_PATH];
 	char			ModulePath[MAX_PATH];
 	char			PathtoExe[MAX_PATH];
 	char			FloppyPath[MAX_PATH];
 	char			CassPath[MAX_PATH];
-    char            COCO3ROMPath[MAX_PATH];
     unsigned char   ShowMousePointer;
 } STRConfig;
 static STRConfig CurrentConfig;
@@ -224,7 +222,6 @@ unsigned char WriteIniFile(void)
 
 	GetCurrentModule(CurrentConfig.ModulePath);
 	ValidatePath(CurrentConfig.ModulePath);
-	ValidatePath(CurrentConfig.ExternalBasicImage);
 
 	WritePrivateProfileString("Version","Release",AppName,IniFilePath);
 	WritePrivateProfileInt("CPU","DoubleSpeedClock",CurrentConfig.CPUMultiplyer,IniFilePath);
@@ -246,7 +243,6 @@ unsigned char WriteIniFile(void)
 	WritePrivateProfileInt("Video", "WindowSizeY", tp.y, IniFilePath);
 
 	WritePrivateProfileInt("Memory","RamSize",CurrentConfig.RamSize,IniFilePath);
-	WritePrivateProfileString("Memory", "ExternalBasicImage", CurrentConfig.ExternalBasicImage, IniFilePath);
 
 	WritePrivateProfileInt("Misc","AutoStart",CurrentConfig.AutoStart,IniFilePath);
 	WritePrivateProfileInt("Misc","CartAutoStart",CurrentConfig.CartAutoStart,IniFilePath);
@@ -313,7 +309,6 @@ unsigned char ReadIniFile(void)
 	CurrentConfig.ShowMousePointer = GetPrivateProfileInt("Misc","ShowMousePointer",1,IniFilePath);
 
 	CurrentConfig.RamSize = GetPrivateProfileInt("Memory","RamSize",1,IniFilePath);
-	GetPrivateProfileString("Memory","ExternalBasicImage","",CurrentConfig.ExternalBasicImage,MAX_PATH,IniFilePath);
 
 	GetPrivateProfileString("Module","OnBoot","",CurrentConfig.ModulePath,MAX_PATH,IniFilePath);
 
@@ -330,7 +325,6 @@ unsigned char ReadIniFile(void)
 	vccKeyboardBuildRuntimeTable((keyboardlayout_e)CurrentConfig.KeyMap);
 
 	CheckPath(CurrentConfig.ModulePath);
-	CheckPath(CurrentConfig.ExternalBasicImage);
 
 	LeftJS.UseMouse=GetPrivateProfileInt("LeftJoyStick","UseMouse",1,IniFilePath);
 	LeftJS.Left=GetPrivateProfileInt("LeftJoyStick","Left",75,IniFilePath);
@@ -353,7 +347,6 @@ unsigned char ReadIniFile(void)
 
 	GetPrivateProfileString("DefaultPaths", "CassPath", "", CurrentConfig.CassPath, MAX_PATH, IniFilePath);
 	GetPrivateProfileString("DefaultPaths", "FloppyPath", "", CurrentConfig.FloppyPath, MAX_PATH, IniFilePath);
-	GetPrivateProfileString("DefaultPaths", "COCO3ROMPath", "", CurrentConfig.COCO3ROMPath, MAX_PATH, IniFilePath);
 
 	for (Index = 0; Index < NumberOfSoundCards; Index++)
 	{
@@ -1544,12 +1537,6 @@ int SelectFile(char *FileName)
 /**********************************/
 /*          Misc Exports          */
 /**********************************/
-
-// Called by tcc1014mmu.c
-char * BasicRomName(void)
-{
-	return(CurrentConfig.ExternalBasicImage);
-}
 
 // tcc1014graphics.c
 int GetPaletteType()

--- a/config.h
+++ b/config.h
@@ -23,7 +23,6 @@ void LoadConfig(SystemState *);
 void LoadModule();
 unsigned char WriteIniFile(void);
 unsigned char ReadIniFile(void);
-char * BasicRomName(void);
 void GetIniFilePath( char *);
 void UpdateConfig (void);
 void UpdateSoundBar(unsigned short,unsigned short);

--- a/tcc1014mmu.h
+++ b/tcc1014mmu.h
@@ -57,9 +57,8 @@ bool MemCheckWrite(unsigned short address);
 void __fastcall fMemWrite8(unsigned char,unsigned short );
 unsigned char __fastcall fMemRead8(short unsigned int);
 
-int load_int_rom(char * );
 void SetMapType(unsigned char);
-void CopyRom(void);
+void LoadRom(void);
 void Set_MmuTask(unsigned char);
 void SetMmuRegister(unsigned char,unsigned char);
 void Set_MmuEnabled (unsigned char );


### PR DESCRIPTION
Several non-working code fragments that were used in the past to load alternate versions of COCO3.ROM are removed.  COCO3.ROM is expected in the directory VCC.exe is in.  Alternately the full path to a different rom can be specified in the vcc.ini file in the "DefaultPaths" section with the tag "COCO3ROMPath"

If the alternate rom is specified and it fails to load or if is not specified and COCO3.ROM in the VCC.exe directory fails to load then Vcc.exe fails to start with a missing coco3 rom messagebox.