### PR TITLE
Refactor DirectX specific code into its own class, like OpenGL

### DIFF
--- a/BuildConfig.h
+++ b/BuildConfig.h
@@ -27,12 +27,19 @@
 
 
 //
-// Enable the use of OpenGL display driver, otherwise use DirectX.
+// Enable the use of OpenGL display driver
 //
 #ifndef _LEGACY_VCC
 #ifndef USE_OPENGL
 #define USE_OPENGL true
 #endif
+#endif
+
+//
+// Enable the use of DirectX display driver
+//
+#ifndef USE_DIRECTX
+#define USE_DIRECTX true
 #endif
 
 //
@@ -84,13 +91,6 @@
 // 
 // Edit options above rather than these:
 //
-#if !USE_OPENGL
-#define USE_DIRECTX true
-#endif
-
-#if USE_OPENGL && USE_DIRECTX
-#error Enable either USE_OPENGL or USE_DIRECTX not both.
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Options that are always off for release

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -19,10 +19,10 @@ This file is part of VCC (Virtual Color Computer).
 #define NO_WARN_MBCS_MFC_DEPRECATION
 #define _WIN32_WINNT 0x05010000 // I want to support XP
 
+#include "BuildConfig.h"
 #include <windows.h>
 #include <commctrl.h>	// Windows common controls
 #include "defines.h"
-#include "ddraw.h"
 #include "stdio.h"
 #include "DirectDrawInterface.h"
 #include "resource.h"
@@ -31,43 +31,40 @@ This file is part of VCC (Virtual Color Computer).
 #include "config.h"
 #include <iostream>
 #include <string>
-#include "BuildConfig.h"
 #include "IDisplay.h"
 #include "Screenshot.h"
 
-#if USE_OPENGL
 #include "OpenGL.h"
 #include "OpenGLFontConsola.h"
-static const VCC::OpenGLFont* g_DisplayFont = nullptr;
-typedef VCC::IDisplayOpenGL IDisplayPtr;
-typedef VCC::OpenGL Display;
-#endif // USE_OPENGL
-
-#if USE_DIRECTX
 #include "DirectX.h"
-typedef VCC::IDisplay IDisplayPtr;
-typedef VCC::DirectX Display;
-#endif // USE_DIRECTX
+#include "DisplayNull.h"
 
 #if USE_DEBUG_AUDIOTAPE
 #include "IDisplayDebug.h"
 #endif // USE_DEBUG_AUDIOTAPE
 
-
-static IDisplayPtr* g_Display = nullptr;
-
 using namespace VCC; // after all includes
 
+static IDisplay* g_Display = nullptr;
+static ISystemState* g_SystemState = nullptr;
 
-//Global Variables for Direct Draw funcions
-LPDIRECTDRAW        g_pDD		= NULL;  // The DirectDraw object
-LPDIRECTDRAWCLIPPER g_pClipper	= NULL;  // Clipper for primary surface
-LPDIRECTDRAWSURFACE g_pDDS		= NULL;  // Primary surface
-LPDIRECTDRAWSURFACE g_pDDSBack	= NULL;  // Back surface
+static IDisplayDirectX* g_DirectXDisplay = nullptr;
+static IDisplayOpenGL* g_OpenGLDisplay = nullptr;
+static const OpenGLFont* g_DisplayFont = nullptr;
 
-static IDirectDrawPalette* ddpal;		//Needed for 8bit Palette mode
+#if USE_OPENGL
+using ClassOpenGL = OpenGL;
+#else
+using ClassOpenGL = DisplayNull;
+#endif
+
+#if USE_DIRECTX
+using ClassDirectX = DirectX;
+#else
+using ClassDirectX = DisplayNull;
+#endif
+
 static HWND hwndStatusBar=NULL;
-static RECT WindowDefaultSize;
 static unsigned int StatusBarHeight=0;
 static TCHAR szTitle[MAX_LOADSTRING];			// The title bar text
 static TCHAR szWindowClass[MAX_LOADSTRING];	// The title bar text
@@ -80,19 +77,21 @@ static unsigned char ForceAspect=1;
 static char StatusText[255]="";
 static unsigned int Color=0;
 static Rect RememberWin = { CW_USEDEFAULT, CW_USEDEFAULT, DefaultWidth, DefaultHeight };
-static POINT ForcedAspectBorderPadding;
+static bool UseOpenGL = true;
 
 //Function Prototypes for this module
 extern LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM); //Callback for the main window
 //void DisplayFlip(SystemState *);
 
-#if USE_OPENGL
 // load font on demand, otherwise false if not supported
 bool LoadOpenGLFont()
 {
-	return g_Display && (g_DisplayFont || g_Display->LoadFont(&g_DisplayFont, IDB_FONT_CONSOLA, OpenGLFontConsola, 32, 127) == OpenGL::OK);
+#if USE_OPENGL
+	return g_OpenGLDisplay && (g_DisplayFont || g_OpenGLDisplay->LoadFont(&g_DisplayFont, IDB_FONT_CONSOLA, OpenGLFontConsola, 32, 127) == OpenGL::OK);
+#else // !USE_OPENGL
+	return false;
+#endif // !USE_OPENGL
 }
-#endif // USE_OPENGL
 
 BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 {
@@ -104,18 +103,22 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 	return TRUE;
 }
 
+template<typename T, typename Interface>
+bool InitGraphics(Interface** ptr, SystemState* CWState, int w, int h)
+{
+	if (!*ptr) *ptr = new T(g_SystemState);
+	if (!g_Display) g_Display = *ptr;
+	if (g_Display && g_Display->Setup(CWState->WindowHandle, w, h, StatusBarHeight, CWState->FullScreen == 1) == IDisplay::OK)
+		return true;
+	g_Display = nullptr;
+	*ptr = nullptr;
+	return false;
+};
+
 bool CreateDDWindow(SystemState *CWState)
 {
-#if USE_DIRECTX
-	HRESULT hr;
-	PALETTEENTRY pal[256];
-#endif // USE_DIRECTX
-	DDSURFACEDESC ddsd;				// A structure to describe the surfaces we want
 	RECT rStatBar;
 	RECT rc = { 0, 0, DefaultWidth, DefaultHeight };
-	unsigned char ColorValues[4]={0,85,170,255};
-	memset(&ddsd, 0, sizeof(ddsd));	// Clear all members of the structure to 0
-	ddsd.dwSize = sizeof(ddsd);		// The first parameter of the structure must contain the size of the structure
 
 	auto isRememberSize = GetRememberSize();
 
@@ -139,19 +142,12 @@ bool CreateDDWindow(SystemState *CWState)
 		yPos = 0;
 	}
 
-#if USE_OPENGL
 	HMONITOR hmon;
-#endif // USE_OPENGL
 
 	if (CWState->WindowHandle != NULL) //If its go a value it must be a mode switch
 	{
-#if USE_OPENGL
-		hmon = MonitorFromWindow(CWState->WindowHandle,
-			MONITOR_DEFAULTTONEAREST);
-#endif // USE_OPENGL
+		hmon = MonitorFromWindow(CWState->WindowHandle,	MONITOR_DEFAULTTONEAREST);
 		CloseScreen();
-		if (g_pDD != NULL)
-			g_pDD->Release();	//Destroy the current Window
 		DestroyWindow(CWState->WindowHandle);
 		UnregisterClass(wcex.lpszClassName,wcex.hInstance);
 	}
@@ -174,9 +170,9 @@ bool CreateDDWindow(SystemState *CWState)
 	}
 	if (!RegisterClassEx(&wcex))
 		return FALSE;
-	switch (CWState->FullScreen)
+	if (CWState->FullScreen == 0)
 	{
-	case 0: //Windowed Mode
+		//Windowed Mode
 		
 		// Calculates the required size of the window rectangle, based on the desired client-rectangle size
 		// The window rectangle can then be passed to the CreateWindow function to create a window whose client area is the desired size.
@@ -207,62 +203,15 @@ bool CreateDDWindow(SystemState *CWState)
 //											rStatBar.right - rStatBar.left, rStatBar.bottom - rStatBar.top,
 											1);
 		::SendMessage(hwndStatusBar, WM_SIZE, 0, 0); // Redraw Status bar in new position
