### PR TITLE
Add support for 16,24,32 signed and float wav formats & various fixes

### DIFF
--- a/BuildConfig.h
+++ b/BuildConfig.h
@@ -73,6 +73,13 @@
 #define USE_DEFAULT_POSITIONING false
 #endif
 
+//
+// Enable debugging display of audio and tape, mux and motor control, as well as output buffers.
+//
+#ifndef USE_DEBUG_AUDIOTAPE
+#define USE_DEBUG_AUDIOTAPE false
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // 
 // Edit options above rather than these:
@@ -84,3 +91,16 @@
 #if USE_OPENGL && USE_DIRECTX
 #error Enable either USE_OPENGL or USE_DIRECTX not both.
 #endif
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Options that are always off for release
+//
+#ifdef NDEBUG
+#undef USE_DEBUG_LINES 
+#define USE_DEBUG_LINES false	
+#undef USE_DEBUG_AUDIOTAPE
+#define USE_DEBUG_AUDIOTAPE false
+#undef USE_DEBUG_MOUSE
+#define USE_DEBUG_MOUSE false
+#endif
+

--- a/Cassette.h
+++ b/Cassette.h
@@ -24,12 +24,15 @@ This file is part of VCC (Virtual Color Computer).
 #define EJECT	3
 #define CAS	1
 #define WAV 0
-#define CAS_WRITEBUFFERSIZE	0x40000
-#define CAS_TAPEREADAHEAD 1000 // decoded batch size
+
+const int CAS_WRITEBUFFERSIZE = 0x40000;
+const int CAS_TAPEREADAHEAD = 1000; // decoded batch size
+const int CAS_SILENCE = 128;
+const int CAS_TAPEAUDIORATE = 44100;
 
 unsigned int GetTapeCounter(void);
 unsigned int LoadTape(void);
-void SetTapeCounter(unsigned int);
+void SetTapeCounter(unsigned int, bool force = false);
 void SetTapeMode(unsigned char);
 void Motor(unsigned char);
 void LoadCassetteBuffer(unsigned char *, unsigned int* CassBufferSize);
@@ -39,5 +42,7 @@ void UpdateTapeStatus(char* status, int max);
 uint8_t CassInBitStream();
 
 extern unsigned char TapeFastLoad;
+unsigned int GetTapeRate();
+unsigned char GetMotorState();
 
 #endif

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -31,6 +31,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "config.h"
 #include <iostream>
 #include <string>
+#include "BuildConfig.h"
 #include "IDisplay.h"
 #include "Screenshot.h"
 
@@ -47,6 +48,11 @@ typedef VCC::OpenGL Display;
 typedef VCC::IDisplay IDisplayPtr;
 typedef VCC::DirectX Display;
 #endif // USE_DIRECTX
+
+#if USE_DEBUG_AUDIOTAPE
+#include "IDisplayDebug.h"
+#endif // USE_DEBUG_AUDIOTAPE
+
 
 static IDisplayPtr* g_Display = nullptr;
 
@@ -360,6 +366,15 @@ void DisplayFlip(SystemState *DFState)	// Double buffering flip
 				g_Display->RenderText(g_DisplayFont, 10, 18, 20, StatusText);
 			}
 		}
+
+#if USE_DEBUG_AUDIOTAPE
+		// put these here for now as it needs to be on top
+		DebugPrint(10, 250, 20, "Audio Out");
+		DebugPrint(10, 400, 20, "Audio In");
+		DebugPrint(10, 515, 20, "Motor");
+		DebugPrint(10, 545, 20, "MUX");
+#endif // USE_DEBUG_AUDIOTAPE
+
 		g_Display->Present();
 	}
 #endif // USE_OPENGL
@@ -815,6 +830,14 @@ void DebugDrawBox(float x, float y, float w, float h, Pixel color)
 {
 	if (g_Display)
 		g_Display->DebugDrawBox(x, y, w, h, color);
+}
+
+void DebugPrint(float x, float y, float size, const char* str)
+{
+#if USE_OPENGL && USE_DEBUG_LINES
+	if (g_Display && LoadOpenGLFont())
+		g_Display->RenderText(g_DisplayFont, x, y, size, str);
+#endif
 }
 
 void DumpScreenshot()

