### PR TITLE
Fix improper use of wParam argument for WM_SETTEXT messages.

### DIFF
--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -242,6 +242,9 @@ int MountTape( char *FileName)	//Return 1 on sucess 0 on fail
 		if (CasBuffer!=NULL)
 			free(CasBuffer);
 
+		if (TotalSize > WRITEBUFFERSIZE)
+			TotalSize = WRITEBUFFERSIZE;
+
 		CasBuffer=(unsigned char *)malloc(WRITEBUFFERSIZE);
 		SetFilePointer(TapeHandle,0,0,FILE_BEGIN);
 		ReadFile(TapeHandle,CasBuffer,TotalSize,&BytesMoved,NULL);	//Read the whole file in for .CAS files
@@ -277,7 +280,7 @@ unsigned int LoadTape(void)
 	memset(&ofn,0,sizeof(ofn));
 	ofn.lStructSize       = sizeof (OPENFILENAME);
 	ofn.hwndOwner         = NULL;
-	ofn.Flags             = OFN_HIDEREADONLY ;
+	ofn.Flags             = OFN_HIDEREADONLY | OFN_NOTESTFILECREATE;
 	ofn.hInstance         = GetModuleHandle(0);
 	ofn.lpstrDefExt			="";
 	ofn.lpstrFilter       =	"Cassette Files (*.cas)\0*.cas\0Wave Files (*.wav)\0*.wav\0\0";

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -575,7 +575,7 @@ void SetStatusBarText(const char *TextBuffer,SystemState *STState)
 {
 	if (!STState->FullScreen)
 	{
-		SendMessage(hwndStatusBar,WM_SETTEXT ,strlen(TextBuffer),(LPARAM)(LPCSTR)TextBuffer);
+		SendMessage(hwndStatusBar,WM_SETTEXT,0,(LPARAM)(LPCSTR)TextBuffer);
 		SendMessage(hwndStatusBar,WM_SIZE,0,0);
 	}
 	else

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -287,7 +287,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 //			SendDlgItemMessage (hDlg, IDC_DISKA,WM_ENABLE  ,(WPARAM)0,(LPARAM)0);
 			SendDlgItemMessage (hDlg, IDC_DISKA,CB_SETCURSEL,(WPARAM)PhysicalDriveA,(LPARAM)0);
 			SendDlgItemMessage (hDlg, IDC_DISKB,CB_SETCURSEL,(WPARAM)PhysicalDriveB,(LPARAM)0);
-			SendDlgItemMessage (hDlg,IDC_ROMPATH,WM_SETTEXT,strlen(TempRomFileName),(LPARAM)(LPCSTR)TempRomFileName);
+			SendDlgItemMessage (hDlg,IDC_ROMPATH,WM_SETTEXT,0,(LPARAM)(LPCSTR)TempRomFileName);
 			return TRUE; 
 		break;
 
@@ -360,7 +360,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 					ofn.lpstrTitle        = TEXT("Disk Rom Image") ;	// title bar string
 					ofn.Flags             = OFN_HIDEREADONLY;
 					GetOpenFileName (&ofn);
-						SendDlgItemMessage(hDlg,IDC_ROMPATH,WM_SETTEXT,strlen(TempRomFileName),(LPARAM)(LPCSTR)TempRomFileName);
+						SendDlgItemMessage(hDlg,IDC_ROMPATH,WM_SETTEXT,0,(LPARAM)(LPCSTR)TempRomFileName);
 				break;
 				case IDC_CLOCK:
 				case IDC_READONLY:
@@ -520,7 +520,7 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 			SendDlgItemMessage(hDlg,IDC_DBLSIDE,BM_SETCHECK,DblSided,0);
 			strcpy(Dummy,TempFileName);
 			PathStripPath(Dummy);
-			SendDlgItemMessage(hDlg,IDC_TEXT1,WM_SETTEXT,strlen(Dummy),(LPARAM)(LPCSTR)Dummy);	
+			SendDlgItemMessage(hDlg,IDC_TEXT1,WM_SETTEXT,0,(LPARAM)(LPCSTR)Dummy);	
 			return TRUE; 
 		break;
 

--- a/SourceDebug.cpp
+++ b/SourceDebug.cpp
@@ -83,11 +83,11 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 
 	bool LoadSource(char* source)
 	{
-		SendDlgItemMessage(hWndSourceDebug, IDC_EDIT_SOURCE, WM_SETTEXT, strlen(source), (LPARAM)(LPCSTR)source);
+		SendDlgItemMessage(hWndSourceDebug, IDC_EDIT_SOURCE, WM_SETTEXT, 0, (LPARAM)(LPCSTR)source);
 
 		int nLines = 0;
 		std::string loaded(std::to_string(nLines) + " lines loaded");
-		SendDlgItemMessage(hWndSourceDebug, IDC_LINES_LOADED, WM_SETTEXT, loaded.size(), (LPARAM)ToLPCSTR(loaded));
+		SendDlgItemMessage(hWndSourceDebug, IDC_LINES_LOADED, WM_SETTEXT, 0, (LPARAM)ToLPCSTR(loaded));
 
 		std::ifstream file(source);
 		if (!file.is_open())
@@ -127,7 +127,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		SendDlgItemMessage(hWndSourceDebug, IDC_SOURCE_LISTING, EM_SETSEL, WPARAM(0), LPARAM(-1));
 		SendDlgItemMessage(hWndSourceDebug, IDC_SOURCE_LISTING, EM_REPLACESEL, WPARAM(TRUE), (LPARAM)ToLPCSTR(lines));
 		SendDlgItemMessage(hWndSourceDebug, IDC_SOURCE_LISTING, EM_LINESCROLL, 0, (LPARAM)-nLines);
-		SendDlgItemMessage(hWndSourceDebug, IDC_LINES_LOADED, WM_SETTEXT, loaded.size(), (LPARAM)ToLPCSTR(loaded));
+		SendDlgItemMessage(hWndSourceDebug, IDC_LINES_LOADED, WM_SETTEXT, 0, (LPARAM)ToLPCSTR(loaded));
 		return true;
 	}
 

--- a/Vcc.c
+++ b/Vcc.c
@@ -780,7 +780,7 @@ LRESULT CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 	switch (message)
 	{
 		case WM_INITDIALOG:
-			SendDlgItemMessage(hDlg,IDC_TITLE,WM_SETTEXT,strlen(g_szAppName),(LPARAM)(LPCSTR)g_szAppName);		
+			SendDlgItemMessage(hDlg,IDC_TITLE,WM_SETTEXT,0,(LPARAM)(LPCSTR)g_szAppName);
 			return TRUE;
 
 		case WM_COMMAND:

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -634,9 +634,9 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 		
     
 
-			SendDlgItemMessage (hDlg,IDC_TCPHOST, WM_SETTEXT, strlen(dwaddress),(LPARAM)(LPCSTR)dwaddress);
+			SendDlgItemMessage (hDlg,IDC_TCPHOST, WM_SETTEXT, 0,(LPARAM)(LPCSTR)dwaddress);
 			sprintf(msg,"%d", dwsport);
-			SendDlgItemMessage (hDlg,IDC_TCPPORT, WM_SETTEXT, strlen(msg),(LPARAM)(LPCSTR)msg);
+			SendDlgItemMessage (hDlg,IDC_TCPPORT, WM_SETTEXT, 0,(LPARAM)(LPCSTR)msg);
 			
 			return TRUE; 
 		break;

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -171,6 +171,7 @@ float RenderFrame (SystemState *RFState)
 
 	if (!(FrameCounter % RFState->FrameSkip))
 	{
+		DrawBottomBoarder[RFState->BitDepth](RFState);
 		UnlockScreen(RFState);
 		SetBoarderChange(0);
 	}
@@ -269,7 +270,7 @@ void SetLinesperScreen (unsigned char Lines)
 	Lines = (Lines & 3);
 	LinesperScreen=Lpf[Lines];
 	TopBoarder=VcenterTable[Lines];
-	BottomBoarder = 240 - (TopBoarder + LinesperScreen);
+	BottomBoarder = 239 - (TopBoarder + LinesperScreen);
 	TopOffScreen = TopOffScreenTable[Lines];
 	BottomOffScreen = BottomOffScreenTable[Lines];
 	return;

--- a/config.c
+++ b/config.c
@@ -496,7 +496,7 @@ LRESULT CALLBACK CpuConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam
 		CpuIcons[1]=LoadIcon(EmuState.WindowInstance,(LPCTSTR)IDI_HITACHI2);
 		SendMessage(hClkSpd,TBM_SETRANGE,TRUE,MAKELONG(2,CurrentConfig.MaxOverclock));
 		sprintf(OutBuffer,"%2.3f Mhz",(float)CurrentConfig.CPUMultiplyer*.894);
-		SendMessage(hClkDsp,WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
+		SendMessage(hClkDsp,WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
 		SendMessage(hClkSpd,TBM_SETPOS,TRUE, CurrentConfig.CPUMultiplyer);
 		for (temp=0;temp<=3;temp++)
 			SendDlgItemMessage(hDlg,Ramchoice[temp],BM_SETCHECK,
@@ -517,7 +517,7 @@ LRESULT CALLBACK CpuConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam
 	case WM_HSCROLL:
 		tmpcfg.CPUMultiplyer = (unsigned char) SendMessage (hClkSpd,TBM_GETPOS,0,0);
 		sprintf(OutBuffer,"%2.3f Mhz",(float)tmpcfg.CPUMultiplyer*.894);
-		SendDlgItemMessage(hDlg,IDC_CLOCKDISPLAY,WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
+		SendDlgItemMessage(hDlg,IDC_CLOCKDISPLAY,WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
 		break;
 
 	case WM_COMMAND:
@@ -652,7 +652,7 @@ void IncreaseOverclockSpeed()
 						   TRUE, CurrentConfig.CPUMultiplyer);
 		sprintf(OutBuffer, "%2.3f Mhz", (float)CurrentConfig.CPUMultiplyer * 0.894);
 		SendDlgItemMessage(hCpuDlg, IDC_CLOCKDISPLAY, WM_SETTEXT,
-						   strlen(OutBuffer), (LPARAM)(LPCSTR)OutBuffer);
+						   0, (LPARAM)(LPCSTR)OutBuffer);
 	}
 	EmuState.ResetPending = 4; // Without this, changing the config does nothing.
 }
@@ -670,7 +670,7 @@ void DecreaseOverclockSpeed()
 						   TRUE, CurrentConfig.CPUMultiplyer);
 		sprintf(OutBuffer, "%2.3f Mhz", (float)CurrentConfig.CPUMultiplyer * 0.894);
 		SendDlgItemMessage(hCpuDlg, IDC_CLOCKDISPLAY, WM_SETTEXT,
-						   strlen(OutBuffer), (LPARAM)(LPCSTR)OutBuffer);
+						   0, (LPARAM)(LPCSTR)OutBuffer);
 	}
 	EmuState.ResetPending = 4;
 }