-
-		::GetWindowRect(CWState->WindowHandle, &WindowDefaultSize);	// And save the Final size of the Window 
-		::ShowWindow(CWState->WindowHandle, g_nCmdShow);
-		::UpdateWindow(CWState->WindowHandle);
-
-#if USE_DIRECTX
-		// Create an instance of a DirectDraw object
-		hr = ::DirectDrawCreate(NULL, &g_pDD, NULL);
-		if (hr) return FALSE;
-		
-		// Initialize the DirectDraw object
-		hr = g_pDD->SetCooperativeLevel(CWState->WindowHandle, DDSCL_NORMAL);	// Set DDSCL_NORMAL to use windowed mode
-		if (hr) return FALSE;
-		
-		ddsd.dwFlags = DDSD_CAPS ; 
-		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
-		
-		// Create our Primary Surface
-		hr = g_pDD->CreateSurface(&ddsd, &g_pDDS, NULL);
-		if (hr) return FALSE;
-		ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS ;
-		ddsd.dwWidth  = CWState->WindowSize.x;								// Make our off-screen surface 
-		ddsd.dwHeight = CWState->WindowSize.y;
-		ddsd.ddsCaps.dwCaps = DDSCAPS_VIDEOMEMORY;				// Try to create back buffer in video RAM
-		hr = g_pDD->CreateSurface(&ddsd, &g_pDDSBack, NULL);	
-		if (hr)													// If not enough Video Ram 			
-		{
-			ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY;			// Try to create back buffer in System RAM
-			hr = g_pDD->CreateSurface(&ddsd, &g_pDDSBack, NULL);
-			if (hr)	return FALSE;								//Giving Up
-			MessageBox(0,"Creating Back Buffer in System Ram\n","Performance Warning",0);
-		}
-
-		hr= g_pDD->GetDisplayMode(&ddsd);
-		if (hr) return FALSE;
-		hr = g_pDD->CreateClipper(0, &g_pClipper, NULL);		// Create the clipper using the DirectDraw object
-		if (hr) return FALSE;
-		hr = g_pClipper->SetHWnd(0, CWState->WindowHandle);						// Assign your window's HWND to the clipper
-		if (hr) return FALSE;
-		hr = g_pDDS->SetClipper(g_pClipper);					// Attach the clipper to the primary surface
-		if (hr) return FALSE;
-		hr= g_pDDSBack->Lock( NULL, &ddsd, DDLOCK_WAIT, NULL );
-		if (hr) return FALSE;
-		hr = g_pDDSBack->Unlock( NULL );						// Unlock surface
-		if (hr) return FALSE;
-#endif // USE_DIRECTX
-		break;
-
-
-	case 1:	//Full Screen Mode
+	}
+	else	//Full Screen Mode
+	{
 		CaptureCurrentWindowRect();
 
-#if USE_OPENGL
 		MONITORINFO mi = { sizeof(mi) };
-		if (!GetMonitorInfo(hmon, &mi)) 
+		if (!GetMonitorInfo(hmon, &mi))
 			return NULL;
+
 		CWState->WindowHandle = CreateWindow(szWindowClass,
 			NULL,
 			WS_POPUP | WS_VISIBLE,
@@ -271,99 +220,48 @@ bool CreateDDWindow(SystemState *CWState)
 			mi.rcMonitor.right - mi.rcMonitor.left,
 			mi.rcMonitor.bottom - mi.rcMonitor.top,
 			NULL, NULL, g_hInstance, 0);
-
-		GetWindowRect(CWState->WindowHandle,&WindowDefaultSize);
-		ShowWindow(CWState->WindowHandle, g_nCmdShow);
-		UpdateWindow(CWState->WindowHandle);
-#endif // USE_OPENGL
-
-#if USE_DIRECTX
-		ddsd.lPitch=0;
-		ddsd.ddpfPixelFormat.dwRGBBitCount=0;
-		CWState->WindowHandle = CreateWindow(szWindowClass, NULL, WS_POPUP | WS_VISIBLE,0, 0, CWState->WindowSize.x, CWState->WindowSize.y, NULL, NULL, g_hInstance, NULL);
-		if (!CWState->WindowHandle )
-		   return FALSE;
-		GetWindowRect(CWState->WindowHandle,&WindowDefaultSize);
-		ShowWindow(CWState->WindowHandle, g_nCmdShow);
-		UpdateWindow(CWState->WindowHandle);
-		hr = DirectDrawCreate( NULL, &g_pDD, NULL );		// Initialize DirectDraw
-		if (hr) return FALSE;
-		hr = g_pDD->SetCooperativeLevel(CWState->WindowHandle, DDSCL_EXCLUSIVE|DDSCL_FULLSCREEN|DDSCL_NOWINDOWCHANGES);
-		if (hr) return FALSE;
-		hr = g_pDD->SetDisplayMode(CWState->WindowSize.x, CWState->WindowSize.y, 32);	// Set 640x480x32 Bit full-screen mode
-		if (hr) return FALSE;
-		ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
-		ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_COMPLEX | DDSCAPS_FLIP;
-		ddsd.dwBackBufferCount = 1;
-		hr = g_pDD->CreateSurface(&ddsd, &g_pDDS, NULL);
-		if (hr) return FALSE;
-		ddsd.ddsCaps.dwCaps = DDSCAPS_BACKBUFFER;
-		g_pDDS->GetAttachedSurface(&ddsd.ddsCaps, &g_pDDSBack);
-		hr= g_pDD->GetDisplayMode(&ddsd);
-		if (hr) return FALSE;
-//***********************************TEST*****************************************
-		for ( unsigned short i=0;i<=63;i++)
-		{
-			pal[i+128].peBlue= ColorValues[(i & 8 ) >>2 | (i & 1) ];
-			pal[i+128].peGreen=ColorValues[(i & 16) >>3 | (i & 2) >>1];
-			pal[i+128].peRed=  ColorValues[(i & 32) >>4 | (i & 4) >>2];
-			pal[i+128].peFlags = PC_RESERVED | PC_NOCOLLAPSE;
-		}
-		g_pDD->CreatePalette(DDPCAPS_8BIT | DDPCAPS_ALLOW256,pal,&ddpal,NULL);
-		g_pDDS->SetPalette(ddpal); // Set pallete for Primary surface
-//**********************************END TEST***************************************
-#endif // USE_DIRECTX
-		break;
 	}
+
+	ShowWindow(CWState->WindowHandle, g_nCmdShow);
+	UpdateWindow(CWState->WindowHandle);
 
 	HWND windowHandle = CWState->WindowHandle;
 	if (windowHandle)
 	{
-		if (!g_Display) g_Display = new Display(CWState);
+		if (!g_SystemState) g_SystemState = new SystemStatePtr(CWState);
+
 		::GetClientRect(windowHandle, &rStatBar);
 		int w = rStatBar.right - rStatBar.left;
 		int h = rStatBar.bottom - rStatBar.top - StatusBarHeight;
-		if (g_Display->Setup(CWState->WindowHandle, w, h, StatusBarHeight) != IDisplay::OK)
+
+		// attempt to use opengl
+		if (UseOpenGL && !InitGraphics<ClassOpenGL>(&g_OpenGLDisplay, CWState, w, h))
+			UseOpenGL = false;
+
+		// otherwise attempt to use directx
+		if (!UseOpenGL && !InitGraphics<ClassDirectX>(&g_DirectXDisplay, CWState, w, h))
 			return FALSE;
+
 		SetAspect(ForceAspect);
 	}
 
 	return TRUE;
 }
 
