### PR TITLE
mc6809 Quiet legacy (VC2015) compiler int to bool warning

### DIFF
--- a/mc6809.c
+++ b/mc6809.c
@@ -33,6 +33,9 @@ This file is part of VCC (Virtual Color Computer).
 #define OTEST16(c,a,b,r) c ^ (((a^b^r)>>15)&1);
 #define ZTEST(r) !r;
 
+// Quiet legacy compiler warning about forcing int value to bool
+#pragma warning( disable : 4800 )
+
 typedef union
 {
 	unsigned short Reg;


### PR DESCRIPTION
Changing the CC registor to bool array caused C4800 warnings when using Visual C 2015 compiler.  Added pragma to turn the warning off. (This warning is off by default on compilers since Visual C 2017)