### PR TITLE
Hack SuperIDE.cpp to appease BitDefender crap

### DIFF
--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -53,6 +53,12 @@ bool FileDialog::show(HWND owner) {
 	return GetOpenFileName(&ofn);
 }
 
+// FileDialog::getdir() returns the directory portion of the path found
+void FileDialog::getdir(char * Dir, int maxsize) {
+	strncpy(Dir,Path,maxsize);
+	if (char * p = strrchr(Dir,'\\')) *p = '\0';
+}
+
 // CloseCartDialog should be called by cartridge DLL's when they are unloaded.
 void CloseCartDialog(HWND hDlg)
 {

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -28,6 +28,31 @@
 #include <windows.h>
 #include "DialogOps.h"
 
+// FileDialog shows a dialog for user to select a file. It wraps GetOpenFilename().
+FileDialog::FileDialog() {
+	ZeroMemory(&ofn, sizeof(ofn));
+	ofn.lpstrTitle = "Choose File";
+	ofn.Flags |= OFN_HIDEREADONLY;
+	ofn.lStructSize = sizeof(ofn);
+	ofn.lpstrFile = Path;
+	ofn.nMaxFile = sizeof(Path);
+}
+
+// FileDialog destructor does nothing
+FileDialog::~FileDialog() { }
+
+// FileDialog::show calls GetOpenFileName()
+bool FileDialog::show(HWND owner) {
+	// use active window if owner is null
+	if (owner != NULL) {
+		ofn.hwndOwner = owner;
+	} else {
+		ofn.hwndOwner = GetActiveWindow();
+	}
+	ofn.hInstance = GetModuleHandle(0);
+	return GetOpenFileName(&ofn);
+}
+
 // CloseCartDialog should be called by cartridge DLL's when they are unloaded.
 void CloseCartDialog(HWND hDlg)
 {

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -32,6 +32,7 @@ public:
 	FileDialog();
 	~FileDialog();
 	bool show(HWND owner = NULL);
+	void getdir(char * Dir, int maxsize = MAX_PATH);
 	OPENFILENAME ofn;
 	char Path[MAX_PATH] = {};
 };

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -22,14 +22,17 @@
 //-------------------------------------------------------------------------------------------
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-// CloseCartDialog should be called by cartridge DLL's when they are unloaded.
+// CloseCartDialog closes a cartridge dialog or asserts that it can not be.
+// It should be called by cartridge DLL's when they are unloaded.
 void CloseCartDialog(HWND hDlg);
 
-#ifdef __cplusplus
-	}
-#endif
+// FileDialog shows a dialog for user to select a file. It wraps GetOpenFilename().
+class FileDialog {
+public:
+	FileDialog();
+	~FileDialog();
+	bool show(HWND owner = NULL);
+	OPENFILENAME ofn;
+	char Path[MAX_PATH] = {};
+};
 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -308,11 +308,14 @@ void Select_Disk(unsigned char Disk)
 	if (GetOpenFileName(&ofn)) {
 	if (!(MountDisk(TempFileName, Disk)))
 		MessageBox(GetActiveWindow(), "Can't Open File", "Can't open the Image specified.", 0);
-	string tmp = ofn.lpstrFile;
-	int idx;
-	idx = tmp.find_last_of("\\");
-	tmp = tmp.substr(0, idx);
-	strcpy(SuperIDEPath, tmp.c_str());
+//  next five lines were causing a BitDefender false Positive Gen:Variant:Lazy.667300
+//	string tmp = ofn.lpstrFile;
+//	int idx;
+//	idx = tmp.find_last_of("\\");
+//	tmp = tmp.substr(0, idx);
+//	strcpy(SuperIDEPath, tmp.c_str());
+		char * tmp = strrchr(ofn.lpstrFile,'\\');
+		if (tmp) strcpy(SuperIDEPath,tmp);
 	}
 	return;
 }

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -294,8 +294,7 @@ void Select_Disk(unsigned char Disk)
 	dlg.ofn.lpstrInitialDir = SuperIDEPath;
 	if (dlg.show()) {
 		if (MountDisk(dlg.Path,Disk)) {
-			strcpy(SuperIDEPath,dlg.Path);
-			if (char * p = strrchr(SuperIDEPath,'\\')) *p = '\0';
+			dlg.getdir(SuperIDEPath);
 		} else {
 			MessageBox(GetActiveWindow(),"Can't Open Image","Error",0);
 		}

--- a/SuperIDE/SuperIDE.vcxproj
+++ b/SuperIDE/SuperIDE.vcxproj
@@ -175,7 +175,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;SUPERIDE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>$(OutDir)</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
-      <PrecompiledHeaderOutputFile>.\Legacy\SuperIDE.pch</PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderOutputFile>.\Release\SuperIDE.pch</PrecompiledHeaderOutputFile>
       <ObjectFileName>$(OutDir)</ObjectFileName>
       <ProgramDataBaseFileName>$(OutDir)</ProgramDataBaseFileName>
       <AdditionalOptions>/arch:SSE</AdditionalOptions>
@@ -183,7 +183,7 @@
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <TypeLibraryName>.\Legacy\SuperIDE.tlb</TypeLibraryName>
+      <TypeLibraryName>.\Release\SuperIDE.tlb</TypeLibraryName>
       <MkTypLibCompatible>true</MkTypLibCompatible>
       <TargetEnvironment>Win32</TargetEnvironment>
     </Midl>

--- a/SuperIDE/SuperIDE.vcxproj
+++ b/SuperIDE/SuperIDE.vcxproj
@@ -261,6 +261,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Fileops.cpp" />
+    <ClCompile Include="..\Dialogops.cpp" />
     <ClCompile Include="cloud9.cpp" />
     <ClCompile Include="IdeBus.cpp" />
     <ClCompile Include="logger.cpp" />


### PR DESCRIPTION
replace:

>>    string tmp = ofn.lpstrFile;
>>    int idx;
>>    idx = tmp.find_last_of("\\");
>>    tmp = tmp.substr(0, idx);
>>    strcpy(SuperIDEPath, tmp.c_str());

with:
>>    dlg.getdir(SuperIDEPath);

To resolve BitDefender false positive.