@@ -704,10 +704,10 @@ LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPara
 	case WM_INITDIALOG:
 		TapeCounter=GetTapeCounter();
 		sprintf(OutBuffer,"%i",TapeCounter);
-		SendDlgItemMessage(hDlg,IDC_TCOUNT,WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
-		SendDlgItemMessage(hDlg,IDC_MODE,WM_SETTEXT,strlen(Tmodes[Tmode]),(LPARAM)(LPCSTR)Tmodes[Tmode]);
+		SendDlgItemMessage(hDlg,IDC_TCOUNT,WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
+		SendDlgItemMessage(hDlg,IDC_MODE,WM_SETTEXT,0,(LPARAM)(LPCSTR)Tmodes[Tmode]);
 		GetTapeName(TapeFileName);  // Defined in Cassette.cpp
-		SendDlgItemMessage(hDlg,IDC_TAPEFILE,WM_SETTEXT,strlen(TapeFileName),(LPARAM)(LPCSTR)TapeFileName);
+		SendDlgItemMessage(hDlg,IDC_TAPEFILE,WM_SETTEXT,0,(LPARAM)(LPCSTR)TapeFileName);
 		SendDlgItemMessage(hDlg,IDC_TCOUNT,EM_SETBKGNDCOLOR ,0,(LPARAM)RGB(0,0,0));
 		SendDlgItemMessage(hDlg,IDC_TCOUNT,EM_SETCHARFORMAT ,SCF_ALL,(LPARAM)&CounterText);
 		SendDlgItemMessage(hDlg,IDC_MODE,EM_SETBKGNDCOLOR ,0,(LPARAM)RGB(0,0,0));
@@ -921,7 +921,7 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 		SendDlgItemMessage(hDlg,IDC_REMEMBER_SIZE, BM_SETCHECK, tmpcfg.RememberSize, 0);
 		sprintf(OutBuffer,"%i",tmpcfg.FrameSkip);
 		SendDlgItemMessage(hDlg,IDC_FRAMEDISPLAY,
-				WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
+				WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
 		if (tmpcfg.MonitorType == 1) {
 			SendDlgItemMessage(hDlg,IDC_COMPOSITE,BM_SETCHECK,0,0);
 			SendDlgItemMessage(hDlg,IDC_RGB,BM_SETCHECK,1,0);
@@ -945,7 +945,7 @@ LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 			SendDlgItemMessage(hDlg,IDC_FRAMESKIP,TBM_GETPOS,(WPARAM) 0, (WPARAM) 0);
 		sprintf(OutBuffer,"%i",tmpcfg.FrameSkip);
 		SendDlgItemMessage(hDlg,IDC_FRAMEDISPLAY,
-			WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
 		break;
 
 	case WM_COMMAND:
@@ -1497,7 +1497,7 @@ LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam
 		if (!strlen(SerialCaptureFile))
 			strcpy(SerialCaptureFile,"No Capture File");
 		SendDlgItemMessage(hDlg,IDC_SERIALFILE,
-			WM_SETTEXT,strlen(SerialCaptureFile),(LPARAM)(LPCSTR)SerialCaptureFile);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)SerialCaptureFile);
 		SendDlgItemMessage(hDlg,IDC_LF,BM_SETCHECK,TextMode,0);
 		SendDlgItemMessage(hDlg,IDC_PRINTMON,BM_SETCHECK,PrtMon,0);
 		SetSerialParams(TextMode);
@@ -1523,14 +1523,14 @@ LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam
 		case IDC_OPEN:
 			SelectFile(SerialCaptureFile);
 			SendDlgItemMessage(hDlg,IDC_SERIALFILE,
-					WM_SETTEXT,strlen(SerialCaptureFile),(LPARAM)(LPCSTR)SerialCaptureFile);
+					WM_SETTEXT,0,(LPARAM)(LPCSTR)SerialCaptureFile);
 			break;
 
 		case IDC_CLOSE:
 			ClosePrintFile();
 			strcpy(SerialCaptureFile,"No Capture File");
 			SendDlgItemMessage(hDlg,IDC_SERIALFILE,
-					WM_SETTEXT,strlen(SerialCaptureFile),(LPARAM)(LPCSTR)SerialCaptureFile);
+					WM_SETTEXT,0,(LPARAM)(LPCSTR)SerialCaptureFile);
 			PrtMon=FALSE;
 			SetMonState(PrtMon);
 			SendDlgItemMessage(hDlg,IDC_PRINTMON,BM_SETCHECK,PrtMon,0);

--- a/config.c
+++ b/config.c
@@ -767,13 +767,13 @@ void UpdateTapeCounter(unsigned int Counter,unsigned char TapeMode)
 	Tmode=TapeMode;
 	sprintf(OutBuffer,"%i",TapeCounter);
 	SendDlgItemMessage(hTapeDlg,IDC_TCOUNT,
-			WM_SETTEXT,strlen(OutBuffer),(LPARAM)(LPCSTR)OutBuffer);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
 	SendDlgItemMessage(hTapeDlg,IDC_MODE,
-			WM_SETTEXT,strlen(Tmodes[Tmode]),(LPARAM)(LPCSTR)Tmodes[Tmode]);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)Tmodes[Tmode]);
 	GetTapeName(TapeFileName);
 	PathStripPath (TapeFileName);
 	SendDlgItemMessage(hTapeDlg,IDC_TAPEFILE,
-			WM_SETTEXT,strlen(TapeFileName),(LPARAM)(LPCSTR)TapeFileName);
+			WM_SETTEXT,0,(LPARAM)(LPCSTR)TapeFileName);
 
 	switch (Tmode) {
 	case REC:

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -437,11 +437,11 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 
 			hConfDlg=hDlg;
 			for (Temp=0;Temp<4;Temp++)
-				SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,5,(LPARAM)(LPCSTR) SlotLabel[Temp] );
+				SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,0,(LPARAM)(LPCSTR) SlotLabel[Temp] );
 			SendDlgItemMessage(hDlg,IDC_PAKSELECT,TBM_SETRANGE,TRUE,MAKELONG(0,3) );
 			SendDlgItemMessage(hDlg,IDC_PAKSELECT,TBM_SETPOS,TRUE,SwitchSlot);
 			ReadModuleParms(SwitchSlot,ConfigText);
