### PR TITLE
Shifted F1 and F2 keys no longer used as VCC controls

### DIFF
--- a/Vcc.c
+++ b/Vcc.c
@@ -110,7 +110,7 @@ void (*CPUForcePC)(unsigned short)=NULL;
 void FullScreenToggle(void);
 void save_key_down(unsigned char kb_char, unsigned char OEMscan);
 void raise_saved_keys(void);
-void FunctionHelpBox(void);
+void FunctionHelpBox(HWND);
 void SetupClock(void);
 
 // Globals
@@ -482,12 +482,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 			switch ( OEMscan )
 			{
-				case DIK_F1:
-					if (IsShiftKeyDown()) FunctionHelpBox();
-
-				case DIK_F2:
-					if (IsShiftKeyDown()) SwapJoySticks();
-
 				case DIK_F3:
 					DecreaseOverclockSpeed();
 				break;
@@ -503,15 +497,17 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 				case DIK_F6:
-					if (IsShiftKeyDown()) {
+					if (IsShiftKeyDown())
 						FlipArtifacts();
-					} else {
+					else
 						SetMonitorType(!SetMonitorType(QUERY));
-					}
 				break;
 
 				case DIK_F7:
-					EmuState.Debugger.ToggleRun();
+					if (IsShiftKeyDown())
+						SwapJoySticks();
+					else
+						EmuState.Debugger.ToggleRun();
 				break;
 
 				case DIK_F8:
@@ -532,21 +528,26 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 				case DIK_F10:
-					SetInfoBand(!SetInfoBand(QUERY));
-					InvalidateBoarder();
 				break;
 				
 				case DIK_F11:
-					if (FlagEmuStop == TH_RUNNING)
-					{
-						FlagEmuStop = TH_REQWAIT;
-						EmuState.FullScreen =! EmuState.FullScreen;
+					if (FlagEmuStop == TH_RUNNING) {
+						if (IsShiftKeyDown()) {
+							SetInfoBand(!SetInfoBand(QUERY));
+							InvalidateBoarder();
+						} else {
+							FlagEmuStop = TH_REQWAIT;
+							EmuState.FullScreen =! EmuState.FullScreen;
+						}
 					}
 				break;
 
 				case DIK_F12:
-					if (IsShiftKeyDown()) CpuDump();
-					else DumpScreenshot();
+					if (IsShiftKeyDown())
+						DumpScreenshot();
+					else
+						// If help dialog is modeless it prevents full screen
+						FunctionHelpBox(hWnd);
 				break;
 
 				default:
@@ -1069,8 +1070,8 @@ void FullScreenToggle(void)
 	return;
 }
 
-void FunctionHelpBox(void)
+void FunctionHelpBox(HWND hWnd)
 {
 	DialogBox(EmuState.WindowInstance,
-			MAKEINTRESOURCE(IDD_FUNCTION_KEYS),NULL,FunctionKeys);
+			MAKEINTRESOURCE(IDD_FUNCTION_KEYS),hWnd,FunctionKeys);
 }

--- a/Vcc.rc
+++ b/Vcc.rc
@@ -55,7 +55,7 @@ BEGIN
         MENUITEM "Cpu",                         ID_CPU_CONFIG
         MENUITEM "Display",                     ID_DISPLAY_CONFIG
         MENUITEM "Keyboard",                    ID_KEYBOARD_CONFIG
-        MENUITEM "JoyStick",                    ID_JOYSTICKS_CONFIG
+        MENUITEM "JoySticks",                   ID_JOYSTICKS_CONFIG
         MENUITEM "Tape",                        ID_TAPE_CONFIG
         MENUITEM "BitBanger",                   ID_BITBANGER_CONFIG
 
@@ -158,39 +158,35 @@ BEGIN
     DEFPUSHBUTTON   "OK",IDOK,175,320,50,14
 END
 
-IDD_FUNCTION_KEYS DIALOGEX 0,0,180,165
+IDD_FUNCTION_KEYS DIALOGEX 0,0,166,145
 STYLE DS_CENTERMOUSE | DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Function Keys"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
