### PR TITLE
Initial Load cassette filter contain both .CAS and .WAV files

### DIFF
--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -444,8 +444,8 @@ unsigned int LoadTape(void)
 	ofn.hwndOwner         = NULL;
 	ofn.Flags             = OFN_HIDEREADONLY | OFN_NOTESTFILECREATE;
 	ofn.hInstance         = GetModuleHandle(0);
-	ofn.lpstrDefExt			="";
-	ofn.lpstrFilter       =	"Cassette Files (*.cas)\0*.cas\0Wave Files (*.wav)\0*.wav\0\0";
+	ofn.lpstrDefExt       = "";
+	ofn.lpstrFilter       = "Cassette Files (.cas,.wav)\0*.cas;*.wav\0\0";
 	ofn.nFilterIndex      = 0 ;								// current filter index
 	ofn.lpstrFile         = TapeFileName;					// contains full path and filename on return
 	ofn.nMaxFile          = MAX_PATH;						// sizeof lpstrFile


### PR DESCRIPTION
This has been bugging me for a while.  The load tape cassette filter required extra steps to load .WAV files.  This request includes both .CAS and .WAV in the initial select.