--- a/IDisplayDebug.h
+++ b/IDisplayDebug.h
@@ -27,6 +27,7 @@
 
 void DebugDrawBox(float x, float y, float w, float h, VCC::Pixel color);
 void DebugDrawLine(float x, float y, float x2, float y2, VCC::Pixel color);
+void DebugPrint(float x, float y, float size, const char* str);
 
 inline void DebugDrawBox(int x, int y, int w, int h, VCC::Pixel color) 
 {

--- a/OpenGL.cpp
+++ b/OpenGL.cpp
@@ -397,19 +397,22 @@ namespace VCC
 			if (debugLines.size())
 			{
 				Pixel lastColor(debugLines[0].color);
+				glEnable(GL_BLEND);
+				glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 				glBegin(GL_LINES);
-				glColor3ub(lastColor.r, lastColor.g, lastColor.b);
+				glColor4ub(lastColor.r, lastColor.g, lastColor.b, lastColor.a);
 				for (size_t i = 0; i < debugLines.size(); ++i)
 				{
 					if (lastColor != debugLines[i].color)
 					{
 						lastColor = debugLines[i].color;
-						glColor3ub(lastColor.r, lastColor.g, lastColor.b);
+						glColor4ub(lastColor.r, lastColor.g, lastColor.b, lastColor.a);
 					}
 					glVertex3f(debugLines[i].x1, debugLines[i].y1, 0);
 					glVertex3f(debugLines[i].x2, debugLines[i].y2, 0);
 				}
 				glEnd();
+				glDisable(GL_BLEND);
 				debugLines.clear();
 			}
 			#endif // USE_DEBUG_LINES

--- a/audio.h
+++ b/audio.h
@@ -18,19 +18,21 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-int SoundInit (HWND,_GUID *,unsigned short);
+int SoundInit (HWND,_GUID *,unsigned int);
 int SoundDeInit(void);
-void FlushAudioBuffer ( unsigned int *,unsigned short);
+void FlushAudioBuffer ( unsigned int *,unsigned int);
 void ResetAudio (void);
 unsigned char PauseAudio(unsigned char Pause);
 int GetFreeBlockCount(void);
 int GetAuxBlockCount(void);
 void PurgeAuxBuffer(void);
-unsigned short GetSoundStatus(void);
+unsigned int GetSoundStatus(void);
 typedef struct CardList {
 	char CardName[64];
 	_GUID *Guid;
 } SndCardList;
+
+const int AUDIO_RATE = 44100;
 
 int GetSoundCardList (SndCardList *);
 

--- a/coco3.h
+++ b/coco3.h
@@ -31,17 +31,17 @@ struct DisplayDetails
 
 
 //unsigned short RenderFrame (unsigned char);
-void SetClockSpeed(unsigned short Cycles);
+void SetClockSpeed(unsigned int Cycles);
 void SetLinesperScreen(unsigned char Lines);
 DisplayDetails GetDisplayDetails(const int clientWidth, const int clientHeight);
 void SetHorzInteruptState(unsigned char);
 void SetVertInteruptState(unsigned char);
-unsigned char SetSndOutMode(unsigned char);
+void SetSndOutMode(unsigned char);
 float RenderFrame (SystemState *);
 
 void SetTimerInteruptState(unsigned char);
 void SetTimerClockRate (unsigned char);	
-void SetInteruptTimer(unsigned short);
+void SetInteruptTimer(unsigned int);
 void MiscReset(void);
 void PasteBASICWithNew();
 void PasteBASIC();
@@ -49,6 +49,6 @@ void PasteText();
 void QueueText(char *);
 void CopyText();
 void FlipArtifacts();
-unsigned short SetAudioRate (unsigned short);
+unsigned int SetAudioRate(unsigned int);
 
 #endif

--- a/config.c
+++ b/config.c
@@ -98,7 +98,7 @@ typedef struct  {
 	unsigned char	SndOutDev;
 	unsigned char	KeyMap;
 	char			SoundCardName[64];
-	unsigned short	AudioRate;	// 0 = Mute
+	unsigned int	AudioRate;	// 0 = Mute
 	char			ModulePath[MAX_PATH];
 	char			PathtoExe[MAX_PATH];
 	char			FloppyPath[MAX_PATH];
@@ -732,29 +732,25 @@ LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPara
 			}
 			break;
 		case IDC_PLAY:
-			Tmode=PLAY;
-			SetTapeMode(Tmode);
+			SetTapeMode(PLAY);
 			break;
 		case IDC_REC:
-			Tmode=REC;
-			SetTapeMode(Tmode);
+			SetTapeMode(REC);
 			break;
 		case IDC_STOP:
-			Tmode=STOP;
-			SetTapeMode(Tmode);
+			SetTapeMode(STOP);
 			break;
 		case IDC_EJECT:
-			Tmode=EJECT;
-			SetTapeMode(Tmode);
+			SetTapeMode(EJECT);
 			break;
 		case IDC_RESET:
-			TapeCounter=0;
-			SetTapeCounter(TapeCounter);
+			SetTapeCounter(0);
+			SetTapeMode(STOP);
 			break;
 		case IDC_TBROWSE:
 			LoadTape();
-			TapeCounter=0;
-			SetTapeCounter(TapeCounter);
+			SendDlgItemMessage(hDlg, IDC_FASTLOAD, BM_SETCHECK, TapeFastLoad, 0);
+			SetTapeCounter(0, true);
 			break;
 		case IDC_FASTLOAD:
 			TapeFastLoad = (unsigned char)SendDlgItemMessage(hDlg, IDC_FASTLOAD, BM_GETCHECK, 0, 0);
@@ -765,35 +761,42 @@ LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPara
 	return(0);
 }
 