-
-
-/*--------------------------------------------------------------------------*/
-// Checks if the memory associated with surfaces is lost and restores if necessary.
-void CheckSurfaces()
-{
-	if (g_pDDS)		// Check the primary surface
-		if (g_pDDS->IsLost() == DDERR_SURFACELOST)
-			g_pDDS->Restore();
-
-	
-	if (g_pDDSBack)		// Check the back buffer
-		if (g_pDDSBack->IsLost() == DDERR_SURFACELOST)
-			g_pDDSBack->Restore();
-
-//	g_pDDS->SetPalette(ddpal);
-}
-/*--------------------------------------------------------------------------*/
-
 void DisplayFlip(SystemState *DFState)	// Double buffering flip
 {
-#if USE_OPENGL
 	if (g_Display)
 	{
 		g_Display->Render();
+#if USE_OPENGL
 		if (DFState->FullScreen && InfoBand)
 		{
 			if (LoadOpenGLFont())
 			{
 				OpenGL::Rect renderRect;
-				g_Display->GetRect(OpenGL::OPT_RECT_RENDER, &renderRect);
-				g_Display->RenderBox(0, 0, renderRect.w, 25, VCC::ColorBlack, true);
-				g_Display->RenderText(g_DisplayFont, 10, 18, 20, StatusText);
+				g_OpenGLDisplay->GetRect(OpenGL::OPT_RECT_RENDER, &renderRect);
+				g_OpenGLDisplay->RenderBox(0, 0, renderRect.w, 25, VCC::ColorBlack, true);
+				g_OpenGLDisplay->RenderText(g_DisplayFont, 10, 18, 20, StatusText);
 			}
 		}
 
@@ -374,107 +272,10 @@ void DisplayFlip(SystemState *DFState)	// Double buffering flip
 		DebugPrint(10, 515, 20, "Motor");
 		DebugPrint(10, 545, 20, "MUX");
 #endif // USE_DEBUG_AUDIOTAPE
+#endif // USE_OPENGL
 
 		g_Display->Present();
 	}
-#endif // USE_OPENGL
-
-#if USE_DIRECTX
-	using namespace std;
-	static HRESULT hr;
-	static RECT    rcSrc;  // source blit rectangle
-	static RECT    rcDest; // destination blit rectangle
-	static RECT	Temp;
-	static POINT   p;	
-
-	ForcedAspectBorderPadding = { 0,0 };
-
-	if (DFState->FullScreen)	// if we're windowed do the blit, else just Flip
-		hr = g_pDDS->Flip(NULL, DDFLIP_NOVSYNC | DDFLIP_DONOTWAIT); //DDFLIP_WAIT
-	else
-	{
-		p.x = 0; p.y = 0;
-		
-		// The ClientToScreen function converts the client-area coordinates of a specified point to screen coordinates.
-		// in other word the client rectangle of the main windows 0, 0 (upper-left corner) 
-		// in a screen x,y coords which is put back into p  
-		::ClientToScreen(DFState->WindowHandle, &p);  // find out where on the primary surface our window lives
-
-		// get the actual client rectangle, which is always 0,0 - w,h
-		::GetClientRect(DFState->WindowHandle, &rcDest);
-
-		// The OffsetRect function moves the specified rectangle by the specified offsets
-		// add the delta screen point we got above, which gives us the client rect in screen coordinates.
-		::OffsetRect(&rcDest, p.x, p.y);
-		
-		// our destination rectangle is going to be 
-		::SetRect(&rcSrc, 0, 0, DFState->WindowSize.x, DFState->WindowSize.y);
-		
-		if (Resizeable)
-		{
-			rcDest.bottom -= StatusBarHeight;
-
-			if (ForceAspect) // Adjust the Aspect Ratio if window is resized
-			{
-				float srcWidth = (float)DFState->WindowSize.x;
-				float srcHeight = (float)DFState->WindowSize.y;
-				float srcRatio = srcWidth / srcHeight;
-
-				// change this to use the existing rcDest and the calc, w = right-left & h = bottom-top, 
-				//                         because rcDest has already been converted to screen cords, right?   
-				static RECT rcClient;
-				::GetClientRect(DFState->WindowHandle, &rcClient);  // x,y is always 0,0 so right, bottom is w,h
-				rcClient.bottom -= StatusBarHeight;
-				
-				float clientWidth = (float)rcClient.right;
-				float clientHeight = (float)rcClient.bottom;
-				float clientRatio = clientWidth / clientHeight;
-
-				float dstWidth = 0, dstHeight = 0;
-
-				if (clientRatio > srcRatio)
-				{
-					dstWidth = srcWidth * clientHeight / srcHeight;
-					dstHeight = clientHeight;
-				}
-				else
-				{
-					dstWidth = clientWidth;
-					dstHeight = srcHeight * clientWidth / srcWidth;
-				}
-
-				float dstX = (clientWidth - dstWidth) / 2; 
-				float dstY = (clientHeight - dstHeight) / 2;
-
-				static POINT pDstLeftTop;
-				pDstLeftTop.x = (long)dstX; pDstLeftTop.y = (long)dstY;
-				ForcedAspectBorderPadding = pDstLeftTop;
-
-				::ClientToScreen(DFState->WindowHandle, &pDstLeftTop);
-
-				static POINT pDstRightBottom;
-				pDstRightBottom.x = (long)(dstX + dstWidth); pDstRightBottom.y = (long)(dstY + dstHeight);
-				::ClientToScreen(DFState->WindowHandle, &pDstRightBottom);
-
-				::SetRect(&rcDest, pDstLeftTop.x, pDstLeftTop.y, pDstRightBottom.x, pDstRightBottom.y);
-			}
-		}
-		else
-		{
-			// this does not seem ideal, it lets you begin to resize and immediately resizes it back ... causing a lot of flicker.
-			rcDest.right = rcDest.left + DFState->WindowSize.x;
-			rcDest.bottom = rcDest.top + DFState->WindowSize.y;
-			::GetWindowRect(DFState->WindowHandle, &Temp);
-			::MoveWindow(DFState->WindowHandle, Temp.left, Temp.top, WindowDefaultSize.right - WindowDefaultSize.left, WindowDefaultSize.bottom-WindowDefaultSize.top, 1);
-		}
-		
-		if (g_pDDSBack == NULL)
-			MessageBox(0, "Odd", "Error", 0); // yes, odd error indeed!! (??)
-		                                      // especially since we go ahead and use it below!
-	
-		hr = g_pDDS->Blt(&rcDest, g_pDDSBack, &rcSrc, DDBLT_WAIT , NULL); // DDBLT_WAIT
-	}
-#endif // USE_DIRECTX
 
 	static RECT CurWindow;
 	::GetWindowRect(DFState->WindowHandle, &CurWindow);
@@ -500,87 +301,22 @@ void DisplayFlip(SystemState *DFState)	// Double buffering flip
 
 unsigned char LockScreen(SystemState *LSState)
 {
-#if USE_DIRECTX
-	HRESULT	hr;
-	DDSURFACEDESC ddsd;				// A structure to describe the surfaces we want
-	memset(&ddsd, 0, sizeof(ddsd));	// Clear all members of the structure to 0
-	ddsd.dwSize = sizeof(ddsd);		// The first parameter of the structure must contain the size of the structure
-	CheckSurfaces();
-	
-	// Lock entire surface, wait if it is busy, return surface memory pointer
-	hr = g_pDDSBack->Lock( NULL, &ddsd, DDLOCK_WAIT | DDLOCK_SURFACEMEMORYPTR, NULL );
-	if (hr)
-	{
-//		MessageBox(0,"Can't Lock surface","Error",0);
-		return(1);
-	}
-	switch (ddsd.ddpfPixelFormat.dwRGBBitCount)
-	{
-		case 8:
-			LSState->SurfacePitch=ddsd.lPitch;
-			LSState->BitDepth=0;
-		break;
-		case 15:
-		case 16:
-			LSState->SurfacePitch=ddsd.lPitch/2;
-			LSState->BitDepth=1;
-		break;
-		case 24:
-			MessageBox(0,"24 Bit color is currently unsupported","Ok",0);
-			exit(0);
-			LSState->SurfacePitch=ddsd.lPitch;
-			LSState->BitDepth=2;
-		break;
-		case 32:
-			LSState->SurfacePitch=ddsd.lPitch/4;
-			LSState->BitDepth=3;
-		break;
-		default:
-			MessageBox(0,"Unsupported Color Depth!","Error",0);
-			return 1;
-		break;
-	}
-	if (ddsd.lpSurface==NULL)
-		MessageBox(0,"Returning NULL!!","ok",0);
-	LSState->PTRsurface8=(unsigned char *)ddsd.lpSurface;
-	LSState->PTRsurface16=(unsigned short *)ddsd.lpSurface;
-	LSState->PTRsurface32=(unsigned int *)ddsd.lpSurface;
-#endif // USE_DIRECTX
+	if (!g_Display) 
+		return 0;
 
-#if USE_OPENGL
-	Pixel* pixels;
-	if (g_Display->GetSurface(&pixels) == OpenGL::OK)
-	{
-		LSState->PTRsurface8 = (unsigned char*)pixels;
-		LSState->PTRsurface16 = (unsigned short*)pixels;
-		LSState->PTRsurface32 = (unsigned int*)pixels;
-		LSState->SurfacePitch = DefaultWidth;
-		LSState->BitDepth = 3;
-	}
-#endif // USE_OPENGL
+	if (g_Display->LockSurface() != IDisplay::OK)
+		return 1;
+
 	return(0);
 }
 
 void UnlockScreen(SystemState *USState)
 {
-#if USE_DIRECTX
-	static HRESULT hr;
-	static size_t Index=0;
-	static HDC hdc;
-	if (USState->FullScreen  & InfoBand) //Put StatusText for full screen here
-	{
-		g_pDDSBack->GetDC(&hdc);
-		SetBkColor( hdc, RGB( 0, 0, 0 ) );
-		SetTextColor(hdc, RGB(255,255,255));
-		Index=strlen(StatusText);
-		for (;Index<132;Index++)
-			StatusText[Index]=32;
-		StatusText[Index]=0;
-		TextOut(hdc, 0, 0, StatusText, 132); 
-		g_pDDSBack->ReleaseDC(hdc);  
-	}
-	hr = g_pDDSBack->Unlock( NULL );
-#endif // USE_DIRECTX
+	if (g_DirectXDisplay && InfoBand)
+		g_DirectXDisplay->RenderStatusLine(StatusText);
+
+	if (g_Display->UnlockSurface() != IDisplay::OK)
+		return;
 
 	DisplayFlip(USState);
 	return;
@@ -654,8 +390,12 @@ unsigned char SetInfoBand( unsigned char Tmp)
 
 unsigned char SetResize(unsigned char Tmp)
 {
-	if (Tmp!=QUERY)
-		Resizeable=Tmp;
+	if (Tmp != QUERY)
+	{
+		Resizeable = Tmp;
+		if (g_Display)
+			g_Display->SetOption(IDisplay::OPT_FLAG_RESIZEABLE, Resizeable);
+	}
 	return(Resizeable);
 }
 
@@ -664,17 +404,15 @@ unsigned char SetAspect (unsigned char Tmp)
 	if (Tmp != QUERY)
 	{
 		ForceAspect = Tmp;
-#if USE_OPENGL
 		if (g_Display)
-			g_Display->SetOption(OpenGL::OPT_FLAG_ASPECT, ForceAspect);
-#endif // USE_OPENGL
+			g_Display->SetOption(IDisplay::OPT_FLAG_ASPECT, ForceAspect);
 	}
 	return(ForceAspect);
 }
 
-#if USE_OPENGL
 void DisplaySignalLostMessage()
 {
+#if USE_OPENGL
 	if (LoadOpenGLFont())
 	{
 		const float fontSize = 20;
@@ -683,14 +421,14 @@ void DisplaySignalLostMessage()
 		const float baseLine = fontSize - 4;
 
 		OpenGL::Rect renderRect;
-		g_Display->GetRect(OpenGL::OPT_RECT_RENDER, &renderRect);
+		g_OpenGLDisplay->GetRect(OpenGL::OPT_RECT_RENDER, &renderRect);
 		float x = (renderRect.w - messageWidth) / 2;
 		float y = (renderRect.h - fontSize) / 2;
-		g_Display->RenderBox(x, y, messageWidth, fontSize, VCC::ColorBlack, true);
-		g_Display->RenderText(g_DisplayFont, x, y + baseLine, fontSize, message);
+		g_OpenGLDisplay->RenderBox(x, y, messageWidth, fontSize, VCC::ColorBlack, true);
+		g_OpenGLDisplay->RenderText(g_DisplayFont, x, y + baseLine, fontSize, message);
 	}
-}
 #endif // USE_OPENGL
+}
 
 float Static(SystemState *STState)
 {
@@ -698,19 +436,19 @@ float Static(SystemState *STState)
 	static unsigned short y=0;
 //	unsigned char Depth=0;
 	unsigned char Temp=0;
-	static unsigned short TextX=0,TextY=0;
-	static unsigned char Counter,Counter1=32;
-	static char Phase=1;
-	static char Message[]=" Signal Missing! Press F9";
-	static unsigned char GreyScales[4]={128,135,184,191};
-	LockScreen(STState);
-	if (STState->PTRsurface32==NULL)
-		return(0);
-//	y=(y+1) % 480;
+	static unsigned char GreyScales[4] = { 128,135,184,191 };
+
+	if (g_Display == nullptr)
+		return 0;
+
+	if (g_Display->LockSurface() != IDisplay::OK)
+		return 0;
+
+	//	y=(y+1) % 480;
+	
 	switch (STState->BitDepth)
 	{
 	case 0:
-		
 		for (y=0;y<480;y+=2)
 			for (x=0;x<160;x++)
 			{
@@ -718,7 +456,7 @@ float Static(SystemState *STState)
 				STState->PTRsurface32[x + (y*STState->SurfacePitch>>2) ]= GreyScales[Temp]|(GreyScales[Temp]<<8)|(GreyScales[Temp]<<16) | (GreyScales[Temp]<<24);
 				STState->PTRsurface32[x + ((y+1)*STState->SurfacePitch>>2) ]= GreyScales[Temp]|(GreyScales[Temp]<<8)|(GreyScales[Temp]<<16) | (GreyScales[Temp]<<24);
 			}
-			break;
+	break;
 	case 1:
 		for (y=0;y<480;y+=2)
 			for (x=0;x<320;x++)
@@ -749,39 +487,18 @@ float Static(SystemState *STState)
 		return(0);
 	}
 
-#if USE_OPENGL
-	if (g_Display)
-	{
-		g_Display->Render();
-		DisplaySignalLostMessage();
-		g_Display->Present();
-	}
-	return(CalculateFPS());
-#endif // USE_OPENGL
+	// need to do during lock
+	if (g_DirectXDisplay)
+		g_DirectXDisplay->RenderSignalLostMessage();
 
-#if USE_DIRECTX
-	if (g_pDDSBack)
-	{
-		HDC hdc;
-		g_pDDSBack->GetDC(&hdc);
-		SetBkColor(hdc, 0);
-		SetTextColor(hdc, RGB(Counter1 << 2, Counter1 << 2, Counter1 << 2));
-		TextOut(hdc, TextX, TextY, Message, strlen(Message));
-		Counter++;
-		Counter1 += Phase;
-		if ((Counter1 == 60) | (Counter1 == 20))
-			Phase = -Phase;
-		Counter %= 60; //about 1 seconds
-		if (!Counter)
-		{
-			TextX = rand() % 580;
-			TextY = rand() % 470;
-		}
-		g_pDDSBack->ReleaseDC(hdc);
-	}
-	UnlockScreen(STState);
-	return(CalculateFPS());
-#endif // USE_DIRECTX
+	if (g_Display->UnlockSurface() != IDisplay::OK)
+		return 0;
+
+	g_Display->Render();
+	DisplaySignalLostMessage();
+	g_Display->Present();
+
+	return CalculateFPS();
 }
 
 const Rect& GetCurWindowSize() 
