### PR TITLE
Fix cassette loading, counter display & open existing file

### DIFF
--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -242,6 +242,9 @@ int MountTape( char *FileName)	//Return 1 on sucess 0 on fail
 		if (CasBuffer!=NULL)
 			free(CasBuffer);
 
+		if (TotalSize > WRITEBUFFERSIZE)
+			TotalSize = WRITEBUFFERSIZE;
+
 		CasBuffer=(unsigned char *)malloc(WRITEBUFFERSIZE);
 		SetFilePointer(TapeHandle,0,0,FILE_BEGIN);
 		ReadFile(TapeHandle,CasBuffer,TotalSize,&BytesMoved,NULL);	//Read the whole file in for .CAS files
@@ -277,7 +280,7 @@ unsigned int LoadTape(void)
 	memset(&ofn,0,sizeof(ofn));
 	ofn.lStructSize       = sizeof (OPENFILENAME);
 	ofn.hwndOwner         = NULL;
-	ofn.Flags             = OFN_HIDEREADONLY ;
+	ofn.Flags             = OFN_HIDEREADONLY | OFN_NOTESTFILECREATE;
 	ofn.hInstance         = GetModuleHandle(0);
 	ofn.lpstrDefExt			="";
 	ofn.lpstrFilter       =	"Cassette Files (*.cas)\0*.cas\0Wave Files (*.wav)\0*.wav\0\0";

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -171,6 +171,7 @@ float RenderFrame (SystemState *RFState)
 
 	if (!(FrameCounter % RFState->FrameSkip))
 	{
+		DrawBottomBoarder[RFState->BitDepth](RFState);
 		UnlockScreen(RFState);
 		SetBoarderChange(0);
 	}
@@ -269,7 +270,7 @@ void SetLinesperScreen (unsigned char Lines)
 	Lines = (Lines & 3);
 	LinesperScreen=Lpf[Lines];
 	TopBoarder=VcenterTable[Lines];
-	BottomBoarder = 240 - (TopBoarder + LinesperScreen);
+	BottomBoarder = 239 - (TopBoarder + LinesperScreen);
 	TopOffScreen = TopOffScreenTable[Lines];
 	BottomOffScreen = BottomOffScreenTable[Lines];
 	return;

--- a/config.c
+++ b/config.c
@@ -767,13 +767,13 @@ void UpdateTapeCounter(unsigned int Counter,unsigned char TapeMode)
 	Tmode=TapeMode;
 	sprintf(OutBuffer,"%i",TapeCounter);
 	SendDlgItemMessage(hTapeDlg,IDC_TCOUNT,
-			WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
 	SendDlgItemMessage(hTapeDlg,IDC_MODE,
-			WM_SETTEXT,strlen(Tmodes[Tmode]),(LPARAM)(LPCSTR)Tmodes[Tmode]);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)Tmodes[Tmode]);
 	GetTapeName(TapeFileName);
 	PathStripPath (TapeFileName);
 	SendDlgItemMessage(hTapeDlg,IDC_TAPEFILE,
-			WM_SETTEXT,strlen(TapeFileName),(LPARAM)(LPCSTR)TapeFileName);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)TapeFileName);
 
 	switch (Tmode) {
 	case REC:


### PR DESCRIPTION
- fix cassette loading (incorrect lines/screen) #298
- cassette counter (incorrect WM_SETTEXT args) #303
- opening current cas file (do not attempt to open file by open file dialog) #96