### PR TITLE
Disable RAM high speed on reset

### DIFF
--- a/Vcc.c
+++ b/Vcc.c
@@ -779,6 +779,7 @@ void DoHardReset(SystemState* const HRState)
 	UpdateBusPointer();
 	EmuState.TurboSpeedFlag=1;
 	ResetBus();
+	SetCPUMultiplyerFlag(0);
 	SetClockSpeed(1);
 	return;
 }
@@ -792,6 +793,7 @@ void SoftReset(void)
 	MmuReset();
 	LoadRom();
 	ResetBus();
+	SetCPUMultiplyerFlag(0);
 	EmuState.TurboSpeedFlag=1;
 	return;
 }


### PR DESCRIPTION
Addresses #345 disable RAM double clock speed (HS poke) on reset.