@@ -797,15 +514,13 @@ int GetRenderWindowStatusBarHeight()
 
 POINT GetForcedAspectBorderPadding()
 {
-#if USE_OPENGL
 	if (g_Display)
 	{
-		OpenGL::Rect area;
-		g_Display->GetRect(OpenGL::OPT_RECT_DISPLAY, &area);
+		IDisplay::Rect area;
+		g_Display->GetRect(IDisplay::OPT_RECT_DISPLAY, &area);
 		return { (long)area.x, (long)area.y };
 	}
-#endif // USE_OPENGL
-	return ForcedAspectBorderPadding;
+	return { 0,0 };
 }
 
 void CloseScreen()
@@ -813,10 +528,15 @@ void CloseScreen()
 	if (g_Display)
 	{
 		g_Display->Cleanup();
+		delete g_Display;
+		delete g_SystemState;
 		g_Display = nullptr;
-#if USE_OPENGL
-		g_DisplayFont = nullptr;
-#endif // USE_OPENGL
+		g_SystemState = nullptr;
+
+		// alias
+		g_DirectXDisplay = nullptr;
+		g_OpenGLDisplay = nullptr;
+		g_DisplayFont = nullptr; 
 	}
 }
 
@@ -834,10 +554,8 @@ void DebugDrawBox(float x, float y, float w, float h, Pixel color)
 
 void DebugPrint(float x, float y, float size, const char* str)
 {
-#if USE_OPENGL && USE_DEBUG_LINES
-	if (g_Display && LoadOpenGLFont())
-		g_Display->RenderText(g_DisplayFont, x, y, size, str);
-#endif
+	if (g_OpenGLDisplay && LoadOpenGLFont())
+		g_OpenGLDisplay->RenderText(g_DisplayFont, x, y, size, str);
 }
 
 void DumpScreenshot()

