### PR TITLE
Fix audio initialization & shutdown

### DIFF
--- a/Vcc.c
+++ b/Vcc.c
@@ -160,7 +160,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 		MessageBox(0,"Can't create primary Window","Error",0);
 		exit(0);
 	}
-
+	InitSound();
 	DynamicMenuCallback( "",0, 0);
 	DynamicMenuCallback( "",1, 0);
 	LoadModule();
@@ -221,7 +221,6 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	CloseScreen();
 	timeEndPeriod(1);
 	UnloadDll();
-	SoundDeInit();
 	WriteIniFile(); //Save Any changes to ini File
 	return Msg.wParam;
 }
@@ -413,6 +412,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			break;
 
 		case WM_CLOSE:
+			SoundDeInit();
 			BinaryRunning=0;
 			UnloadDll();
 			break;

--- a/audio.c
+++ b/audio.c
@@ -68,20 +68,9 @@ int SoundInit (HWND main_window_handle,_GUID * Guid,unsigned short Rate)
 	CurrentRate=Rate;
 	if (InitPassed)
 	{
-		InitPassed=0;
-		lpdsbuffer1->Stop();
-
-		if (lpdsbuffer1 !=NULL)
-		{
-			hr=lpdsbuffer1->Release();
-			lpdsbuffer1=NULL;
-		}
-
-		if (lpds!=NULL)
-		{
-			hr=lpds->Release();
-			lpds=NULL;
-		}
+		PauseAudio(true);
+		ResetAudio();
+		SoundDeInit();
 	}
 	SndLenth1= 0;
 	SndLenth2= 0;
@@ -235,8 +224,17 @@ int SoundDeInit(void)
 	if (InitPassed)
 	{
 		InitPassed=0;
-		lpdsbuffer1->Stop();
-		lpds->Release();
+		if (lpdsbuffer1 != NULL)
+		{
+			hr = lpdsbuffer1->Release();
+			lpdsbuffer1 = NULL;
+		}
+
+		if (lpds != NULL)
+		{
+			hr = lpds->Release();
+			lpds = NULL;
+		}
 	}
 	return(0);
 }

--- a/config.c
+++ b/config.c
@@ -194,8 +194,8 @@ void LoadConfig(SystemState *LCState)
 	CurrentConfig.RebootNow=0;
 	UpdateConfig();
 	RefreshJoystickStatus();
-	SoundInit(EmuState.WindowHandle,
-			SoundCards[CurrentConfig.SndOutDev].Guid,CurrentConfig.AudioRate);
+	if (EmuState.WindowHandle != NULL)
+		InitSound();
 
 //  Try to open the config file.  Create it if necessary.  Abort if failure.
 	hr = CreateFile(IniFilePath, GENERIC_READ | GENERIC_WRITE,
@@ -208,6 +208,12 @@ void LoadConfig(SystemState *LCState)
 		CloseHandle(hr);
 		if (lasterror != ERROR_ALREADY_EXISTS) WriteIniFile();  //!=183
 	}
+}
+
+void InitSound()
+{
+	SoundInit(EmuState.WindowHandle,
+		SoundCards[CurrentConfig.SndOutDev].Guid, CurrentConfig.AudioRate);
 }
 
 /***********************************************************/

--- a/config.h
+++ b/config.h
@@ -21,6 +21,7 @@ This file is part of VCC (Virtual Color Computer).
 #include<iostream>
 using namespace std;
 void LoadConfig(SystemState *);
+void InitSound();
 void LoadModule();
 unsigned char WriteIniFile(void);
 unsigned char ReadIniFile(void);


### PR DESCRIPTION
- fix for audio initialization occurring before main window opened.
- was crashing on close during audio playback as dlls were unloaded before stopping audio.