### PR TITLE
Don't record the maximized window size

### DIFF
--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -248,6 +248,19 @@ bool CreateDDWindow(SystemState *CWState)
 	return TRUE;
 }
 
+/*--------------------------------------------------------------------------*/
+
+
+bool IsMaximized(SystemState* DFState)
+{
+	WINDOWPLACEMENT wp;
+	memset(&wp, 0, sizeof(wp));
+	wp.length = sizeof(wp);
+	GetWindowPlacement(DFState->WindowHandle, &wp);
+	return wp.showCmd == SW_MAXIMIZE;
+}
+
+
 void DisplayFlip(SystemState *DFState)	// Double buffering flip
 {
 	if (g_Display)
@@ -284,18 +297,22 @@ void DisplayFlip(SystemState *DFState)	// Double buffering flip
 	int clientWidth = (int)CurScreen.right;
 	int clientHeight = (int)CurScreen.bottom;
 
+	if (!IsMaximized(DFState) && !DFState->FullScreen && !DFState->Exiting)
+	{
 #if USE_DEFAULT_POSITIONING
-	// preserve default positioning (like older versions):
-	RememberWin.x = RememberWin.IsDefaultX() ? CW_USEDEFAULT : CurWindow.left;
-	RememberWin.y = RememberWin.IsDefaultY() ? CW_USEDEFAULT : CurWindow.top;
+		// preserve default positioning (like older versions):
+		RememberWin.x = RememberWin.IsDefaultX() ? CW_USEDEFAULT : CurWindow.left;
+		RememberWin.y = RememberWin.IsDefaultY() ? CW_USEDEFAULT : CurWindow.top;
 #else // !USE_DEFAULT_POSITIONING
-	// remember positioning:
-	RememberWin.x = CurWindow.left;
-	RememberWin.y = CurWindow.top;
+		// remember positioning:
+		RememberWin.x = CurWindow.left;
+		RememberWin.y = CurWindow.top;
 #endif // !USE_DEFAULT_POSITIONING
-	// remember size:
-	RememberWin.w = clientWidth; // Used for saving new window size to the ini file.
-	RememberWin.h = clientHeight-StatusBarHeight;
+	
+		// remember size:
+		RememberWin.w = clientWidth; // Used for saving new window size to the ini file.
+		RememberWin.h = clientHeight - StatusBarHeight;
+	}
 	return;
 }
 

--- a/Vcc.c
+++ b/Vcc.c
@@ -158,6 +158,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	EmuState.Throttle = 1;
 	EmuState.WindowSize.w=DefaultWidth;
 	EmuState.WindowSize.h=DefaultHeight;
+	EmuState.Exiting = false;
 	LoadConfig(&EmuState);
 	EmuState.ResetPending=2; // after LoadConfig pls
 	InitInstance(hInstance, nCmdShow);
@@ -217,6 +218,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 			TranslateMessage(&Msg);
 			DispatchMessage(&Msg) ;
 	}
+	EmuState.Exiting = true;
 
 	PostThreadMessage(threadID, WM_QUIT, 0, 0);
 	SetEvent(hEMUQuit);								// Signal emulation thread to finish up.

--- a/defines.h
+++ b/defines.h
@@ -244,6 +244,7 @@ struct SystemState
     unsigned char	ResetPending;
     VCC::Size		WindowSize;
     unsigned char	FullScreen;
+    bool        	Exiting;
     unsigned char	MousePointer;
     unsigned char	OverclockFlag;
     char			StatusLine[256];


### PR DESCRIPTION
- will avoid recording the maximized window size so that next open the app starts at the normal size.
Fixes #325