--- a/DirectX.cpp
+++ b/DirectX.cpp
@@ -1,80 +1,489 @@
+//  Copyright 2015 by Joseph Forgion
+//  This file is part of VCC (Virtual Color Computer).
+//
+//  VCC (Virtual Color Computer) is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  VCC (Virtual Color Computer) is distributed in the hope that it will be
+//  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along
+//  with VCC. If not, see <http://www.gnu.org/licenses/>.
+//
+//  2025/04/10 - Craig Allsop - Add OpenGL rendering.
+//
+
 #include "DirectX.h"
 
 #if USE_DIRECTX
 
 #include "DirectDrawInterface.h"
+#include "ddraw.h"
 
-using namespace VCC;
-
-DirectX::DirectX(SystemState* state) : state(state)
+namespace VCC
 {
-}
-
-int DirectX::Setup(void* hwnd, int width, int height, int statusHeight)
-{
-    return OK;
-}
-
-int DirectX::Render()
-{
-    return OK;
-}
-
-int DirectX::Present()
-{
-    return OK;
-}
-
-int DirectX::Cleanup()
-{
-    return OK;
-}
-
-int DirectX::SetOption(int flagOption, bool enabled)
-{
-    return ERR_UNSUPPORTED;
-}
-
-int DirectX::GetSurface(Pixel** pixels)
-{
-    if (state->BitDepth == 3)
+    //
+    // Private wrapper on result code for logging errors
+    //
+    static int Result(int code)
     {
-        *pixels = (Pixel*)(state->PTRsurface32);
-        return OK;
+        if (code != IDisplay::OK)
+        {
+            char message[256];
+            snprintf(message, 64, "DirectX error %d\nCheck DirectX support", code);
+            MessageBox(0, message, "Error", 0);
+            //PrintLogC("OpenGL Error: %d\n", code);
+        }
+        return code;
     }
-    return ERR_UNSUPPORTED;
-}
 
-int DirectX::GetRect(int rectOption, Rect* rect)
-{
-    switch (rectOption)
+    namespace Detail
     {
-        //case OPT_RECT_DISPLAY: GetDisplayArea(rect); break;
-        //case OPT_RECT_RENDER: GetRenderArea(rect); break;
-        case OPT_RECT_SURFACE: GetSurfaceArea(rect); break;
-        default: return ERR_BADOPTION;
+        //Global Variables for Direct Draw funcions
+        LPDIRECTDRAW        g_pDD;       // The DirectDraw object
+        LPDIRECTDRAWCLIPPER g_pClipper;  // Clipper for primary surface
+        LPDIRECTDRAWSURFACE g_pDDS;      // Primary surface
+        LPDIRECTDRAWSURFACE g_pDDSBack;  // Back surface
+        IDirectDrawPalette* ddpal;       // Needed for 8bit Palette mode
+        bool isInitialized;
+        bool isFullscreen;
+        bool forceAspect;
+        bool resizeable;
+        int statusBarHeight;
+        RECT WindowDefaultSize;
+        POINT ForcedAspectBorderPadding;
+
+        // surface while locked
+        void* surface;
+        int bitDepth;
+        long surfacePitch;
     }
-    return OK;
-}
 
-int DirectX::LockSurface()
-{
-    if (LockScreen(state) == 0) return OK;
-    return ERR_UNSUPPORTED;
-}
+    DirectX::DirectX(ISystemState* state) : state(state)
+    {
+        using namespace Detail;
+        isInitialized = false;
+        isFullscreen = false;
+        forceAspect = false;
+        statusBarHeight = 0;
+        resizeable = true;
+        WindowDefaultSize = {};
+        ForcedAspectBorderPadding = {};
+        g_pDDSBack = nullptr;
+        g_pDDS = nullptr;
+        g_pClipper = nullptr;
+        g_pDD = nullptr;
+        ddpal = nullptr;
+        surface = nullptr;
+        bitDepth = 0;
+        surfacePitch = 0;
+    }
 
