### PR TITLE
F10 brings up a fullscreen cartridge menu

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -67,6 +67,7 @@ void LoadConfig(void);
 void SaveConfig(void);
 long CreateDiskHeader(char *,unsigned char,unsigned char,unsigned char);
 void Load_Disk(unsigned char);
+void CenterDialog(HWND hDlg);
 
 static HWND g_hConfDlg;
 static HINSTANCE g_hinstDLL;
@@ -249,6 +250,15 @@ void CPUAssertInterupt(unsigned char Interupt,unsigned char Latencey)
 	return;
 }
 
+void CenterDialog(HWND hDlg)
+{
+    RECT rPar, rDlg;
+    GetWindowRect(GetParent(hDlg), &rPar);
+    GetWindowRect(hDlg, &rDlg);
+    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
+    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
+    SetWindowPos(hDlg, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
 
 LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -262,6 +272,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 	switch (message)
 	{
 		case WM_INITDIALOG:
+			CenterDialog(hDlg);
 			TempSelectRom=SelectRom;
 			if (!RealDisks)
 			{

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -55,6 +55,7 @@ void LoadConfig(void);
 void SaveConfig(void);
 void BuildDynaMenu(void);
 int CreateDisk(HWND,int);
+void CenterDialog(HWND hDlg);
 
 static HINSTANCE g_hinstDLL;
 static HWND hConfDlg = NULL;
@@ -142,12 +143,23 @@ extern "C"
     }
 }
 
+void CenterDialog(HWND hDlg)
+{
+    RECT rPar, rDlg;
+    GetWindowRect(GetParent(hDlg), &rPar);
+    GetWindowRect(hDlg, &rDlg);
+    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
+    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
+    SetWindowPos(hDlg, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
+
 LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
     switch (message)
     {
     case WM_INITDIALOG:
         hConfDlg=hDlg;
+		CenterDialog(hDlg);
         SendDlgItemMessage(hDlg,IDC_CLOCK,BM_SETCHECK,ClockEnabled,0);
         SendDlgItemMessage(hDlg,IDC_READONLY,BM_SETCHECK,ClockReadOnly,0);
         EnableWindow(GetDlgItem(hDlg, IDC_CLOCK), TRUE);

--- a/Vcc.c
+++ b/Vcc.c
@@ -528,6 +528,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 				case DIK_F10:
+					if (!IsShiftKeyDown() && EmuState.FullScreen) {
+						RECT r;
+						HMENU hMenu=RefreshDynamicMenu();
+						GetClientRect(hWnd,&r);
+						TrackPopupMenu(hMenu, TPM_CENTERALIGN|TPM_VCENTERALIGN,
+							r.right/2, r.bottom/2, 0, hWnd, NULL);
+					}
 				break;
 				
 				case DIK_F11:

--- a/Vcc.rc
+++ b/Vcc.rc
@@ -172,7 +172,7 @@ BEGIN
     LTEXT " F7   Pause Toggle"        IDC_STATIC,5,60,85,10
     LTEXT " F8   Toggle Throttle",    IDC_STATIC,5,70,85,10
     LTEXT " F9   Stop/Start reset",   IDC_STATIC,5,80,85,10
-    LTEXT "F10  \t---",               IDC_STATIC,5,90,85,10
+    LTEXT "F10  Cartridge Menu",      IDC_STATIC,5,90,85,10
     LTEXT "F11  Toggle Fullscreen",   IDC_STATIC,5,100,85,10
     LTEXT "F12  Function Keys",       IDC_STATIC,5,110,85,10
     LTEXT "Shifted",          IDC_STATIC,110,8,50,10

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -44,6 +44,7 @@ static unsigned int BankedCartOffset[MAXPAX]={0,0,0,0};
 static unsigned char Temp,Temp2;
 static char IniFile[MAX_PATH]="";
 static char MPIPath[MAX_PATH];
+void CenterDialog(HWND);
 
 using namespace std;
 
@@ -419,6 +420,16 @@ extern "C"
 	}
 }
 
+void CenterDialog(HWND hDlg)
+{
+    RECT rPar, rDlg;
+    GetWindowRect(GetParent(hDlg), &rPar);
+    GetWindowRect(hDlg, &rDlg);
+    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
+    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
+    SetWindowPos(hDlg, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
+
 LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	unsigned short EDITBOXS[4]={IDC_EDIT1,IDC_EDIT2,IDC_EDIT3,IDC_EDIT4};
@@ -434,7 +445,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 			EndDialog(hDlg, LOWORD(wParam));
 
 		case WM_INITDIALOG:
-
+			CenterDialog(hDlg);
 			hConfDlg=hDlg;
 			for (Temp=0;Temp<4;Temp++)
 				SendDlgItemMessage(hDlg,EDITBOXS[Temp],WM_SETTEXT,0,(LPARAM)(LPCSTR) SlotLabel[Temp] );

--- a/pakinterface.c
+++ b/pakinterface.c
@@ -521,7 +521,7 @@ void DynamicMenuCallback(const char *MenuName,int MenuId, int Type)
 	return;
 }
 
-void RefreshDynamicMenu(void)
+HMENU RefreshDynamicMenu(void)
 {
 	MENUITEMINFO	Mii;
 	char MenuTitle[32]="Cartridge";
@@ -613,6 +613,6 @@ void RefreshDynamicMenu(void)
 		}
 	}
 	DrawMenuBar(EmuState.WindowHandle);
-	return;
+	return hSubMenu[0];
 }
 

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -35,7 +35,7 @@ void UpdateBusPointer(void);
 void UnloadDll(void);
 void UnloadPack(void);
 void DynamicMenuActivated(unsigned char );
-void RefreshDynamicMenu(void);
+HMENU RefreshDynamicMenu(void);
 #define ID_SDYNAMENU 5000	//Defines the start and end IDs for the dynamic menus
 #define ID_EDYNAMENU 5100
 #define NOMODULE	1

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -140,6 +140,7 @@ void LoadConfig(void);
 void SaveConfig(void);
 void BuildDynaMenu(void);
 void UpdateListBox(HWND);
+void CenterDialog(HWND);
 void UpdateCardBox(void);
 void UpdateFlashItem(void);
 void InitCardBox(void);
@@ -381,6 +382,19 @@ void BuildDynaMenu(void)
 }
 
 //------------------------------------------------------------
+// Center a dialog box in parent window
+//------------------------------------------------------------
+void CenterDialog(HWND hDlg)
+{
+    RECT rPar, rDlg;
+    GetWindowRect(GetParent(hDlg), &rPar);
+    GetWindowRect(hDlg, &rDlg);
+    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
+    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
+    SetWindowPos(hDlg, NULL, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
+
+//------------------------------------------------------------
 // Configure the SDC
 //------------------------------------------------------------
 LRESULT CALLBACK
@@ -391,6 +405,7 @@ SDC_Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
         EndDialog(hDlg,LOWORD(wParam));
         break;
     case WM_INITDIALOG:
+        CenterDialog(hDlg);
         hConfDlg=hDlg;
         InitFlashBox();
         InitCardBox();


### PR DESCRIPTION
When in full screen mode pressing F10 brings up the Cartridge menu.  This allows user to modify the config (change floppies,etc) without exiting fullscreen mode.

Also centered fd502, harddisk, mpi, and sdc config menus on screen so they don't end up in far top left corner when activated.

Note issue #321 "lost windows event when dialog is used" was exposed while testing this change.  When issue occurs fullscreen toggle sometimes appears to hang waiting for another keyboard or mouse event.  The issue exists on previous VCC versions.
