### PR TITLE
PAK assert INT_CART not INT_IRQ or INT_FIRQ

### DIFF
--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -248,9 +248,9 @@ void sc6551_heartbeat()
         // Set RxF if there is data buffered
         if (Icnt) {
             StatReg |= StatRxF;
-            // If not disabled or already done assert IRQ
+            // Assert CART if interrupts not disabled or already asserted.
             if (!((CmdReg & CmdRxI) || (StatReg & StatIRQ))) {
-                AssertInt(INT_IRQ,NULL);
+                AssertInt(INT_CART,NULL);
                 StatReg |= StatIRQ;
             }
         }

--- a/interrupts.h
+++ b/interrupts.h
@@ -3,10 +3,10 @@
 // CPU interrupts (counting from 1 because legacy)
 // Pakinterface uses INT_NONE to clear cart IRQ
 enum Interrupt {
-	INT_NONE = 0,
 	INT_IRQ = 1,
 	INT_FIRQ,
-	INT_NMI
+	INT_NMI,
+	INT_CART
 };
 
 // Interrupt sources keep track of their own state.

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -188,13 +188,12 @@ void PackMem8Write(unsigned short Address,unsigned char Value)
 	return;
 }
 
-// Convert PAK assert to CPUAssert or CPUDeAssert.
+// Convert PAK interrupt assert to CPU assert or Gime assert.
 void (PakAssertInterupt) (unsigned char interrupt, unsigned char source)
 {
 	(void) source; // not used
 	switch (interrupt) {
-	case INT_IRQ:
-	case INT_FIRQ:
+	case INT_CART:
 		GimeAssertCartInterupt();
 		break;
 	case INT_NMI:


### PR DESCRIPTION
INT_CART interrupt added for consistancy.  Cartridges can only assert INT_CART or INT_NMI.