-int DirectX::UnlockSurface()
-{
-    UnlockScreen(state);
-    return OK;
-}
+    int DirectX::Setup(void* hwnd, int width, int height, int statusHeight, bool fullscreen)
+    {
+        using namespace Detail;
 
-void DirectX::GetSurfaceArea(Rect* rect)
-{
-    rect->x = 0;
-    rect->y = 0;
-    rect->w = 640;
-    rect->h = 480;
+        isFullscreen = fullscreen;
+        statusBarHeight = statusHeight;
+
+        GetWindowRect((HWND)hwnd, &WindowDefaultSize);
+
+        HRESULT hr;
+        PALETTEENTRY pal[256];
+        DDSURFACEDESC ddsd;				// A structure to describe the surfaces we want
+        unsigned char ColorValues[4] = { 0,85,170,255 };
+
+        memset(&ddsd, 0, sizeof(ddsd));	// Clear all members of the structure to 0
+        ddsd.dwSize = sizeof(ddsd);		// The first parameter of the structure must contain the size of the structure
+
+        // Create an instance of a DirectDraw object
+        hr = ::DirectDrawCreate(NULL, &g_pDD, NULL);
+        if (hr) return Result(ERR_UNKNOWN);
+
+        VCC::Rect windowRect = { 0, 0, 640, 480 };
+
+        if (fullscreen)
+        {
+            ddsd.lPitch = 0;
+            ddsd.ddpfPixelFormat.dwRGBBitCount = 0;
+            hr = DirectDrawCreate(NULL, &g_pDD, NULL);		// Initialize DirectDraw
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pDD->SetCooperativeLevel((HWND)hwnd, DDSCL_EXCLUSIVE | DDSCL_FULLSCREEN | DDSCL_NOWINDOWCHANGES);
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pDD->SetDisplayMode(windowRect.w, windowRect.h, 32);	// Set 640x480x32 Bit full-screen mode
+            if (hr) return Result(ERR_UNKNOWN);
+            ddsd.dwFlags = DDSD_CAPS | DDSD_BACKBUFFERCOUNT;
+            ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE | DDSCAPS_COMPLEX | DDSCAPS_FLIP;
+            ddsd.dwBackBufferCount = 1;
+            hr = g_pDD->CreateSurface(&ddsd, &g_pDDS, NULL);
+            if (hr) return Result(ERR_UNKNOWN);
+            ddsd.ddsCaps.dwCaps = DDSCAPS_BACKBUFFER;
+            g_pDDS->GetAttachedSurface(&ddsd.ddsCaps, &g_pDDSBack);
+            hr = g_pDD->GetDisplayMode(&ddsd);
+            if (hr) return Result(ERR_UNKNOWN);
+            //***********************************TEST*****************************************
+            for (unsigned short i = 0;i <= 63;i++)
+            {
+                pal[i + 128].peBlue = ColorValues[(i & 8) >> 2 | (i & 1)];
+                pal[i + 128].peGreen = ColorValues[(i & 16) >> 3 | (i & 2) >> 1];
+                pal[i + 128].peRed = ColorValues[(i & 32) >> 4 | (i & 4) >> 2];
+                pal[i + 128].peFlags = PC_RESERVED | PC_NOCOLLAPSE;
+            }
+            g_pDD->CreatePalette(DDPCAPS_8BIT | DDPCAPS_ALLOW256, pal, &ddpal, NULL);
+            g_pDDS->SetPalette(ddpal); // Set pallete for Primary surface
+            //**********************************END TEST***************************************
+        }
+        else
+        {
+            // Initialize the DirectDraw object
+            hr = g_pDD->SetCooperativeLevel((HWND)hwnd, DDSCL_NORMAL);	// Set DDSCL_NORMAL to use windowed mode
+            if (hr) return Result(ERR_UNKNOWN);
+
+            ddsd.dwFlags = DDSD_CAPS;
+            ddsd.ddsCaps.dwCaps = DDSCAPS_PRIMARYSURFACE;
+
+            // Create our Primary Surface
+            hr = g_pDD->CreateSurface(&ddsd, &g_pDDS, NULL);
+            if (hr) return Result(ERR_UNKNOWN);
+            ddsd.dwFlags = DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS;
+            ddsd.dwWidth = windowRect.w;								// Make our off-screen surface 
+            ddsd.dwHeight = windowRect.h;
+            ddsd.ddsCaps.dwCaps = DDSCAPS_VIDEOMEMORY;				// Try to create back buffer in video RAM
+            hr = g_pDD->CreateSurface(&ddsd, &g_pDDSBack, NULL);
+            if (hr)													// If not enough Video Ram 			
+            {
+                ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY;			// Try to create back buffer in System RAM
+                hr = g_pDD->CreateSurface(&ddsd, &g_pDDSBack, NULL);
+                if (hr)	return Result(ERR_UNKNOWN);								//Giving Up
+                MessageBox(0, "Creating Back Buffer in System Ram\n", "Performance Warning", 0);
+            }
+
+            hr = g_pDD->GetDisplayMode(&ddsd);
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pDD->CreateClipper(0, &g_pClipper, NULL);		// Create the clipper using the DirectDraw object
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pClipper->SetHWnd(0, (HWND)hwnd);						// Assign your window's HWND to the clipper
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pDDS->SetClipper(g_pClipper);					// Attach the clipper to the primary surface
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pDDSBack->Lock(NULL, &ddsd, DDLOCK_WAIT, NULL);
+            if (hr) return Result(ERR_UNKNOWN);
+            hr = g_pDDSBack->Unlock(NULL);						// Unlock surface
+            if (hr) return Result(ERR_UNKNOWN);
+        }
+
+        return Result(OK);
+    }
+
+    int DirectX::Render()
+    {
+        using namespace std;
+        using namespace Detail;
+
+        static HRESULT hr;
+        static RECT    rcSrc;  // source blit rectangle
+        static RECT    rcDest; // destination blit rectangle
+        static RECT	Temp;
+        static POINT   p;
+
+        HWND hwnd;
+        if (state->GetWindowHandle((void**)&hwnd) != OK)
+            return Result(ERR_UNKNOWN);
+
+        VCC::Rect windowRect;
+        if (state->GetRect(1, &windowRect) != OK)
+            return Result(ERR_UNKNOWN);
+
+        ForcedAspectBorderPadding = { 0,0 };
+
+        if (isFullscreen)	// if we're windowed do the blit, else just Flip
+            hr = g_pDDS->Flip(NULL, DDFLIP_NOVSYNC | DDFLIP_DONOTWAIT); //DDFLIP_WAIT
+        else
+        {
+            p.x = 0; p.y = 0;
+
+            // The ClientToScreen function converts the client-area coordinates of a specified point to screen coordinates.
+            // in other word the client rectangle of the main windows 0, 0 (upper-left corner) 
+            // in a screen x,y coords which is put back into p  
+            ::ClientToScreen(hwnd, &p);  // find out where on the primary surface our window lives
+
+            // get the actual client rectangle, which is always 0,0 - w,h
+            ::GetClientRect(hwnd, &rcDest);
+
+            // The OffsetRect function moves the specified rectangle by the specified offsets
+            // add the delta screen point we got above, which gives us the client rect in screen coordinates.
+            ::OffsetRect(&rcDest, p.x, p.y);
+
+            // our destination rectangle is going to be 
+            ::SetRect(&rcSrc, 0, 0, windowRect.w, windowRect.h);
+
+            if (resizeable)
+            {
+                rcDest.bottom -= statusBarHeight;
+
+                if (forceAspect) // Adjust the Aspect Ratio if window is resized
+                {
+                    float srcWidth = (float)windowRect.w;
+                    float srcHeight = (float)windowRect.h;
+                    float srcRatio = srcWidth / srcHeight;
+
+                    // change this to use the existing rcDest and the calc, w = right-left & h = bottom-top, 
+                    //                         because rcDest has already been converted to screen cords, right?   
+                    static RECT rcClient;
+                    ::GetClientRect(hwnd, &rcClient);  // x,y is always 0,0 so right, bottom is w,h
+                    rcClient.bottom -= statusBarHeight;
+
+                    float clientWidth = (float)rcClient.right;
+                    float clientHeight = (float)rcClient.bottom;
+                    float clientRatio = clientWidth / clientHeight;
+
+                    float dstWidth = 0, dstHeight = 0;
+
+                    if (clientRatio > srcRatio)
+                    {
+                        dstWidth = srcWidth * clientHeight / srcHeight;
+                        dstHeight = clientHeight;
+                    }
+                    else
+                    {
+                        dstWidth = clientWidth;
+                        dstHeight = srcHeight * clientWidth / srcWidth;
+                    }
+
+                    float dstX = (clientWidth - dstWidth) / 2;
+                    float dstY = (clientHeight - dstHeight) / 2;
+
+                    static POINT pDstLeftTop;
+                    pDstLeftTop.x = (long)dstX; pDstLeftTop.y = (long)dstY;
+                    ForcedAspectBorderPadding = pDstLeftTop;
+
+                    ::ClientToScreen(hwnd, &pDstLeftTop);
+
+                    static POINT pDstRightBottom;
+                    pDstRightBottom.x = (long)(dstX + dstWidth); pDstRightBottom.y = (long)(dstY + dstHeight);
+                    ::ClientToScreen(hwnd, &pDstRightBottom);
+
+                    ::SetRect(&rcDest, pDstLeftTop.x, pDstLeftTop.y, pDstRightBottom.x, pDstRightBottom.y);
+                }
+            }
+            else
+            {
+                // this does not seem ideal, it lets you begin to resize and immediately resizes it back ... causing a lot of flicker.
+                rcDest.right = rcDest.left + windowRect.w;
+                rcDest.bottom = rcDest.top + windowRect.h;
+                ::GetWindowRect(hwnd, &Temp);
+                ::MoveWindow(hwnd, Temp.left, Temp.top, WindowDefaultSize.right - WindowDefaultSize.left, WindowDefaultSize.bottom - WindowDefaultSize.top, 1);
+            }
+
+            if (g_pDDSBack == NULL)
+                return Result(ERR_UNKNOWN);
+
+            hr = g_pDDS->Blt(&rcDest, g_pDDSBack, &rcSrc, DDBLT_WAIT, NULL); // DDBLT_WAIT
+            if (hr) return Result(ERR_UNKNOWN);
+        }
+
+        return Result(OK);
+    }
+
+    int DirectX::Present()
+    {
+        return Result(OK);
+    }
+
+    int DirectX::Cleanup()
+    {
+        using namespace Detail;
+        if (g_pDD != NULL)
+            g_pDD->Release();	//Destroy the current Window
+
+        return Result(OK);
+    }
+
+    int DirectX::SetOption(int flagOption, bool enabled)
+    {
+        using namespace Detail;
+        //if (!isInitialized) return Result(ERR_NOTINITIALIZED);
+        switch (flagOption)
+        {
+            case OPT_FLAG_ASPECT: forceAspect = enabled; break;
+            case OPT_FLAG_RESIZEABLE: resizeable = enabled; break;
+            default: return Result(ERR_BADOPTION);
+        }
+        return Result(OK);
+    }
+
+    int DirectX::GetSurface(Pixel** pixels)
+    {
+        using namespace Detail;
+        if (!surface) return Result(ERR_UNKNOWN);
+        if (bitDepth == 3)
+        {
+            *pixels = (Pixel*)surface;
+            return Result(OK);
+        }
+        return Result(ERR_UNSUPPORTED);
+    }
+
+    int DirectX::GetRect(int rectOption, Rect* rect)
+    {
+        switch (rectOption)
+        {
+            case OPT_RECT_DISPLAY: GetDisplayArea(rect); break;
+            //case OPT_RECT_RENDER: GetRenderArea(rect); break;
+            case OPT_RECT_SURFACE: GetSurfaceArea(rect); break;
+            default: return Result(ERR_BADOPTION);
+        }
+        return Result(OK);
+    }
+
+    int DirectX::LockSurface()
+    {
+        using namespace Detail;
+
+        CheckSurfaces();
+
+        HRESULT	hr;
+        DDSURFACEDESC ddsd;				// A structure to describe the surfaces we want
+        memset(&ddsd, 0, sizeof(ddsd));	// Clear all members of the structure to 0
+        ddsd.dwSize = sizeof(ddsd);		// The first parameter of the structure must contain the size of the structure
+
+        // Lock entire surface, wait if it is busy, return surface memory pointer
+        hr = g_pDDSBack->Lock(NULL, &ddsd, DDLOCK_WAIT | DDLOCK_SURFACEMEMORYPTR, NULL);
+        if (hr)
+        {
+            //		MessageBox(0,"Can't Lock surface","Error",0);
+            return Result(ERR_UNKNOWN);
+        }
+
+        switch (ddsd.ddpfPixelFormat.dwRGBBitCount)
+        {
+            case 8:
+                surfacePitch = ddsd.lPitch;
+                bitDepth = 0;
+                break;
+            case 15:
+            case 16:
+                surfacePitch = ddsd.lPitch / 2;
+                bitDepth = 1;
+                break;
+            case 24:
+                MessageBox(0, "24 Bit color is currently unsupported", "Ok", 0);
+                exit(0);
+                surfacePitch = ddsd.lPitch;
+                bitDepth = 2;
+                break;
+            case 32:
+                surfacePitch = ddsd.lPitch / 4;
+                bitDepth = 3;
+                break;
+            default:
+                MessageBox(0, "Unsupported Color Depth!", "Error", 0);
+                return 1;
+                break;
+        }
+        if (ddsd.lpSurface == NULL)
+            MessageBox(0, "Returning NULL!!", "ok", 0);
+
+        surface = ddsd.lpSurface;
+        state->SetSurface(surface, bitDepth, surfacePitch);
+
+        return Result(OK);
+    }
+
+    int DirectX::UnlockSurface()
+    {
+        using namespace Detail;
+
+        HRESULT hr;
+        hr = g_pDDSBack->Unlock(NULL);
+        surface = nullptr;
+        if (hr) return Result(ERR_UNKNOWN);
+
+        return Result(OK);
+    }
+
+    void DirectX::GetSurfaceArea(Rect* rect)
+    {
+        rect->x = 0;
+        rect->y = 0;
+        rect->w = 640;
+        rect->h = 480;
+    }
+
+    void DirectX::GetDisplayArea(Rect* rect)
+    {
+        using namespace Detail;
+        rect->x = (float)ForcedAspectBorderPadding.x;
+        rect->y = (float)ForcedAspectBorderPadding.y;
+        rect->w = 640;
+        rect->h = 480;
+    }
+
+    void DirectX::CheckSurfaces()
+    {
+        using namespace Detail;
+
+        if (g_pDDS)		// Check the primary surface
+            if (g_pDDS->IsLost() == DDERR_SURFACELOST)
+                g_pDDS->Restore();
+
+        if (g_pDDSBack)		// Check the back buffer
+            if (g_pDDSBack->IsLost() == DDERR_SURFACELOST)
+                g_pDDSBack->Restore();
+
+    }
+
+    int DirectX::RenderSignalLostMessage()
+    {
+        using namespace Detail;
+        static unsigned short TextX = rand() % 580, TextY = rand() % 470;
+        static unsigned char Counter, Counter1 = 32;
+        static char Phase = 1;
+        static char Message[] = " Signal Missing! Press F9";
+
+        HDC hdc;
+        g_pDDSBack->GetDC(&hdc);
+        SetBkColor(hdc, 0);
+        SetTextColor(hdc, RGB(Counter1 << 2, Counter1 << 2, Counter1 << 2));
+        TextOut(hdc, TextX, TextY, Message, strlen(Message));
+        Counter++;
+        Counter1 += Phase;
+        if (Counter1 == 60 || Counter1 == 20)
+            Phase = -Phase;
+        Counter %= 60; //about 1 seconds
+        if (!Counter)
+        {
+            TextX = rand() % 580;
+            TextY = rand() % 470;
+        }
+        g_pDDSBack->ReleaseDC(hdc);
+        return Result(OK);
+    }
+
+    int DirectX::RenderStatusLine(char * statusText)
+    {
+        using namespace Detail;
+        size_t Index = 0;
+        HDC hdc;
+        //Put StatusText for full screen here
+        if (isFullscreen)
+        {
+            g_pDDSBack->GetDC(&hdc);
+            SetBkColor(hdc, RGB(0, 0, 0));
+            SetTextColor(hdc, RGB(255, 255, 255));
+            Index = strlen(statusText);
+            for (;Index < 132;Index++)
+                statusText[Index] = 32;
+            statusText[Index] = 0;
+            TextOut(hdc, 0, 0, statusText, 132);
+            g_pDDSBack->ReleaseDC(hdc);
+        }
+        return Result(OK);
+    }
 }
 
 #endif // USE_DIRECTX