-			SendDlgItemMessage(hDlg,IDC_MODINFO,WM_SETTEXT,strlen(ConfigText),(LPARAM)(LPCSTR)ConfigText );
+			SendDlgItemMessage(hDlg,IDC_MODINFO,WM_SETTEXT,0,(LPARAM)(LPCSTR)ConfigText );
 			SendDlgItemMessage(hDlg, IDC_PAK, BM_SETCHECK, PersistPaks, 0);
 			SendDlgItemMessage(hDlg, IDC_SCS_DISABLE, BM_SETCHECK, DisableSCS, 0);
 
@@ -478,7 +478,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 				{
 					LoadCartDLL(Temp,ModulePaths[Temp]);
 					for (Temp=0;Temp<4;Temp++)
-						SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,strlen(SlotLabel[Temp]),(LPARAM)(LPCSTR)SlotLabel[Temp] );
+						SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,0,(LPARAM)(LPCSTR)SlotLabel[Temp] );
 				}
 			}
 
@@ -487,7 +487,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 				if ( LOWORD(wParam) == REMOVEBTN[Temp] )
 				{
 					UnloadModule(Temp);	
-					SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,strlen(SlotLabel[Temp]),(LPARAM)(LPCSTR)SlotLabel[Temp] );
+					SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,0,(LPARAM)(LPCSTR)SlotLabel[Temp] );
 				}
 			}
 
@@ -507,7 +507,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 			SpareSelectSlot= SwitchSlot;
 			ChipSelectSlot= SwitchSlot;
 			ReadModuleParms(SwitchSlot,ConfigText);
-			SendDlgItemMessage(hDlg,IDC_MODINFO,WM_SETTEXT,strlen(ConfigText),(LPARAM)(LPCSTR)ConfigText );
+			SendDlgItemMessage(hDlg,IDC_MODINFO,WM_SETTEXT,0,(LPARAM)(LPCSTR)ConfigText );
 			PakSetCart(0);
 			if (CartForSlot[SpareSelectSlot]==1)
 				PakSetCart(1);


### PR DESCRIPTION
The wParam argument for WM_SETTEXT is claimed to be unused in Microsoft documentation but a string length has been used for this argument in quite a few places in Vcc code.  This request replaces the wParam argument in these cases with zero because it has been found that in rare cases a non-zero wParam can cause issues.  There are no current specific unresolved issues caused by the inproper use.