-    GROUPBOX "",IDC_STATIC,3,2,174,140,BS_CENTER
-    CTEXT "Normal",IDC_STATIC,10,8,50,10
-    LTEXT " F1   Coco F1",            IDC_STATIC,5,20,85,10
-    LTEXT " F2   Coco F2",            IDC_STATIC,5,30,85,10
-    LTEXT " F3   Decrease Overclock", IDC_STATIC,5,40,85,10
-    LTEXT " F4   Increase Overclock", IDC_STATIC,5,50,85,10
-    LTEXT " F5   Soft Reset",         IDC_STATIC,5,60,85,10
-    LTEXT " F6   Toggle RGB",         IDC_STATIC,5,70,85,10
-    LTEXT " F7   Pause/Run",          IDC_STATIC,5,80,85,10
-    LTEXT " F8   Toggle Throttle",    IDC_STATIC,5,90,85,10
-    LTEXT " F9   Stop/Start reset",   IDC_STATIC,5,100,85,10
-    LTEXT "F10  Toggle FS Status",    IDC_STATIC,5,110,85,10
-    LTEXT "F11  Toggle Fullscreen",   IDC_STATIC,5,120,85,10
-    LTEXT "F12  Take Screenshot",     IDC_STATIC,5,130,85,10
-    CTEXT "Shifted",IDC_STATIC,100,8,50,10
-    LTEXT "Function Key Help",  IDC_STATIC,100,20,65,10
-    LTEXT "Swap Joysticks",     IDC_STATIC,100,30,65,10
-    LTEXT "    ---",            IDC_STATIC,100,40,65,10
-    LTEXT "    ---",            IDC_STATIC,100,50,65,10
-    LTEXT "Hard Reset",         IDC_STATIC,100,60,65,10
-    LTEXT "Flip Artifacts",     IDC_STATIC,100,70,65,10
-    LTEXT "    ---",            IDC_STATIC,100,80,65,10
-    LTEXT "Toggle Overclock",   IDC_STATIC,100,90,65,10
-    LTEXT "    ---",            IDC_STATIC,100,100,65,10
-    LTEXT "    ---",            IDC_STATIC,100,110,65,10
-    LTEXT "    ---",            IDC_STATIC,100,120,65,10
-    LTEXT "Dump CPU Memory",    IDC_STATIC,100,130,65,10
-    DEFPUSHBUTTON "OK",IDOK,65,146,50,15
+    GROUPBOX "",IDC_STATIC,3,2,160,121,BS_CENTER
+    LTEXT "Unmodified",IDC_STATIC,30,8,50,10
+    LTEXT " F3   Decrease Overclock", IDC_STATIC,5,20,85,10
+    LTEXT " F4   Increase Overclock", IDC_STATIC,5,30,85,10
+    LTEXT " F5   Soft Reset",         IDC_STATIC,5,40,85,10
+    LTEXT " F6   RGB Toggle",         IDC_STATIC,5,50,85,10
+    LTEXT " F7   Pause Toggle"        IDC_STATIC,5,60,85,10
+    LTEXT " F8   Toggle Throttle",    IDC_STATIC,5,70,85,10
+    LTEXT " F9   Stop/Start reset",   IDC_STATIC,5,80,85,10
+    LTEXT "F10  \t---",               IDC_STATIC,5,90,85,10
+    LTEXT "F11  Toggle Fullscreen",   IDC_STATIC,5,100,85,10
+    LTEXT "F12  Function Keys",       IDC_STATIC,5,110,85,10
+    LTEXT "Shifted",          IDC_STATIC,110,8,50,10
+    LTEXT "---",              IDC_STATIC,115,20,40,10
+    LTEXT "---",              IDC_STATIC,115,30,40,10
+    LTEXT "Hard Reset",       IDC_STATIC,100,40,60,10
+    LTEXT "Flip Artifacts",   IDC_STATIC,100,50,60,10
+    LTEXT "Swap Joysticks",   IDC_STATIC,100,60,60,10
+    LTEXT "Overclock Toggle", IDC_STATIC,100,70,60,10
+    LTEXT "---",              IDC_STATIC,115,80,40,10
+    LTEXT "---",              IDC_STATIC,115,90,40,10
+    LTEXT "Toggle FS Status", IDC_STATIC,100,100,60,10
+    LTEXT "Take Screenshot",  IDC_STATIC,100,110,60,10
+    DEFPUSHBUTTON "OK",IDOK,57,126,50,15
 END
 
 IDD_DISPLAY DIALOGEX 0, 0, 254, 220


### PR DESCRIPTION
Shifted F1 and F2 keys were being used for function key help and swap joysticks
These have been moved to F12 and shifted F7.  Screenshot moved to shifted F12.