--- a/DirectX.h
+++ b/DirectX.h
@@ -26,16 +26,17 @@
 
 namespace VCC
 {
-    struct DirectX : public IDisplay
+    struct DirectX : public IDisplayDirectX
     {
         enum
         {
             ERR_UNSUPPORTED = 100,          // unsupported command
             ERR_BADOPTION,                  // invalid option being set
+            ERR_UNKNOWN
         };
 
-        DirectX(SystemState* state);
-        int Setup(void* hwnd, int width, int height, int statusHeight) override;
+        DirectX(ISystemState* state);
+        int Setup(void* hwnd, int width, int height, int statusHeight, bool fullscreen) override;
         int Render() override;
         int Present() override;
         int Cleanup() override;
@@ -46,12 +47,16 @@ namespace VCC
         int UnlockSurface() override;
         void DebugDrawLine(float x1, float y1, float x2, float y2, Pixel color) {};
         void DebugDrawBox(float x, float y, float w, float h, Pixel color) {};
+        int RenderSignalLostMessage() override;
+        int RenderStatusLine(char* statusText) override;
 
     private:
 
-        SystemState* state;
+        ISystemState* state;
 
+        void GetDisplayArea(Rect* rect);
         void GetSurfaceArea(Rect* rect);
+        void CheckSurfaces();
     };
 }
 

--- a/DisplayNull.h
+++ b/DisplayNull.h
@@ -1,0 +1,47 @@
+#pragma once
+
+//  Copyright 2015 by Joseph Forgion
+//  This file is part of VCC (Virtual Color Computer).
+//
+//  VCC (Virtual Color Computer) is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  VCC (Virtual Color Computer) is distributed in the hope that it will be
+//  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along
+//  with VCC. If not, see <http://www.gnu.org/licenses/>.
+//
+//  2025/04/10 - Craig Allsop - Add OpenGL rendering.
+//
+
+#include "defines.h"
+#include "IDisplay.h"
+
+namespace VCC
+{
+	struct DisplayNull : IDisplayDirectX, IDisplayOpenGL
+	{
+		DisplayNull(ISystemState*) {}
+		int Setup(void* hwnd, int width, int height, int statusHeight, bool fullscreen) override { return !OK; }
+		int Render() override { return OK; }
+		int Present() override { return OK; }
+		int Cleanup() override { return OK; }
+		int SetOption(int flagOption, bool enabled) override { return OK; }
+		int GetSurface(Pixel** pixels) override { return OK; }
+		int GetRect(int rectOption, Rect* rect) override { return OK; }
+		int LockSurface() override { return OK; }
+		int UnlockSurface() override { return OK; }
+		void DebugDrawLine(float x1, float y1, float x2, float y2, Pixel color) {}
+		void DebugDrawBox(float x, float y, float w, float h, Pixel color) {}
+		int RenderSignalLostMessage() override { return OK; }
+		int RenderBox(float x, float y, float w, float h, Pixel color, bool filled) override { return OK; }
+		int RenderText(const OpenGLFont* font, float x, float y, float size, const char* text) override { return OK; }
+		int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end) override { return OK; }
+		int RenderStatusLine(char* statusText) { return OK; }
+	};
+}

--- a/IDisplay.h
+++ b/IDisplay.h
@@ -88,13 +88,14 @@ namespace VCC
 		{
 			OPT_FLAG_ASPECT = 1,	// force aspect ratio (default) ELSE stretch display
 			OPT_FLAG_NTSC,			// use 50hz aspect ELSE 60hz aspect (default)
+			OPT_FLAG_RESIZEABLE,
 		};
 
 		// setup display:
 		//	width = full window width
 		//	height = full window height not including status bar
 		//  statusHeight = height to leave for status bar
-		virtual int Setup(void* hwnd, int width, int height, int statusHeight) = 0;
+		virtual int Setup(void* hwnd, int width, int height, int statusHeight, bool fullscreen) = 0;
 
 		//
 		// render the surface to the screen
@@ -160,7 +161,19 @@ namespace VCC
 		//
 		virtual int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end) = 0;
 
-		virtual int LockSurface() { return OK; }
 		virtual int UnlockSurface() { return OK; }
+	};
+
+	struct IDisplayDirectX : IDisplay
+	{
+		//
+		// render the signal lost message for directx
+		//
+		virtual int RenderSignalLostMessage() = 0;
+
+		//
+		// render the status line on screen for directx
+		//
+		virtual int RenderStatusLine(char* statusText) = 0;
 	};
 }

--- a/OpenGL.cpp
+++ b/OpenGL.cpp
@@ -87,15 +87,17 @@ namespace VCC
 		GLuint texId; // OpenGL texture on gpu
 		wglprocSwapIntervalEXT wglSwapIntervalEXT;
 
+		ISystemState* state;
+
 		#if USE_DEBUG_LINES
 		struct Line { float x1; float y1; float x2; float y2; Pixel color; };
 		std::vector<Line> debugLines;
 		#endif // USE_DEBUG_LINES
 
