### PR TITLE
Remove redundancies

### DIFF
--- a/Vcc.sln
+++ b/Vcc.sln
@@ -4,10 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.10.35027.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vcc", "Vcc.vcxproj", "{822E50CF-A326-4B7A-A2CA-2A4C4055FC34}"
-	ProjectSection(ProjectDependencies) = postProject
-		{C78D7242-DB92-49BC-AFF5-433E16C3C9D4} = {C78D7242-DB92-49BC-AFF5-433E16C3C9D4}
-		{BD7CA587-71D0-43D6-A730-582126B1C1F4} = {BD7CA587-71D0-43D6-A730-582126B1C1F4}
-	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fd502", "FD502\fd502.vcxproj", "{F4DC9499-4FF1-4A56-83DD-6499062972AA}"
 EndProject

--- a/config.h
+++ b/config.h
@@ -27,7 +27,7 @@ unsigned char WriteIniFile(void);
 unsigned char ReadIniFile(void);
 void GetIniFilePath( char *);
 void UpdateConfig (void);
-void UpdateSoundBar(int,int);
+void UpdateSoundBar(unsigned int *,unsigned int);
 void UpdateTapeCounter(unsigned int,unsigned char,bool force = false);
 int GetKeyboardLayout();
 void SetWindowRect(const VCC::Rect&);


### PR DESCRIPTION
Remive unneeded dependancies from vcc.sln
Move sound bar level calcs to config.c so they are not done when the audio config dialog is not running.