### PR TITLE
Support FF98 bit 4 monochrome on composite

### DIFF
--- a/tcc1014graphics.c
+++ b/tcc1014graphics.c
@@ -134,6 +134,15 @@ static unsigned char BlinkState=1;
 static bool UserFlipped = false;
 static unsigned int last_mmode = 0;
 
+//
+// FF98 bit 4 - monochrome on composite
+// 0 = composite
+// 1 = rgb
+int Pmode4MonType()
+{
+	return (CC3Vmode & 0x10) ? 1 : MonType;
+}
+
 // BEGIN of 8 Bit render loop *****************************************************************************************
 void UpdateScreen8 (SystemState *US8State)
 {
@@ -163,7 +172,9 @@ void UpdateScreen8 (SystemState *US8State)
 
 	if (LinesperRow < 13)
 		TagY++;
-	
+
+	auto pmode4MonType = Pmode4MonType();
+
 	if (!US8State->LineCounter)
 	{
 		StartofVidram=NewStartofVidram;
@@ -2024,7 +2035,7 @@ case 192+2:	//Bpp=0 Sr=2
 	{
 		WidePixel=US8State->WRamBuffer[(VidMask & ( Start+(unsigned char)(Hoffset+HorzBeam) ))>>1];
 //************************************************************************************
-		if (!MonType && BoarderColor8 == 0xFF)
+		if (!pmode4MonType && BoarderColor8 == 0xFF)
 		{ //Pcolor
 			for (Bit=7;Bit>=0;Bit--)
 			{
@@ -3256,7 +3267,9 @@ void UpdateScreen16 (SystemState *USState16)
 
 	if (LinesperRow < 13)
 		TagY++;
-	
+
+	auto pmode4MonType = Pmode4MonType();
+
 	if (!USState16->LineCounter)
 	{
 		StartofVidram=NewStartofVidram;
@@ -5117,7 +5130,7 @@ case 192+2:	//Bpp=0 Sr=2
 	{
 		WidePixel=USState16->WRamBuffer[(VidMask & ( Start+(unsigned char)(Hoffset+HorzBeam) ))>>1];
 //************************************************************************************
-		if (!MonType && BoarderColor16 == 0xFFFF)
+		if (!pmode4MonType && BoarderColor16 == 0xFFFF)
 		{ //Pcolor
 			for (Bit=7;Bit>=0;Bit--)
 			{
@@ -6373,6 +6386,8 @@ void UpdateScreen32(SystemState *USState32)
 			if (!USState32->ScanLines)
 				szSurface32[x + (PixelsperLine * (Stretch+1))+HorzCenter+(((y+VertCenter)*2+1)*Xpitch)]=BoarderColor32;
 		}
+
+	auto pmode4MonType = Pmode4MonType();
 
 	if (LinesperRow < 13)
 		TagY++;
@@ -8252,7 +8267,7 @@ case 192+1: //Bpp=0 Sr=1 1BPP Stretch=2
 case 192+2:	//Bpp=0 Sr=2 
 	curr_gmode = "gmode19 (PMODE4)";
 
-	if (!MonType && BoarderColor32 == 0xFFFFFF && GetPaletteType() == PALETTE_NTSC)
+	if (!pmode4MonType && BoarderColor32 == 0xFFFFFF && GetPaletteType() == PALETTE_NTSC)
 	{
 		// byte pointer to ram
 		unsigned char* cocoRam = (unsigned char*)WideBuffer;
@@ -8267,7 +8282,7 @@ case 192+2:	//Bpp=0 Sr=2
 	{
 		WidePixel=WideBuffer[(VidMask & ( Start+(unsigned char)(Hoffset+HorzBeam) ))>>1];
 //************************************************************************************
-		if (!MonType && BoarderColor32 == 0xFFFFFF)
+		if (!pmode4MonType && BoarderColor32 == 0xFFFFFF)
 		{ //Pcolor
 			for (Bit=7;Bit>=0;Bit--)
 			{


### PR DESCRIPTION
Fix for issue #189 - add support for monochrome on composite which will switch to rgb monitor type, so black and white.
bit 5 - which controls red/blue is already supported