### PR TITLE
Fix TFR inst cycle timing & thus DoD's demo

### DIFF
--- a/mc6809.cpp
+++ b/mc6809.cpp
@@ -688,7 +688,6 @@ void Do_Opcode(int CycleFor)
 			// Move the register value from the source to the destination.
 			const uint16_t value = MC6809ReadTfrExgRegister(Source);
 			MC6809WriteTfrExgRegister(Dest, value);
-			break;
 		}
 
 		CycleCounter += 6;


### PR DESCRIPTION
- a stray 'break' skipped the correct cycle count for TFR instruction

Fixes #377