### PR TITLE
Chambers running too fast, should not be in fast mode

### DIFF
--- a/tcc1014registers.c
+++ b/tcc1014registers.c
@@ -380,11 +380,24 @@ void sam_write(unsigned char data ,unsigned char port)
 	if ( (port==0xDE) | (port ==0xDF))
 		SetMapType(port&1);
 
-	if ( (port==0xD7) | (port==0xD9) )
-		SetCPUMultiplyerFlag (1);
+	// RAM high speed poke
+	if (port==0xD9)
+		SetCPUMultiplyerFlag(1);
 
-	if ( (port==0xD6) | (port==0xD8) )
-		SetCPUMultiplyerFlag (0);
+	if (port==0xD8)
+		SetCPUMultiplyerFlag(0);
+
+//
+// todo: ROM high speed poke, currently unsupported by vcc
+// should only be fast in rom not ram so can't just use
+// SetCPUMultiplyerFlag. 
+//
+//	if (port==0xD7)
+//		SetCPUMultiplyerFlag (1);
+//
+//	if (port==0xD6)
+//		SetCPUMultiplyerFlag (0);
+
 
 	return;
 }


### PR DESCRIPTION
- during investigation noticed vcc issues twice as many instructions vs xroar as xroar is running at normal speed
- this game shouldn't be running in fast mode but it does, it writes to 65495 which speeds up rom not ram
- fixes issue #295 and maybe others