### PR TITLE
Fix copying of trace buffer while rendering/exporting

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -241,6 +241,18 @@ namespace VCC { namespace Debugger
 		Decoder_->CaptureEmulatorCycle(evt, state, lineNS, irqNS, soundNS, cycles, drift);
 	}
 
+
+	void Debugger::LockTrace() const
+	{
+		Section_.Lock();
+	}
+	
+	void Debugger::UnlockTrace() const
+	{
+		Section_.Unlock();
+	}
+
+
 	void Debugger::SetTraceEnable()
 	{
 		TraceEnabled_ = true;
@@ -311,11 +323,9 @@ namespace VCC { namespace Debugger
 		return Decoder_->GetSampleCount();
 	}
 
-	void Debugger::GetTraceResult(tracebuffer_type &result, long start, int count) const
+	const Debugger::Debugger::tracebuffer_type& Debugger::GetTraceResult() const
 	{
-		SectionLocker lock(Section_);
-
-		Decoder_->GetTrace(result, start, count);
+		return Decoder_->GetTrace();
 	}
 
 	void Debugger::SetTraceMark(int mark, long sample)
@@ -339,14 +349,11 @@ namespace VCC { namespace Debugger
 
 		result.clear();
 
+		auto& trace = Decoder_->GetTrace();
+
 		for (const auto& kv: TraceMarks_)
 		{
-			tracebuffer_type mark;
-			Decoder_->GetTrace(mark, kv.second, 1);
-			if (mark.size() > 0)
-			{
-				result.push_back(mark[0]);
-			}
+			result.push_back(trace[kv.second]);
 		}
 	}
 

--- a/Debugger.h
+++ b/Debugger.h
@@ -96,7 +96,9 @@ namespace VCC { namespace Debugger
 		void SetTraceOptions(bool screen, bool emulation);
 
 		long GetTraceSamples() const;
-		void GetTraceResult(tracebuffer_type &result, long start, int count) const;
+		void LockTrace() const;
+		void UnlockTrace() const;
+		const tracebuffer_type& GetTraceResult() const;
 		void SetTraceMark(int mark, long sample);
 		void ClearTraceMarks();
 		void GetTraceMarkSamples(tracebuffer_type& result) const;

--- a/OpDecoder.cpp
+++ b/OpDecoder.cpp
@@ -109,18 +109,9 @@ namespace VCC { namespace Debugger
 		TraceCaptured_.push_back(emulator);
 	}
 
-	long OpDecoder::GetTrace(std::vector<CPUTrace>& trace, long start, long count)
+	const std::vector<VCC::CPUTrace>& OpDecoder::GetTrace() const
 	{
-		trace.clear();
-		for (unsigned long n = start; n < TraceCaptured_.size(); n++)
-		{
-			if (trace.size() >= (unsigned)count)
-			{
-				break;
-			}
-			trace.push_back(TraceCaptured_[n]);
-		}
-		return trace.size();
+		return TraceCaptured_;
 	}
 
 	size_t OpDecoder::GetSampleCount() const

--- a/OpDecoder.h
+++ b/OpDecoder.h
@@ -48,7 +48,7 @@ namespace VCC { namespace Debugger
 		void CaptureScreenEvent(TraceEvent evt, double cycles);
 		void CaptureEmulatorCycle(TraceEvent evt, int state, double lineNS, double irqNS, double soundNS, double cycles, double drift);
 
-		long GetTrace(std::vector<CPUTrace>& trace, long start, long count);
+		const std::vector<CPUTrace>& GetTrace() const;
 
 		size_t GetSampleCount() const;
 


### PR DESCRIPTION
- removes the copying going on that is just a waste of time and memory.