-void UpdateTapeCounter(unsigned int Counter,unsigned char TapeMode)
+void UpdateTapeCounter(unsigned int Counter,unsigned char TapeMode, bool forced)
 {
 	if (hTapeDlg==NULL) return;
-	TapeCounter=Counter;
-	Tmode=TapeMode;
-	sprintf(OutBuffer,"%i",TapeCounter);
-	SendDlgItemMessage(hTapeDlg,IDC_TCOUNT,
-			WM_SETTEXT,0,(LPARAM)(LPCSTR)OutBuffer);
-	SendDlgItemMessage(hTapeDlg,IDC_MODE,
-			WM_SETTEXT,0,(LPARAM)(LPCSTR)Tmodes[Tmode]);
-	GetTapeName(TapeFileName);
-	PathStripPath (TapeFileName);
-	SendDlgItemMessage(hTapeDlg,IDC_TAPEFILE,
-			WM_SETTEXT,0,(LPARAM)(LPCSTR)TapeFileName);
 
-	switch (Tmode) {
-	case REC:
-		SendDlgItemMessage(hTapeDlg,IDC_MODE,EM_SETBKGNDCOLOR ,0,(LPARAM)RGB(0xAF,0,0));
-		break;
-
-	case PLAY:
-		SendDlgItemMessage(hTapeDlg,IDC_MODE,EM_SETBKGNDCOLOR ,0,(LPARAM)RGB(0,0xAF,0));
-		break;
-
-	default:
-		SendDlgItemMessage(hTapeDlg,IDC_MODE,EM_SETBKGNDCOLOR ,0,(LPARAM)RGB(0,0,0));
-		break;
+	if (Counter != TapeCounter || forced)
+	{
+		TapeCounter = Counter;
+		sprintf(OutBuffer, "%i", TapeCounter);
+		SendDlgItemMessage(hTapeDlg, IDC_TCOUNT,
+			WM_SETTEXT, 0, (LPARAM)(LPCSTR)OutBuffer);
 	}
-	return;
+
+	if (Tmode != TapeMode || forced)
+	{
+		Tmode = TapeMode;
+		SendDlgItemMessage(hTapeDlg, IDC_MODE,
+			WM_SETTEXT, 0, (LPARAM)(LPCSTR)Tmodes[Tmode]);
+		GetTapeName(TapeFileName);
+		PathStripPath(TapeFileName);
+		SendDlgItemMessage(hTapeDlg, IDC_TAPEFILE,
+			WM_SETTEXT, 0, (LPARAM)(LPCSTR)TapeFileName);
+
+		switch (Tmode) {
+			case REC:
+				SendDlgItemMessage(hTapeDlg, IDC_MODE, EM_SETBKGNDCOLOR, 0, (LPARAM)RGB(0xAF, 0, 0));
+				break;
+
+			case PLAY:
+				SendDlgItemMessage(hTapeDlg, IDC_MODE, EM_SETBKGNDCOLOR, 0, (LPARAM)RGB(0, 0xAF, 0));
+				break;
+
+			default:
+				SendDlgItemMessage(hTapeDlg, IDC_MODE, EM_SETBKGNDCOLOR, 0, (LPARAM)RGB(0, 0, 0));
+				break;
+		}
+	}
 }
 
 /********************************************/

--- a/config.h
+++ b/config.h
@@ -28,7 +28,7 @@ unsigned char ReadIniFile(void);
 void GetIniFilePath( char *);
 void UpdateConfig (void);
 void UpdateSoundBar(unsigned short,unsigned short);
-void UpdateTapeCounter(unsigned int,unsigned char);
+void UpdateTapeCounter(unsigned int,unsigned char,bool force = false);
 int GetKeyboardLayout();
 void SetWindowRect(const VCC::Rect&);
 void CaptureCurrentWindowRect();

--- a/defines.h
+++ b/defines.h
@@ -195,7 +195,6 @@ struct SystemState
 extern SystemState EmuState;
 
 static char RateList[4][7]={"Mute","11025","22050","44100"};
-static unsigned short iRateList[4]={0,11025,22050,44100};
-#define TAPEAUDIORATE 44100
+static unsigned int iRateList[4]={0,11025,22050,44100};
 
 #endif

--- a/mc6821.c
+++ b/mc6821.c
@@ -345,30 +345,30 @@ void irq_hs(int phase)	//63.5 uS
 
 void irq_fs(int phase)	//60HZ Vertical sync pulse 16.667 mS
 {
-	if ((CartInserted==1) & (CartAutoStart==1))
+	if ((CartInserted == 1) && (CartAutoStart == 1))
 		AssertCart();
 	switch (phase)
 	{
-	case 0:	//FS went High to low
-		if ((rega[3] & 2) == 0) //IRQ on High to low transition
-		{
-			rega[3] = (rega[3] | 128);
-			if (rega[3] & 1)
-				CPUAssertInterupt(IRQ, 4);
-		}
-		return;
-	break;
+		case 0:	//FS went High to low
+			if ((rega[3] & 2) == 0) //IRQ on High to low transition
+			{
+				rega[3] = (rega[3] | 128);
+				if (rega[3] & 1)
+					CPUAssertInterupt(IRQ, 4);
+			}
+			return;
+			break;
 
-	case 1:	//FS went Low to High
+		case 1:	//FS went Low to High
 
-		if ((rega[3] & 2)) //IRQ  Low to High transition
-		{
-			rega[3] = (rega[3] | 128);
-			if (rega[3] & 1)
-				CPUAssertInterupt(IRQ, 1);
-		}
-		return;
-	break;
+			if ((rega[3] & 2)) //IRQ  Low to High transition
+			{
+				rega[3] = (rega[3] | 128);
+				if (rega[3] & 1)
+					CPUAssertInterupt(IRQ, 1);
+			}
+			return;
+			break;
 	} //END switch
 
 	return;

--- a/throttle.c
+++ b/throttle.c
@@ -63,8 +63,11 @@ void CheckSound()
 				return;
 
 			// Dont let it fill up either
-			while (GetFreeBlockCount() < 1)
+			int count = 100; // loop limit
+			while (GetFreeBlockCount() < 1 && count > 0)
 			{
+Sleep(1);
+				--count;
 			}
 		}
 	}


### PR DESCRIPTION
- add support for 16, 24, 32 bit signed WAV formats, 32 bit float WAV format
- fix motor on/off control, no longer resets audio
- separate cass buffer and output audio buffer
- fix audio levels for cas formats
- allow 'play' to open and start playing (crashed previously)
- added debug audio display mux/dac/LR channels
- fixed audio pop when switching mux/dac
tests:
- Micky's alpine adventures wav files
- tuts tomb original version
- orc 90 cart