-		OpenGL::Detail()
+		OpenGL::Detail(ISystemState *state)
 			: isInitialized(false), hWnd(NULL), hDC(NULL), hRC(NULL)
 			, width(0), height(0), statusHeight(0), aspect(true), ntsc(false)
-			, pixels(nullptr), texId(0), wglSwapIntervalEXT(nullptr)
+			, pixels(nullptr), texId(0), wglSwapIntervalEXT(nullptr), state(state)
 		{
 		}
 
@@ -446,6 +448,7 @@ namespace VCC
 			{
 				case OPT_FLAG_ASPECT: aspect = enabled; break;
 				case OPT_FLAG_NTSC: ntsc = enabled; break;
+				case OPT_FLAG_RESIZEABLE: break;
 				default: return Result(ERR_BADOPTION);
 			}
 			return Result(OK);
@@ -643,6 +646,13 @@ namespace VCC
 			return Result(OK);
 		}
 
+		int LockSurface()
+		{
+			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
+			state->SetSurface(pixels, 3, DefaultWidth);
+			return Result(OK);
+		}
+
 	private:
 
 		// returns the box where display should be rendered
@@ -698,9 +708,9 @@ namespace VCC
 		return Result(ERR_NOTINITIALIZED);
 	}
 
-	int OpenGL::Setup(void* hwnd, int width, int height, int statusHeight)
+	int OpenGL::Setup(void* hwnd, int width, int height, int statusHeight, bool fullscreen)
 	{
-		detail = new Detail();
+		detail = new Detail(state);
 		return detail->Setup(hwnd, width, height, statusHeight);
 	}
 
@@ -762,6 +772,13 @@ namespace VCC
 	{
 		if (detail)
 			return detail->LoadFont(outFont, bitmapRes, glyphs, start, end);
+		return Result(ERR_NOTINITIALIZED);
+	}
+
+	int OpenGL::LockSurface()
+	{
+		if (detail)
+			return detail->LockSurface();
 		return Result(ERR_NOTINITIALIZED);
 	}
 

--- a/OpenGL.h
+++ b/OpenGL.h
@@ -54,9 +54,9 @@ namespace VCC
 			ERR_TMPMAKECONTEXT,		// unable to set context
 		};
 
-		OpenGL(SystemState*) : detail(nullptr) {}
+		OpenGL(ISystemState* state) : detail(nullptr), state(state) {}
 
-		int Setup(void* hwnd, int width, int height, int statusHeight) override;
+		int Setup(void* hwnd, int width, int height, int statusHeight, bool fullscreen) override;
 		int Render() override;
 		int RenderBox(float x, float y, float w, float h, Pixel color, bool filled) override;
 		int RenderText(const OpenGLFont* font, float x, float y, float size, const char* text) override;
@@ -67,6 +67,7 @@ namespace VCC
 		int GetSurface(Pixel** pixels) override;
 		int GetRect(int rectOption, Rect* area) override;
 		int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end) override;
+		int LockSurface() override;
 
 		void DebugDrawLine(float x1, float y1, float x2, float y2, Pixel color) override;
 		void DebugDrawBox(float x, float y, float w, float h, Pixel color) override;
@@ -74,6 +75,7 @@ namespace VCC
 	private:
 		struct Detail;
 		Detail* detail;
+		ISystemState* state;
 	};
 }
 

--- a/Vcc.c
+++ b/Vcc.c
@@ -152,8 +152,8 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
 	Cls(0,&EmuState);
 	EmuState.Throttle = 1;
-	EmuState.WindowSize.x=DefaultWidth;
-	EmuState.WindowSize.y=DefaultHeight;
+	EmuState.WindowSize.w=DefaultWidth;
+	EmuState.WindowSize.h=DefaultHeight;
 	LoadConfig(&EmuState);
 	EmuState.ResetPending=2; // after LoadConfig pls
 	InitInstance(hInstance, nCmdShow);

--- a/Vcc.vcxproj
+++ b/Vcc.vcxproj
@@ -377,6 +377,7 @@
     <ClInclude Include="audio.h" />
     <ClInclude Include="BuildConfig.h" />
     <ClInclude Include="DirectX.h" />
+    <ClInclude Include="DisplayNull.h" />
     <ClInclude Include="IDisplay.h" />
     <ClInclude Include="IDisplayDebug.h" />
     <ClInclude Include="OpenGL.h" />

--- a/Vcc.vcxproj.filters
+++ b/Vcc.vcxproj.filters
@@ -262,6 +262,9 @@
     <ClInclude Include="DirectX.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="DisplayNull.h">
+      <Filter>Source</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="resources\3guys.bmp">

--- a/tcc1014graphics.c
+++ b/tcc1014graphics.c
@@ -9498,7 +9498,7 @@ void DrawTopBoarder8(SystemState *DTState)
 	if (BoarderChange==0)
 		return;
 
-	for (x=0;x<DTState->WindowSize.x;x++)
+	for (x=0;x<DTState->WindowSize.w;x++)
 	{
 		DTState->PTRsurface8[x +((DTState->LineCounter*2)*DTState->SurfacePitch)]=BoarderColor8|128;
 		if (!DTState->ScanLines)
@@ -9513,7 +9513,7 @@ void DrawTopBoarder16(SystemState *DTState)
 	if (BoarderChange==0)
 		return;
 
-	for (x=0;x<DTState->WindowSize.x;x++)
+	for (x=0;x<DTState->WindowSize.w;x++)
 	{
 		DTState->PTRsurface16[x +((DTState->LineCounter*2)*DTState->SurfacePitch)]=BoarderColor16;
 		if (!DTState->ScanLines)
@@ -9535,7 +9535,7 @@ void DrawTopBoarder32(SystemState *DTState)
 	if (BoarderChange==0)
 		return;
 
-	for (x=0;x<DTState->WindowSize.x;x++)
+	for (x=0;x<DTState->WindowSize.w;x++)
 	{
 		DTState->PTRsurface32[x +((DTState->LineCounter*2)*DTState->SurfacePitch)]=BoarderColor32;
 		if (!DTState->ScanLines)
@@ -9554,8 +9554,8 @@ void DrawBottomBoarder8(SystemState *DTState)
 {
 	if (BoarderChange==0) return;
 	int ndx = 2 * (LinesperScreen + VertCenter + DTState->LineCounter);
-	if (ndx >= DTState->WindowSize.y) return;  // Range check
-	unsigned int cnt = DTState->WindowSize.x;
+	if (ndx >= DTState->WindowSize.h) return;  // Range check
+	unsigned int cnt = DTState->WindowSize.w;
 	if (!DTState->ScanLines) cnt *= 2;
 	unsigned char *p = DTState->PTRsurface8 + DTState->SurfacePitch * ndx;
 	while(cnt--) *p++ = BoarderColor8|128;
@@ -9565,8 +9565,8 @@ void DrawBottomBoarder16(SystemState *DTState)
 {
 	if (BoarderChange==0) return;
 	int ndx = 2 * (LinesperScreen + VertCenter + DTState->LineCounter);
-	if (ndx >= DTState->WindowSize.y) return;  // Range check
-	unsigned int cnt = DTState->WindowSize.x;
+	if (ndx >= DTState->WindowSize.h) return;  // Range check
+	unsigned int cnt = DTState->WindowSize.w;
 	if (!DTState->ScanLines) cnt *= 2;
 	unsigned short *p = DTState->PTRsurface16 + DTState->SurfacePitch * ndx;
 	while(cnt--) *p++ = BoarderColor16;
@@ -9582,8 +9582,8 @@ void DrawBottomBoarder32(SystemState *DTState)
 {
 	if (BoarderChange==0) return;
 	int ndx = 2 * (LinesperScreen + VertCenter + DTState->LineCounter);
-	if (ndx >= DTState->WindowSize.y) return;  // Range check
-	unsigned int cnt = DTState->WindowSize.x;
+	if (ndx >= DTState->WindowSize.h) return;  // Range check
+	unsigned int cnt = DTState->WindowSize.w;
 	if (!DTState->ScanLines) cnt *= 2;
 	unsigned int *p = DTState->PTRsurface32 + DTState->SurfacePitch * ndx;
 	while(cnt--) *p++ = BoarderColor32;


### PR DESCRIPTION
- moves majority of the specific code into respective display class
- makes it possible for both opengl and directx
- defaults to trying opengl, otherwise falls back to directx
- USE_DIRECTX & USE_OPENGL can still eliminate either one, e.g. legacy, linux
- can be added to config later to allow user to choose the display driver to use
