### PR TITLE
Code clean up part 3

### DIFF
--- a/Audio.cpp
+++ b/Audio.cpp
@@ -265,7 +265,7 @@ int GetSoundCardList (SndCardList *List)
 	return CardCount;
 }
 
-BOOL CALLBACK DSEnumCallback(LPGUID lpGuid,LPCSTR lpcstrDescription,LPCSTR lpcstrModule,LPVOID lpContext)          
+BOOL CALLBACK DSEnumCallback(LPGUID lpGuid,LPCSTR lpcstrDescription,LPCSTR /*lpcstrModule*/,LPVOID /*lpContext*/)          
 {
 	strncpy(Cards[CardCount].CardName,lpcstrDescription,63);
 	Cards[CardCount++].Guid=lpGuid;

--- a/Audio.cpp
+++ b/Audio.cpp
@@ -34,7 +34,7 @@ This file is part of VCC (Virtual Color Computer).
 
 using AuxBufferType = VCC::Array<VCC::Array<uint32_t, AUDIO_RATE / 60>, 6>;
 
-#define MAXCARDS	12
+constexpr auto MAXCARDS = 12u;
 //PlayBack
 static LPDIRECTSOUND	lpds;           // directsound interface pointer
 static DSBUFFERDESC		dsbd;           // directsound description

--- a/Audio.cpp
+++ b/Audio.cpp
@@ -292,7 +292,7 @@ int SoundDeInit(void)
 	return 0;
 }
 
-int SoundInInit (HWND main_window_handle,const _GUID * Guid)
+int SoundInInit (const _GUID * Guid)
 {
 	hr=DirectSoundCaptureCreate(Guid, &lpdsin, nullptr);
 	if (hr!=DS_OK)

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -77,7 +77,7 @@ namespace VCC
 		for (size_t i = 0; i < samples; ++i)
 		{
 			auto p = inBuffer + i * width + width - 1;
-			int sample = (int)*(int8_t*)p;
+			int sample = *p;
 			outBuffer[i] = (uint8_t)(sample + CAS_SILENCE);
 		}
 	}
@@ -87,7 +87,7 @@ namespace VCC
 		for (size_t i = 0; i < samples; ++i)
 		{
 			auto p = inBuffer + i * width + width - 1;
-			uint8_t sample = *(uint8_t*)p;
+			uint8_t sample = *p;
 			outBuffer[i] = sample;
 		}
 	}
@@ -97,7 +97,7 @@ namespace VCC
 		for (size_t i = 0; i < samples; ++i)
 		{
 			auto p = inBuffer + i * width;
-			float sample = *(float*)p;
+			float sample = *reinterpret_cast<const float*>(p);
 			outBuffer[i] = (uint8_t)(sample * 128) + 256 / 2;
 		}
 	}

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -218,7 +218,7 @@ void UpdateTapeStatus(char* status, int max)
 		StalledCtr++;
 	}
 	if (TotalSize > 0 && StalledCtr < 1000)
-		snprintf(status, max, " | Tape:%05d (%d%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
+		snprintf(status, max, " | Tape:%05ul (%ul%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
 }
 
 void SetTapeMode(unsigned char Mode)	//Handles button pressed from Dialog

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -218,7 +218,7 @@ void UpdateTapeStatus(char* status, int max)
 		StalledCtr++;
 	}
 	if (TotalSize > 0 && StalledCtr < 1000)
-		snprintf(status, max, " | Tape:%05ul (%ul%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
+		snprintf(status, max, " | Tape:%05lu (%lu%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
 }
 
 void SetTapeMode(unsigned char Mode)	//Handles button pressed from Dialog

--- a/CommandLine.cpp
+++ b/CommandLine.cpp
@@ -85,7 +85,7 @@ This file is part of VCC (Virtual Color Computer).
 // Define global command line settings
 struct CmdLineArguments CmdArg;
 
-#define SEPMARK 3  //To mark spaces as separators
+constexpr auto SEPMARK = 3u;  //To mark spaces as separators
 
 char *ParseCmdString(const char *, const char *); 
 char *GetNextToken ();

--- a/CommandLine.h
+++ b/CommandLine.h
@@ -20,8 +20,8 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 // Declare global variables defined by GetCmdLineArgs
-#define CL_MAX_PATH 256
-#define CL_MAX_PASTE 256
+constexpr auto CL_MAX_PATH = 256u;
+constexpr auto CL_MAX_PASTE = 256u;
 struct CmdLineArguments {
 	char QLoadFile[CL_MAX_PATH];
 	char IniFile[CL_MAX_PATH];
@@ -34,6 +34,8 @@ extern struct CmdLineArguments CmdArg;
 int  GetCmdLineArgs(char * lpCmdLine);
 
 // Errors returned
+// FIXME: These need to be turned into a scoped enum and the signature of functions
+// that use them updated.
 #define CL_ERR_UNKOPT 1  // Unknown option found
 #define CL_ERR_XTRARG 2  // Too many arguments
 

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -95,13 +95,13 @@ void FileDialog::setpath(const char * NewPath) {
 }
 
 // Get a copy of the selected file path
-void FileDialog::getpath(char * PathCopy, int maxsize) {
+void FileDialog::getpath(char * PathCopy, int maxsize) const {
     if (PathCopy == nullptr || Path == nullptr || maxsize < 1) return;
 	strncpy(PathCopy,Path,maxsize);
 }
 
 // Get a copy of the selected file path with unix dir delimiters
-void FileDialog::getupath(char * PathCopy, int maxsize) {
+void FileDialog::getupath(char * PathCopy, int maxsize) const {
     if (PathCopy == nullptr || Path == nullptr || maxsize < 1) return;
     int i = 0;
     while (Path[i] != '\0' && i < maxsize - 1) {
@@ -121,7 +121,7 @@ char * FileDialog::path() {
 }
 
 // FileDialog::getdir() returns the directory portion of the file path
-void FileDialog::getdir(char * Dir, int maxsize) {
+void FileDialog::getdir(char * Dir, int maxsize) const {
     if (Dir == nullptr || Path == nullptr || maxsize < 1) return;
 	strncpy(Dir,Path,maxsize);
 	if (char * p = strrchr(Dir,'\\')) *p = '\0';

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -39,9 +39,6 @@ FileDialog::FileDialog() {
 	ofn.Flags = OFN_HIDEREADONLY;
 }
 
-// FileDialog destructor does nothing
-FileDialog::~FileDialog() { }
-
 // FileDialog::show calls GetOpenFileName() or GetSaveFileName()
 bool FileDialog::show(BOOL Save, HWND Owner) {
 

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -57,9 +57,9 @@ public:
 	void setFilter(const char * Filter);
 	void setFlags(unsigned int Flags);
 	void setTitle(const char * Title);
-	void getdir(char * Dir, int maxsize = MAX_PATH);
-	void getpath(char * Path, int maxsize = MAX_PATH);
-	void getupath(char * Path, int maxsize = MAX_PATH);
+	void getdir(char * Dir, int maxsize = MAX_PATH) const;
+	void getpath(char * Path, int maxsize = MAX_PATH) const;
+	void getupath(char * Path, int maxsize = MAX_PATH) const;
 	char * path();
 private:
 	OPENFILENAME ofn;

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -49,7 +49,7 @@ void CloseCartDialog(HWND hDlg);
 class FileDialog {
 public:
 	FileDialog();
-	~FileDialog();
+
 	bool show(BOOL Save = FALSE, HWND Owner = nullptr);
 	void setpath(const char * Path);
 	void setDefExt(const char * DefExt);

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -319,7 +319,7 @@ void DisplayFlip(SystemState *DFState)	// Double buffering flip
 	return;
 }
 
-unsigned char LockScreen(const SystemState *LSState)
+unsigned char LockScreen()
 {
 	if (!g_Display) 
 		return 0;
@@ -365,7 +365,7 @@ void DoCls(SystemState *CLStatus)
 {
 	unsigned short x=0,y=0;
 
-	if(LockScreen(CLStatus))
+	if(LockScreen())
 		return;
 	switch (CLStatus->BitDepth)
 	{

--- a/DirectDrawInterface.h
+++ b/DirectDrawInterface.h
@@ -39,6 +39,4 @@ POINT GetForcedAspectBorderPadding();
 void CloseScreen();
 void DumpScreenshot();
 
-#define MAX_LOADSTRING 100
-
 #endif

--- a/DirectDrawInterface.h
+++ b/DirectDrawInterface.h
@@ -21,7 +21,6 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 
 BOOL InitInstance(HINSTANCE,int);
-BOOL InitDrawSurface(bool );
 void UnlockScreen(SystemState *);
 unsigned char LockScreen(const SystemState *);
 void SetStatusBarText(const char *,const SystemState *);

--- a/DirectDrawInterface.h
+++ b/DirectDrawInterface.h
@@ -22,7 +22,7 @@ This file is part of VCC (Virtual Color Computer).
 
 BOOL InitInstance(HINSTANCE,int);
 void UnlockScreen(SystemState *);
-unsigned char LockScreen(const SystemState *);
+unsigned char LockScreen();
 void SetStatusBarText(const char *,const SystemState *);
 int GetRenderWindowStatusBarHeight();
 bool CreateDDWindow(SystemState *);

--- a/DirectX.cpp
+++ b/DirectX.cpp
@@ -406,7 +406,7 @@ namespace VCC
         return Result(OK);
     }
 
-    void DirectX::GetSurfaceArea(Rect* rect)
+    void DirectX::GetSurfaceArea(Rect* rect) const
     {
         rect->x = 0;
         rect->y = 0;
@@ -414,7 +414,7 @@ namespace VCC
         rect->h = 480;
     }
 
-    void DirectX::GetDisplayArea(Rect* rect)
+    void DirectX::GetDisplayArea(Rect* rect) const
     {
         using namespace Detail;
         rect->x = (float)ForcedAspectBorderPadding.x;
@@ -423,7 +423,7 @@ namespace VCC
         rect->h = 480;
     }
 
-    void DirectX::CheckSurfaces()
+    void DirectX::CheckSurfaces() const
     {
         using namespace Detail;
 

--- a/DirectX.h
+++ b/DirectX.h
@@ -55,9 +55,9 @@ namespace VCC
 
         ISystemState* state;
 
-        void GetDisplayArea(Rect* rect);
-        void GetSurfaceArea(Rect* rect);
-        void CheckSurfaces();
+        void GetDisplayArea(Rect* rect) const;
+        void GetSurfaceArea(Rect* rect) const;
+        void CheckSurfaces() const;
     };
 }
 

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -494,7 +494,7 @@ LRESULT CALLBACK SubTextDlgProc(HWND hCtl,UINT msg,WPARAM wPrm,LPARAM lPrm)
 /*    Breakpoints list Dialog Processing          */
 /**************************************************/
 INT_PTR CALLBACK BreakpointsDlgProc
-    (HWND hDlg,UINT msg,WPARAM wPrm,LPARAM lPrm)
+    (HWND hDlg,UINT msg,WPARAM wPrm,LPARAM /*lPrm*/)
 {
     int sel;
     HWND hList;

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -102,7 +102,6 @@ int errDisplayTimer = 0;
 
 // String functions used for decode
 std::string PadRight(std::string const&,size_t);
-std::string OpFDB(int,std::string,std::string,std::string);
 std::string FmtLine(
 	int adr,
 	const std::string& ins,

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -192,7 +192,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawSamplingInProgress(HDC hdc, LPRECT clientRect)
+	void DrawSamplingInProgress(HDC hdc)
 	{
 		status = TraceStatus::Collecting;
 
@@ -216,7 +216,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawNoSamplesCollected(HDC hdc, LPRECT clientRect)
+	void DrawNoSamplesCollected(HDC hdc)
 	{
 		status = TraceStatus::Empty;
 
@@ -244,7 +244,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Nothing collected yet?
 		if (samples == 0)
 		{
-			DrawNoSamplesCollected(hdc, clientRect);
+			DrawNoSamplesCollected(hdc);
 			return;
 		}
 
@@ -633,7 +633,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Show tracing is in progress.
 		if (tracing)
 		{
-			DrawSamplingInProgress(hdc, clientRect);
+			DrawSamplingInProgress(hdc);
 			return;
 		}
 

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -1244,7 +1244,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 //-------------------------------------------------------------------------------
 // Export to file dialog
 //-------------------------------------------------------------------------------
-	INT_PTR CALLBACK ExportTraceProc(HWND hDlg,UINT uMsg,WPARAM wPrm,LPARAM lPrm) {
+	INT_PTR CALLBACK ExportTraceProc(HWND hDlg,UINT uMsg,WPARAM wPrm,LPARAM /*lPrm*/) {
 		switch (uMsg) {
 		case WM_INITDIALOG:
 			SetDlgItemInt(hDlg,IDC_EDIT_START,ExportStart,FALSE);

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -296,7 +296,7 @@ void dw_open( void )
 }
 
 // TCP connection thread
-unsigned __stdcall dw_thread(void *Dummy)
+unsigned __stdcall dw_thread(void* /*Dummy*/)
 {
 	_DLOG("dw_thread %d\n",dwEnabled);
 	WSADATA wsaData;

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -23,8 +23,8 @@
 //#define USE_LOGGING
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <process.h>
 #include <stdio.h>
 #include "../logger.h"

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -27,7 +27,7 @@
 #include <windows.h>
 #include <process.h>
 #include <stdio.h>
-#include "..\logger.h"
+#include "../logger.h"
 #include "becker.h"
 
 #define BUFFER_SIZE 512
@@ -37,7 +37,7 @@
 //------------------------------------------------------
 // local functions
 //------------------------------------------------------
-int dw_open(char *,unsigned short);
+void dw_open();
 void dw_close();
 unsigned char dw_status(void);
 unsigned char dw_read(void);

--- a/FD502/distortc.cpp
+++ b/FD502/distortc.cpp
@@ -15,11 +15,10 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "windows.h"
-#include "stdio.h"
-#include "stdlib.h"
+#include <Windows.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "distoRTC.h"
-#include "windows.h"
 
 /* Table description:							   Bit3  Bit2  Bit1  Bit0
 Write to $FF51 read from $FF50

--- a/FD502/distortc.cpp
+++ b/FD502/distortc.cpp
@@ -18,7 +18,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "distoRTC.h"
+#include "distortc.h"
 
 /* Table description:							   Bit3  Bit2  Bit1  Bit0
 Write to $FF51 read from $FF50

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -40,11 +40,13 @@ This file is part of VCC (Virtual Color Computer).
 #include "becker.h"
 #endif
 
-#define EXTROMSIZE 16384
+constexpr auto EXTROMSIZE = 16384u;
 
 using namespace std;
 
 extern DiskInfo Drive[5];
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*PAKINTERUPT)(unsigned char, unsigned char);

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -599,7 +599,7 @@ long CreateDiskHeader(char *FileName,unsigned char Type,unsigned char Tracks,uns
 	unsigned short TrackSize=0x1900;
 	unsigned char IgnoreDensity=0,SingleDensity=0,HeaderSize=0;
 	unsigned long BytesWritten=0,FileSize=0;
-	hr=CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,0,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,0);
+	hr=CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,nullptr,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,nullptr);
 	if (hr==INVALID_HANDLE_VALUE)
 		return 1; //Failed to create File
 
@@ -653,9 +653,9 @@ long CreateDiskHeader(char *FileName,unsigned char Type,unsigned char Tracks,uns
 		break;
 
 	}
-	SetFilePointer(hr,0,0,FILE_BEGIN);
+	SetFilePointer(hr,0,nullptr,FILE_BEGIN);
 	WriteFile(hr,HeaderBuffer,HeaderSize,&BytesWritten,nullptr);
-	SetFilePointer(hr,FileSize-1,0,FILE_BEGIN);
+	SetFilePointer(hr,FileSize-1,nullptr,FILE_BEGIN);
 	WriteFile(hr,&Dummy,1,&BytesWritten,nullptr);
 	CloseHandle(hr);
 	return 0;

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 #pragma warning( disable : 4800 ) // For legacy builds
 
 //#define USE_LOGGING
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include <iostream>
 #include "resource.h"
@@ -310,7 +310,6 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 			SendDlgItemMessage (hDlg,IDC_BECKER_PORT,WM_SETTEXT,0,(LPARAM)(LPCSTR)BeckerPort);
 
 			return TRUE;
-		break;
 
 		case WM_COMMAND:
 			switch (LOWORD(wParam))
@@ -513,7 +512,6 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
 		case WM_CLOSE:
 			EndDialog(hDlg,LOWORD(wParam));  //Modal dialog
 			return TRUE;
-			break;
 
 		case WM_INITDIALOG:
 			for (temp=0;temp<=2;temp++)
@@ -585,7 +583,6 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
 					return FALSE;
 			}
 			return TRUE;
-		break;
 	}
     return FALSE;
 }

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -265,7 +265,7 @@ void CenterDialog(HWND hDlg)
     SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
-LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	static unsigned char temp=0,temp2=0;
 	long ChipChoice[3]={IDC_EXTROM,IDC_TRSDOS,IDC_RGB};
@@ -500,7 +500,7 @@ long CreateDisk (unsigned char Disk)
 	return 0;
 }
 
-LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	unsigned char temp=0,temp2=0;
 	static unsigned char NewDiskType=JVC,NewDiskTracks=2,DblSided=1;

--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -32,6 +32,8 @@ void BuildDynaMenu(void);
 #define SLAVE 1
 #define STANDALONE 2
 
+// FIXME: These need to be turned into a scoped enum and the signature of functions
+// that use them updated.
 #define External 0
 #define TandyDisk 1
 #define RGBDisk 2

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -297,10 +297,10 @@ unsigned char MountDisk(char *FileName,unsigned char disk)
 
 	if (Drive[disk].RawDrive==0)
 	{
-		Drive[disk].FileHandle = CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+		Drive[disk].FileHandle = CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 		if (Drive[disk].FileHandle==INVALID_HANDLE_VALUE)
 		{	//Can't open read/write might be read only
-			Drive[disk].FileHandle = CreateFile(FileName,GENERIC_READ,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+			Drive[disk].FileHandle = CreateFile(FileName,GENERIC_READ,0,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 			Drive[disk].WriteProtect=0xFF;
 		}
 		if (Drive[disk].FileHandle==INVALID_HANDLE_VALUE)

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -31,7 +31,7 @@ This file is part of VCC (Virtual Color Computer).
 *																				*
 ********************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <winioctl.h>

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -42,10 +42,10 @@ This file is part of VCC (Virtual Color Computer).
 #include "fdrawcmd.h"	// http://simonowen.com/fdrawcmd/
 /****************Fuction Protos for this Module************/
 
-unsigned char GetBytefromSector (unsigned char);
-unsigned char GetBytefromAddress(unsigned char);
-unsigned char GetBytefromTrack  (unsigned char);
-unsigned char (*GetBytefromDisk)(unsigned char)=&GetBytefromSector;
+unsigned char GetBytefromSector ();
+unsigned char GetBytefromAddress();
+unsigned char GetBytefromTrack  ();
+unsigned char (*GetBytefromDisk)()=&GetBytefromSector;
 
 unsigned char WriteBytetoSector (unsigned char);
 unsigned char WriteBytetoTrack  (unsigned char);
@@ -136,7 +136,7 @@ unsigned char disk_io_read(unsigned char port)
 			if (CurrentCommand==IDLE)
 				temp=DataReg;
 			else
-				temp=GetBytefromDisk(0);
+				temp=GetBytefromDisk();
 			break;
 
 		case 0x40:	//Control Register can't be read
@@ -546,7 +546,7 @@ long WriteSector (	unsigned char Side,		//0 or 1
 
 long WriteTrack (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
-					unsigned char Dummy,	//Sector Value unused
+					unsigned char /*Dummy*/,	//Sector Value unused
 					unsigned char *WriteBuffer)
 {
 	unsigned char xTrack=0,xSide=0,xSector=0,xLenth=0;
@@ -646,7 +646,7 @@ long WriteTrack (	unsigned char Side,		//0 or 1
 
 long ReadTrack (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
-					unsigned char Dummy,	//Sector Value unused
+					unsigned char /*Dummy*/,	//Sector Value unused
 					unsigned char *WriteBuffer)
 {
 	unsigned long BytesRead=0,Result=0;
@@ -811,7 +811,7 @@ void PingFdc(void)
 			if (IOWaiter>WAITTIME)
 			{
 				LostDataFlag=1;
-				GetBytefromSector(0);
+				GetBytefromSector();
 			}
 		break;
 
@@ -830,7 +830,7 @@ void PingFdc(void)
 			if (IOWaiter>WAITTIME)
 			{
 				LostDataFlag=1;
-				GetBytefromAddress (0);	
+				GetBytefromAddress ();	
 			}
 		break;
 
@@ -841,7 +841,7 @@ void PingFdc(void)
 			if (IOWaiter>WAITTIME)
 			{
 				LostDataFlag=1;
-				GetBytefromTrack(0);
+				GetBytefromTrack();
 			}
 		break;
 
@@ -981,7 +981,7 @@ void DispatchCommand(unsigned char Tmp)
 	return;
 }
 
-unsigned char GetBytefromSector (unsigned char Tmp)
+unsigned char GetBytefromSector ()
 {
 	unsigned char RetVal=0;
 
@@ -1020,7 +1020,7 @@ unsigned char GetBytefromSector (unsigned char Tmp)
 	return RetVal;
 }
 
-unsigned char GetBytefromAddress (unsigned char Tmp)
+unsigned char GetBytefromAddress ()
 {
 	unsigned char RetVal=0;
 	unsigned short Crc=0;
@@ -1080,7 +1080,7 @@ unsigned char GetBytefromAddress (unsigned char Tmp)
 	return RetVal;
 }
 
-unsigned char GetBytefromTrack (unsigned char Tmp)
+unsigned char GetBytefromTrack ()
 {
 	unsigned char RetVal=0;
 

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -51,13 +51,13 @@ struct DiskInfo
 
 struct SectorInfo
 {
-	unsigned char Track;
-	unsigned char Side;
-	unsigned char Sector;
-	unsigned short Lenth;
-	unsigned short CRC;
-	long DAM;
-	unsigned char Density;
+	unsigned char Track = 0;
+	unsigned char Side = 0;
+	unsigned char Sector = 0;
+	unsigned short Lenth = 0;
+	unsigned short CRC = 0;
+	long DAM = 0;
+	unsigned char Density = 0;
 };
 
 

--- a/Fileops.cpp
+++ b/Fileops.cpp
@@ -122,13 +122,13 @@ DWORD WritePrivateProfileInt(LPCTSTR SectionName,LPCTSTR KeyName,int KeyValue,LP
 	return(WritePrivateProfileString(SectionName,KeyName,Buffer,IniFileName));
 }
 
-BOOL FilePrintf(HANDLE hFile, const void * fmt, ...)
+BOOL FilePrintf(HANDLE hFile, const char* fmt, ...)
 {
 	DWORD dummy;
 	va_list args;
 	char msg[512];
 	va_start(args, fmt);
-	vsnprintf(msg, 512, (char *)fmt, args);
+	vsnprintf(msg, 512, fmt, args);
 	va_end(args);
 	return WriteFile(hFile,msg,strlen(msg),&dummy,nullptr);
 }

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -14,9 +14,7 @@ Cartridge* Cartridge::m_Singleton(nullptr);
 Cartridge::Cartridge(std::string name, std::string catalogId)
 	:
 	m_Name(move(name)),
-	m_CatalogId(move(catalogId)),
-	AssetCartridgeLinePtr(detail::NullAssetCartridgeLine),
-	AddMenuItemPtr(detail::NullAddMenuItem)
+	m_CatalogId(move(catalogId))
 {
 	if (m_Singleton)
 	{

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -41,7 +41,7 @@ void Cartridge::LoadConfiguration(const std::string& /*filename*/)
 }
 
 
-void Cartridge::LoadMenu()
+void Cartridge::LoadMenuItems()
 {
 }
 
@@ -72,7 +72,7 @@ void Cartridge::SetConfigurationPath(std::string path)
 {
 	m_ConfigurationPath = move(path);
 	LoadConfiguration(m_ConfigurationPath);
-	LoadMenu();
+	LoadMenuItems();
 }
 
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -40,23 +40,23 @@ protected:
 		StandAlone
 	};
 
-	void AssetCartridgeLine(bool state)
+	void AssetCartridgeLine(bool state) const
 	{
 		AssetCartridgeLinePtr(state);
 	}
 
-	void AddMenuSeparator()
+	void AddMenuSeparator() const
 	{
 		AddMenuItem("", 6000, ItemType::Head);
 	}
 
-	void AddMenuItem(const std::string& name, int id, ItemType type)
+	void AddMenuItem(const std::string& name, int id, ItemType type) const
 	{
 		AddMenuItemPtr(name.c_str(), id, static_cast<int>(type));
 	}
 
 	virtual void LoadConfiguration(const std::string& filename);
-	virtual void LoadMenu();
+	virtual void LoadMenuItems();
 
 
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CartridgeTrampolines.h"
+#include "detail/default_handlers.h"
 #include <string>
 
 
@@ -80,6 +81,6 @@ private:
 	std::string			m_Name;
 	std::string			m_CatalogId;
 	std::string			m_ConfigurationPath;
-	SETCART				AssetCartridgeLinePtr;
-	DYNAMICMENUCALLBACK AddMenuItemPtr;
+	SETCART				AssetCartridgeLinePtr = detail::NullAssetCartridgeLine;
+	DYNAMICMENUCALLBACK AddMenuItemPtr = detail::NullAddMenuItem;
 };

--- a/GMC/GMC.h
+++ b/GMC/GMC.h
@@ -7,6 +7,8 @@
 #define GMC_EXPORT
 #endif
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void(*SETCART)(unsigned char);
 typedef void(*SETCARTPOINTER)(SETCART);
 typedef void(*DYNAMICMENUCALLBACK)(const char *, int, int);

--- a/GMC/GMCCartridge.cpp
+++ b/GMC/GMCCartridge.cpp
@@ -1,10 +1,6 @@
 #include "GMCCartridge.h"
 #include <Windows.h>
 
-#undef AddMenuSeparator
-
-#undef AddMenuItem
-#undef LoadMenu
 
 GMCCartridge::GMCCartridge()
 	: Cartridge("Game Master Catridge", "SN76489")
@@ -18,7 +14,7 @@ void GMCCartridge::LoadConfiguration(const std::string& filename)
 }
 
 
-void GMCCartridge::LoadMenu()
+void GMCCartridge::LoadMenuItems()
 {
 	AddMenuItem("", 0, ItemType::Head);
 	AddMenuSeparator();

--- a/GMC/GMCCartridge.h
+++ b/GMC/GMCCartridge.h
@@ -12,7 +12,6 @@ public:
 	GMCCartridge();
 
 	void LoadConfiguration(const std::string& filename) override;
-	void LoadMenu() override;
 
 	std::string GetStatusMessage() const override;
 	void OnMenuItemSelected(unsigned char menuId) override;
@@ -21,6 +20,12 @@ public:
 	unsigned char OnReadMemory(unsigned short address) const override;
 	void OnWritePort(unsigned char port, unsigned char data) override;
 	unsigned char OnReadPort(unsigned char port) const override;
+
+
+protected:
+
+	void LoadMenuItems() override;
+
 
 private:
 

--- a/GMC/ROM.cpp
+++ b/GMC/ROM.cpp
@@ -1,6 +1,6 @@
 #include "ROM.h"
 #include <fstream>
-#include <windows.h>
+#include <Windows.h>
 using namespace std;
 
 bool ROM::Load(std::string filename)

--- a/GMC/detail/default_handlers.h
+++ b/GMC/detail/default_handlers.h
@@ -1,0 +1,5 @@
+namespace detail
+{
+	void NullAssetCartridgeLine(unsigned char);
+	void NullAddMenuItem(const char*, int, int);
+}

--- a/GMC/gmc.vcxproj
+++ b/GMC/gmc.vcxproj
@@ -259,6 +259,7 @@
   <ItemGroup>
     <ClInclude Include="CartridgeTrampolines.h" />
     <ClInclude Include="Configuration.h" />
+    <ClInclude Include="detail\default_handlers.h" />
     <ClInclude Include="GMC.h" />
     <ClInclude Include="Cartridge.h" />
     <ClInclude Include="GMCCartridge.h" />

--- a/GMC/gmc.vcxproj.filters
+++ b/GMC/gmc.vcxproj.filters
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Cartridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CartridgeTrampolines.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Configuration.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="GMCCartridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ROM.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="sn76496.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="detail\default_handlers.h">
+      <Filter>Header Files\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="Cartridge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CartridgeTrampolines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Configuration.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GMC.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GMCCartridge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ROM.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="sn76496.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Resource Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{91041c29-a58e-47d1-be3c-2181e226240f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{1bc76e3c-f021-4d3d-9abc-d398f3daab81}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\detail">
+      <UniqueIdentifier>{9281fe40-ccf9-438e-b774-607516e595a9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{c2b09bad-8285-4ea1-9cde-aaaa010a2925}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="GMC.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/GMC/main.cpp
+++ b/GMC/main.cpp
@@ -1,5 +1,5 @@
 #include "GMCCartridge.h"
-#include <windows.h>
+#include <Windows.h>
 
 GMCCartridge theCart;
 
@@ -41,7 +41,7 @@ std::string SelectROMFile()
 		selectedPath.clear();
 	}
 
-	return move(selectedPath);
+	return selectedPath;
 }
 
 

--- a/GMC/sn76496.cpp
+++ b/GMC/sn76496.cpp
@@ -285,7 +285,7 @@ void SN76489Device::write(uint8_t data)
 	}
 }
 
-inline bool SN76489Device::in_noise_mode()
+inline bool SN76489Device::in_noise_mode() const
 {
 	return ((m_register[6] & 4) != 0);
 }

--- a/GMC/sn76496.cpp
+++ b/GMC/sn76496.cpp
@@ -143,14 +143,6 @@
 
 
 SN76489Device::SN76489Device()
-	: m_feedback_mask(0x4000)
-	, m_period_divider(6.11f)
-	, m_whitenoise_tap1(0x01)
-	, m_whitenoise_tap2(0x02)
-	, m_negate(false)	//	Was true!
-	, m_stereo(false)
-	, m_ncr_style_psg(false)
-	, m_sega_style_psg(true)
 {}
 
 

--- a/GMC/sn76496.h
+++ b/GMC/sn76496.h
@@ -28,25 +28,25 @@ private:
 	void            countdown_cycles();
 
 
-	const int32_t	m_feedback_mask;    // mask for feedback
-	const int32_t	m_whitenoise_tap1;  // mask for white noise tap 1 (higher one, usually bit 14)
-	const int32_t	m_whitenoise_tap2;  // mask for white noise tap 2 (lower one, usually bit 13)
-	const bool		m_negate;           // output negate flag
-	const bool		m_stereo;           // whether we're dealing with stereo or not
-	const float		m_period_divider;   // period divider
-	const bool		m_ncr_style_psg;    // flag to ignore writes to regs 1,3,5,6,7 with bit 7 low
-	const bool		m_sega_style_psg;   // flag to make frequency zero acts as if it is one more than max (0x3ff+1) or if it acts like 0; the initial register is pointing to 0x3 instead of 0x0; the volume reg is preloaded with 0xF instead of 0x0
+	const int32_t	m_feedback_mask = 0x4000;	// mask for feedback
+	const int32_t	m_whitenoise_tap1 = 0x01;	// mask for white noise tap 1 (higher one, usually bit 14)
+	const int32_t	m_whitenoise_tap2 = 0x02;	// mask for white noise tap 2 (lower one, usually bit 13)
+	const bool		m_negate = false;			// output negate flag
+	const bool		m_stereo = false;			// whether we're dealing with stereo or not
+	const float		m_period_divider = 6.11f;	// period divider
+	const bool		m_ncr_style_psg = false;	// flag to ignore writes to regs 1,3,5,6,7 with bit 7 low
+	const bool		m_sega_style_psg = true;	// flag to make frequency zero acts as if it is one more than max (0x3ff+1) or if it acts like 0; the initial register is pointing to 0x3 instead of 0x0; the volume reg is preloaded with 0xF instead of 0x0
 
-	int32_t         m_vol_table[16];    // volume table (for 4-bit to db conversion)
+	int32_t         m_vol_table[16] = { 0 };	// volume table (for 4-bit to db conversion)
 
-	bool            m_ready_state;
-	int32_t         m_cycles_to_ready;  // number of cycles until the READY line goes active
-	int32_t         m_register[8];      // registers
-	int32_t         m_last_register;    // last register written
-	uint32_t        m_RNG;              // noise generator LFSR
-	int32_t         m_stereo_mask;      // the stereo output mask
-	int32_t         m_period[4];        // Length of 1/2 of waveform
-	int32_t         m_volume[4];        // db volume of voice 0-2 and noise
-	int32_t         m_count[4];         // Position within the waveform
-	int32_t         m_output[4];        // 1-bit output of each channel, pre-volume
+	bool            m_ready_state = false;
+	int32_t         m_cycles_to_ready = 0;	// number of cycles until the READY line goes active
+	int32_t         m_register[8] = { 0 };	// registers
+	int32_t         m_last_register = 0;	// last register written
+	uint32_t        m_RNG = 0;				// noise generator LFSR
+	int32_t         m_stereo_mask = 0;		// the stereo output mask
+	int32_t         m_period[4] = { 0 };	// Length of 1/2 of waveform
+	int32_t         m_volume[4] = { 0 };	// db volume of voice 0-2 and noise
+	int32_t         m_count[4] = { 0 };		// Position within the waveform
+	int32_t         m_output[4] = { 0 };	// 1-bit output of each channel, pre-volume
 };

--- a/GMC/sn76496.h
+++ b/GMC/sn76496.h
@@ -11,6 +11,7 @@ public:
 	using stream_sample_t = unsigned short;
 
 	SN76489Device();
+	virtual ~SN76489Device() = default;
 
 	virtual void device_start();
 	virtual void write(uint8_t data);
@@ -23,7 +24,7 @@ protected:
 
 private:
 
-	inline bool     in_noise_mode();
+	inline bool     in_noise_mode() const;
 	void            countdown_cycles();
 
 

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -51,7 +51,7 @@ This file is part of VCC (Virtual Color Computer).
 *   Note: This is not an issue for Vcc.
 ****************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "cc3vhd.h"
 #include "harddisk.h"

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -56,7 +56,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "cc3vhd.h"
 #include "harddisk.h"
 #include "defines.h"
-#include "..\fileops.h"
+#include "../fileops.h"
 
 typedef union {
     unsigned int All;

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -102,15 +102,15 @@ int MountHD(const char* FileName, int drive)
     DMAaddress.word = 0;
     HardDrive[drive] = CreateFile( FileName,
                                    GENERIC_READ | GENERIC_WRITE,
-                                   0,0,OPEN_EXISTING,
-                                   FILE_ATTRIBUTE_NORMAL,0);
+                                   0,nullptr,OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL,nullptr);
 
     // If can't open read/write try read only.
     if (HardDrive[drive] == INVALID_HANDLE_VALUE) {
         HardDrive[drive] = CreateFile( FileName,
                                        GENERIC_READ,
-                                       0,0,OPEN_EXISTING,
-                                       FILE_ATTRIBUTE_NORMAL,0);
+                                       0,nullptr,OPEN_EXISTING,
+                                       FILE_ATTRIBUTE_NORMAL,nullptr);
         WpHD[drive]=1; // drive is write protected
     }
 
@@ -162,7 +162,7 @@ void HDcommand(unsigned char Command) {
         }
 
         // Seek desired sector
-        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,0,FILE_BEGIN);
+        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,nullptr,FILE_BEGIN);
 
         // Read it; zero fill if past end of file
         ReadFile(HardDrive[DriveSelect],SectorBuffer,SECTORSIZE,&BytesMoved,nullptr);
@@ -199,7 +199,7 @@ void HDcommand(unsigned char Command) {
         }
 
         // Seek desired sector
-        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,0,FILE_BEGIN);
+        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,nullptr,FILE_BEGIN);
 
         // Write it
         WriteFile(HardDrive[DriveSelect],SectorBuffer,SECTORSIZE,&BytesMoved,nullptr);

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -87,7 +87,7 @@ unsigned long BytesMoved=0;
 
 void HDcommand(unsigned char);
 
-int MountHD(char FileName[MAX_PATH], int drive)
+int MountHD(const char* FileName, int drive)
 {
     drive = drive&1;  // Drive can be 0 or 1
 

--- a/HardDisk/cc3vhd.h
+++ b/HardDisk/cc3vhd.h
@@ -35,19 +35,20 @@ void VhdReset(void);
 #define SLAVE 1
 #define STANDALONE 2
 
-//#define DRIVESIZE 130
-#define DRIVESIZE 512 // Mb
-#define MAX_SECTOR DRIVESIZE*1024*1024
-#define SECTORSIZE 256
+constexpr auto DRIVESIZE = 512u; // Mb
+constexpr auto MAX_SECTOR = DRIVESIZE * 1024 * 1024;
+constexpr auto SECTORSIZE = 256u;
 
-#define HD_OK        0
-#define HD_PWRUP    -1
-#define HD_INVLD    -2
-#define HD_NODSK     4
-#define HD_WP        5
+// FIXME: These need should probably be turned into a scoped enum.
+constexpr auto HD_OK	= 0;
+constexpr auto HD_PWRUP	= -1;
+constexpr auto HD_INVLD	= -2;
+constexpr auto HD_NODSK	= 4;
+constexpr auto HD_WP	= 5;
 
-#define SECTOR_READ     0
-#define SECTOR_WRITE    1
-#define DISK_FLUSH      2
+// FIXME: These need should probably be turned into a scoped enum.
+constexpr auto SECTOR_READ	= 0u;
+constexpr auto SECTOR_WRITE	= 1u;
+constexpr auto DISK_FLUSH	= 2u;
 
 #endif

--- a/HardDisk/cc3vhd.h
+++ b/HardDisk/cc3vhd.h
@@ -22,7 +22,7 @@ along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licens
 // cc3vhd.h
 
 void UnmountHD(int);
-int MountHD(char [256], int);
+int MountHD(const char*, int);
 unsigned char IdeRead(unsigned char);
 void IdeWrite (unsigned char, unsigned char);
 void DiskStatus(char *);

--- a/HardDisk/cloud9.cpp
+++ b/HardDisk/cloud9.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 *																		*
 ************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include "cloud9.h"
 
 static 	SYSTEMTIME now;

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -155,7 +155,7 @@ void CenterDialog(HWND hDlg)
     SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
-LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
     switch (message)
     {
@@ -404,7 +404,7 @@ void BuildDynaMenu(void)
 
 
 // Dialog for creating a new hard disk
-LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
     unsigned int hdsize=DEF_HD_SIZE;
     switch (message)

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -29,7 +29,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "../DialogOps.h"
 #include "../MachineDefs.h"
 
-#define DEF_HD_SIZE 132480
+constexpr auto DEF_HD_SIZE = 132480u;
 
 static char VHDfile0[MAX_PATH] { 0 };
 static char VHDfile1[MAX_PATH] { 0 };
@@ -38,6 +38,8 @@ static char NewVHDfile[MAX_PATH];
 static char IniFile[MAX_PATH]  { 0 };
 static char HardDiskPath[MAX_PATH];
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -437,7 +437,7 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 int CreateDisk(HWND hDlg, int hdsize)
 {
     HANDLE hr=CreateFile( NewVHDfile, GENERIC_READ | GENERIC_WRITE,
-                          0,0,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,0);
+                          0,nullptr,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,nullptr);
     if (hr==INVALID_HANDLE_VALUE) {
         *NewVHDfile='\0';
         MessageBox(hDlg,"Can't create File","Error",0);
@@ -445,7 +445,7 @@ int CreateDisk(HWND hDlg, int hdsize)
     }
 
     if (hdsize>0) {
-        SetFilePointer(hr, hdsize * 1024, 0, FILE_BEGIN);
+        SetFilePointer(hr, hdsize * 1024, nullptr, FILE_BEGIN);
         SetEndOfFile(hr);
     }
 

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -18,7 +18,7 @@ This file is part of VCC (Virtual Color Computer).
 
 // hardisk.cpp : Defines the entry point for the DLL application.
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include<iostream>
 #include "resource.h"

--- a/MachineDefs.h
+++ b/MachineDefs.h
@@ -9,24 +9,24 @@ namespace VCC
 	struct CPUState
 	{
 		//  
-		unsigned char DP;
-		unsigned char CC;
-		unsigned char MD;
+		unsigned char DP = 0;
+		unsigned char CC = 0;
+		unsigned char MD = 0;
 		//
-		unsigned char A;
-		unsigned char B;
-		unsigned char E;
-		unsigned char F;
-		unsigned short X;
-		unsigned short Y;
-		unsigned short U;
-		unsigned short S;
-		unsigned short PC;
-		unsigned short V;
+		unsigned char A = 0;
+		unsigned char B = 0;
+		unsigned char E = 0;
+		unsigned char F = 0;
+		unsigned short X = 0;
+		unsigned short Y = 0;
+		unsigned short U = 0;
+		unsigned short S = 0;
+		unsigned short PC = 0;
+		unsigned short V = 0;
 		//
-		bool IsNative6309;
-		bool phyAddr;               // Decode using block relative addressing
-		unsigned short block;       // Physical address = PC + block * 0x2000
+		bool IsNative6309 = false;
+		bool phyAddr = false;		// Decode using block relative addressing
+		unsigned short block = 0;	// Physical address = PC + block * 0x2000
 	};
 
 	// Trace Events
@@ -54,19 +54,19 @@ namespace VCC
 	// CPU Execution Tracing
 	struct CPUTrace
 	{
-		TraceEvent event;					// Trace Event type
-		int frame;							// Frame being rendered
-		int line;							// Line being rendered
-		long cycleTime;						// Time since Trace start in CPU cycles
-		unsigned short pc;					// Program Counter at time of event
+		TraceEvent event = TraceEvent::Instruction;	// Trace Event type
+		int frame = 0;						// Frame being rendered
+		int line = 0;						// Line being rendered
+		long cycleTime = 0;					// Time since Trace start in CPU cycles
+		unsigned short pc = 0;				// Program Counter at time of event
 		std::vector<unsigned char> bytes;	// Op code bytes
 		std::string instruction;			// Instruction
 		std::string operand;				// Instruction Operand
 		CPUState startState;				// CPU State before instruction
 		CPUState endState;					// CPU State after instruction
-		int execCycles;						// Number of cycles indicated by emulator
-		int decodeCycles;					// Number of cycles from OpDecoder
-		int emulationState;					// State switch in emulation cycles
+		int execCycles = 0;					// Number of cycles indicated by emulator
+		int decodeCycles = 0;				// Number of cycles from OpDecoder
+		int emulationState = 0;				// State switch in emulation cycles
 		std::vector<double> emulator;		// Emulation Tracing
 	};
 

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -466,13 +466,13 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	std::string OpCodeTables::ToInterRegister(unsigned char reg)
+	std::string OpCodeTables::ToInterRegister(unsigned char reg) const
 	{
 		std::vector<std::string> regs = { "D", "X", "Y", "U", "S", "PC", "W", "V", "A", "B", "CC", "DP", "0", "0", "E", "F" };
 		return regs[reg];
 	}
 
-	std::string OpCodeTables::ToRegister(unsigned char postbyte)
+	std::string OpCodeTables::ToRegister(unsigned char postbyte) const
 	{
 		int reg = (postbyte & 0b01100000) >> 5;
 		switch (reg)
@@ -489,7 +489,7 @@ namespace VCC { namespace Debugger
 		return "?";
 	}
 
-	std::string OpCodeTables::ToRelativeAddressString(int value, int oplen, int operandlen)
+	std::string OpCodeTables::ToRelativeAddressString(int value, int oplen, int operandlen) const
 	{
 		std::ostringstream fmt;
 
@@ -522,7 +522,7 @@ namespace VCC { namespace Debugger
 		return fmt.str();
 	}
 
-	int OpCodeTables::AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309)
+	int OpCodeTables::AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309) const
 	{
 		if (IsNative6309)
 		{

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -105,7 +105,7 @@ namespace VCC { namespace Debugger
 		case Indexed:
 			break;
 		case Relative:
-			trace.operand = ToRelativeAddressString(operand, opcode.oplen, operandLen);
+			trace.operand = ToRelativeAddressString(operand, operandLen);
 			break;
 		case Extended:
 			trace.operand = "$" + ToHexString(operand, 4);
@@ -305,7 +305,7 @@ namespace VCC { namespace Debugger
 
 		// All long branches are relative.
 		int operand = (trace.bytes[opcode.oplen] << 8) + trace.bytes[opcode.oplen + 1];
-		trace.operand = ToRelativeAddressString(operand, opcode.oplen, operandLen);
+		trace.operand = ToRelativeAddressString(operand, operandLen);
 
 		// No adjustment needed on 6309 
 		if (state.IsNative6309)
@@ -489,7 +489,7 @@ namespace VCC { namespace Debugger
 		return "?";
 	}
 
-	std::string OpCodeTables::ToRelativeAddressString(int value, int oplen, int operandlen) const
+	std::string OpCodeTables::ToRelativeAddressString(int value, int operandlen) const
 	{
 		std::ostringstream fmt;
 

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -26,7 +26,7 @@
 
 namespace VCC { namespace Debugger
 {
-	bool OpCodeTables::ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		bool valid = true;
 		trace.decodeCycles = state.IsNative6309 ? opcode.num6309cycles : opcode.num6809cycles;

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -66,7 +66,7 @@ namespace VCC { namespace Debugger
 		return valid;
 	}
 
-	bool OpCodeTables::ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -134,7 +134,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -190,7 +190,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand)
+	bool OpCodeTables::GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand) const
 	{
 		// Convert to key.
 		std::string key = std::bitset<8>(postbyte).to_string();
@@ -198,7 +198,7 @@ namespace VCC { namespace Debugger
 		// MSB = 0?  5 bit offset.
 		if (key[0] == '0')
 		{
-			mode = IndexingModes["0RRnnnnn"];
+			mode = IndexingModes.at("0RRnnnnn");
 			operand = mode.form;
 
 			// Determine the register.
@@ -215,7 +215,7 @@ namespace VCC { namespace Debugger
 		// Try exact match.
 		if (IndexingModes.find(key) != IndexingModes.end())
 		{
-			mode = IndexingModes[key];
+			mode = IndexingModes.at(key);
 			operand = mode.form;
 			return true;
 		}
@@ -225,7 +225,7 @@ namespace VCC { namespace Debugger
 		key[2] = 'X';
 		if (IndexingModes.find(key) != IndexingModes.end())
 		{
-			mode = IndexingModes[key];
+			mode = IndexingModes.at(key);
 			operand = mode.form;
 			return true;
 		}
@@ -235,7 +235,7 @@ namespace VCC { namespace Debugger
 		key[2] = 'R';
 		if (IndexingModes.find(key) != IndexingModes.end())
 		{
-			mode = IndexingModes[key];
+			mode = IndexingModes.at(key);
 			operand = mode.form;
 			replace(operand, "R", ToRegister(postbyte));
 			return true;
@@ -245,13 +245,13 @@ namespace VCC { namespace Debugger
 		return false;
 	}
 
-	bool OpCodeTables::ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		trace.decodeCycles = AdjustCycles(opcode, 0, 0, state.IsNative6309);
 		return true;
 	}
 
-	bool OpCodeTables::ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -288,7 +288,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -373,7 +373,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -406,7 +406,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Two rules:
 		//	1) DIVD executes in l fewer cycle if a two's-complement overflow occurs. 
@@ -460,7 +460,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		trace.decodeCycles = AdjustCycles(opcode, 0, 0, state.IsNative6309);
 		return true;

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -916,7 +916,7 @@ namespace VCC { namespace Debugger
 			bool only6309;				// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
-		std::map<std::string, IndexModeInfo> IndexingModes = 
+		const std::map<std::string, IndexModeInfo> IndexingModes = 
 		{ 
 			{ "1RR00100", {"1RR00100", ",R",		0,	0,	0,	false } },
 			{ "0RRnnnnn", {"0RRnnnnn", "n,R",		1,	1,	0,	false } },
@@ -965,18 +965,18 @@ namespace VCC { namespace Debugger
 
 	protected:
 
-		bool ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
+		bool ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
 
 		int AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309) const;
 
-		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand);
+		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand) const;
 		std::string ToRegister(unsigned char postbyte) const;
 		std::string ToInterRegister(unsigned char reg) const;
 		std::string ToRelativeAddressString(int value, int oplen, int operandlen) const;

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -974,12 +974,12 @@ namespace VCC { namespace Debugger
 		bool ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
 		bool ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
 
-		int AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309);
+		int AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309) const;
 
 		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand);
-		std::string ToRegister(unsigned char postbyte);
-		std::string ToInterRegister(unsigned char reg);
-		std::string ToRelativeAddressString(int value, int oplen, int operandlen);
+		std::string ToRegister(unsigned char postbyte) const;
+		std::string ToInterRegister(unsigned char reg) const;
+		std::string ToRelativeAddressString(int value, int oplen, int operandlen) const;
 
 	};
 }}

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -979,7 +979,7 @@ namespace VCC { namespace Debugger
 		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand) const;
 		std::string ToRegister(unsigned char postbyte) const;
 		std::string ToInterRegister(unsigned char reg) const;
-		std::string ToRelativeAddressString(int value, int oplen, int operandlen) const;
+		std::string ToRelativeAddressString(int value, int operandlen) const;
 
 	};
 }}

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -910,10 +910,10 @@ namespace VCC { namespace Debugger
 		{
 			std::string postbyte;		// 8-bit postbyte key
 			std::string form;			// Assembler form
-			int num6809cycles;			// Additional number of cycles (6809 only and 6309 in emulation)
-			int num6309cycles;			// Additional number of cycles (6309 native only)
-			int numbytes;				// Additional number of bytes
-			bool only6309;				// Valid only if running a 6309, in other words, invalid on a 6809
+			int num6809cycles = 0;		// Additional number of cycles (6809 only and 6309 in emulation)
+			int num6309cycles = 0;		// Additional number of cycles (6309 native only)
+			int numbytes = 0;			// Additional number of bytes
+			bool only6309 = 0;			// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
 		const std::map<std::string, IndexModeInfo> IndexingModes = 

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -961,7 +961,7 @@ namespace VCC { namespace Debugger
 	public:
 
 		// Calculate the exact number of cycles based on CPU state
-		bool ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
+		bool ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
 
 	protected:
 

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -913,7 +913,7 @@ namespace VCC { namespace Debugger
 			int num6809cycles = 0;		// Additional number of cycles (6809 only and 6309 in emulation)
 			int num6309cycles = 0;		// Additional number of cycles (6309 native only)
 			int numbytes = 0;			// Additional number of bytes
-			bool only6309 = 0;			// Valid only if running a 6309, in other words, invalid on a 6809
+			bool only6309 = false;		// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
 		const std::map<std::string, IndexModeInfo> IndexingModes = 

--- a/OpDecoder.cpp
+++ b/OpDecoder.cpp
@@ -119,7 +119,7 @@ namespace VCC { namespace Debugger
 		return TraceCaptured_.size();
 	}
 
-	OpDecoder::IRQType OpDecoder::ToIRQType(unsigned char irq)
+	OpDecoder::IRQType OpDecoder::ToIRQType(unsigned char irq) const
 	{
 		switch (irq)
 		{
@@ -133,7 +133,7 @@ namespace VCC { namespace Debugger
 		return IRQType();
 	}
 
-	bool OpDecoder::DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt)
+	bool OpDecoder::DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt) const
 	{
 		switch (irq)
 		{

--- a/OpDecoder.h
+++ b/OpDecoder.h
@@ -52,13 +52,13 @@ namespace VCC { namespace Debugger
 
 		size_t GetSampleCount() const;
 
-		IRQType ToIRQType(unsigned char irq);
+		IRQType ToIRQType(unsigned char irq) const;
 
 		bool DecodeInstruction(const CPUState& state, CPUTrace& trace);
 
 	protected:
 
-		bool DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt);
+		bool DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt) const;
 		bool DecodeScreen(TraceEvent evt, std::string& screen);
 		bool DecodePage2Instruction(unsigned short PC, const CPUState& state, CPUTrace& trace);
 		bool DecodePage3Instruction(unsigned short PC, const CPUState& state, CPUTrace& trace);

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -21,6 +21,8 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 #include "memboard.h"
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -16,7 +16,7 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include "resource.h" 
 #include "defines.h"
 #include "memboard.h"

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -79,7 +79,6 @@ extern "C"
 			default:
 				return;
 		}	//End port switch		
-		return;
 	}
 }
 

--- a/Ramdisk/memboard.cpp
+++ b/Ramdisk/memboard.cpp
@@ -16,7 +16,7 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "memboard.h"
 

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -17,9 +17,9 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 #include "logger.h"
-#include "idebus.h"
+#include "IdeBus.h"
 #include <stdio.h>
-#include <windows.h>
+#include <Windows.h>
 
 static unsigned int Lba=0,LastLba;
 char Message[256]="";	//DEBUG

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -81,7 +81,7 @@ void IdeRegWrite(unsigned char Reg,unsigned short Data)
 			{
 				if ((CurrentCommand==0x30) | (CurrentCommand==0x31))
 				{
-					SetFilePointer(hDiskFile[DiskSelect],Lba*512,0,FILE_BEGIN);
+					SetFilePointer(hDiskFile[DiskSelect],Lba*512,nullptr,FILE_BEGIN);
 					WriteFile(hDiskFile[DiskSelect],XferBuffer,512,&BytesMoved,nullptr);
 				}
 				BufferIndex=0;
@@ -213,7 +213,7 @@ void ExecuteCommand(void)
 			BufferLenth=512;
 			BufferIndex=0;
 			Registers.Status[DiskSelect]=DRQ|RDY;
-			SetFilePointer(hDiskFile[DiskSelect],Lba*512,0,FILE_BEGIN);
+			SetFilePointer(hDiskFile[DiskSelect],Lba*512,nullptr,FILE_BEGIN);
 			memset(XferBuffer,0,512);
 			ReadFile(hDiskFile[DiskSelect],XferBuffer,512,&BytesMoved,nullptr);
 			LastLba=Lba;
@@ -282,13 +282,13 @@ HANDLE OpenDisk(char *ImageFile,unsigned char DiskNum)
 
 	strncpy(SerialNumber,ImageFile,20);
 
-	hTemp=CreateFile( ImageFile,GENERIC_READ | GENERIC_WRITE,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+	hTemp=CreateFile( ImageFile,GENERIC_READ | GENERIC_WRITE,0,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 	if (hTemp==INVALID_HANDLE_VALUE)
 		return hTemp;
 
 	Registers.Status[DiskNum]=RDY;
 	Registers.Error[DiskNum]=0;
-	FileSize=SetFilePointer(hTemp,0,0,FILE_END);
+	FileSize=SetFilePointer(hTemp,0,nullptr,FILE_END);
 	LbaSectors=FileSize>>9;
 	//Build Disk ID return Buffer
 	ByteSwap(Model);

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -31,6 +31,8 @@ This file is part of VCC (Virtual Color Computer).
 static char FileName[MAX_PATH] { 0 };
 static char IniFile[MAX_PATH]  { 0 };
 static char SuperIDEPath[MAX_PATH];
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -219,7 +219,7 @@ void BuildDynaMenu(void)
 	DynamicMenuCallback("",1,0);
 }
 
-LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	unsigned char BTemp=0;
 	switch (message)

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -16,17 +16,17 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include "stdio.h"
 #include <iostream>
 #include "resource.h" 
 #include "defines.h"
-#include "Superide.h"
-#include "idebus.h"
+#include "SuperIDE.h"
+#include "IdeBus.h"
 #include "cloud9.h"
 #include "logger.h"
 #include "../fileops.h"
-#include "../dialogops.h"
+#include "../DialogOps.h"
 
 static char FileName[MAX_PATH] { 0 };
 static char IniFile[MAX_PATH]  { 0 };

--- a/SuperIDE/cloud9.cpp
+++ b/SuperIDE/cloud9.cpp
@@ -25,7 +25,7 @@ This file is part of VCC (Virtual Color Computer).
 *																		*
 ************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include "cloud9.h"
 
 static 	SYSTEMTIME now;

--- a/SuperIDE/logger.cpp
+++ b/SuperIDE/logger.cpp
@@ -37,7 +37,7 @@ void WriteLog(char *Message,unsigned char Type)
 			SetConsoleTitle("Logging Window"); 
 		}
 		sprintf(cTemp,"%s",Message);
-		WriteConsole(hout,cTemp,strlen(cTemp),&dummy,0);
+		WriteConsole(hout,cTemp,strlen(cTemp),&dummy,nullptr);
 		Counter++;
 		break;
 

--- a/SuperIDE/logger.cpp
+++ b/SuperIDE/logger.cpp
@@ -15,7 +15,7 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 
 #include "logger.h"

--- a/SuperIDE/logger.h
+++ b/SuperIDE/logger.h
@@ -20,6 +20,7 @@ This file is part of VCC (Virtual Color Computer).
 
 void WriteLog(char *,unsigned char);
 
+// FIXME: These should be a scoped enum
 #define TOCONS	0
 #define TOFILE	1
 

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -431,7 +431,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	        OEMscan = (unsigned char) ((lParam >> 16) & 0xFF);
             Extended=(lParam >> 24) & 1;
 		    if (Extended && (OEMscan!=DIK_NUMLOCK)) OEMscan += 0x80;
-			vccKeyboardHandleKey(kb_char,OEMscan,kEventKeyUp);
+			vccKeyboardHandleKey(OEMscan,kEventKeyUp);
 			
 			return 0;
 			break;
@@ -555,7 +555,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					// send shift and other keystrokes to the emulator if it is active
 					if ( EmuState.EmulationRunning )
 					{
-						vccKeyboardHandleKey(kb_char, OEMscan, kEventKeyDown);
+						vccKeyboardHandleKey(OEMscan, kEventKeyDown);
 						// Save key down in case focus is lost
 						save_key_down(kb_char,OEMscan);
 					}
@@ -666,8 +666,8 @@ void save_key_down(unsigned char kb_char, unsigned char OEMscan) {
 
 // Send key up events to keyboard handler for saved keys
 void raise_saved_keys() {
-	if (SC_save1) vccKeyboardHandleKey(KB_save1,SC_save1,kEventKeyUp);
-	if (SC_save2) vccKeyboardHandleKey(KB_save2,SC_save2,kEventKeyUp);
+	if (SC_save1) vccKeyboardHandleKey(SC_save1,kEventKeyUp);
+	if (SC_save2) vccKeyboardHandleKey(SC_save2,kEventKeyUp);
 	SC_save1 = 0;
 	SC_save2 = 0;
 	return;

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -30,6 +30,7 @@ This file is part of VCC (Virtual Color Computer).
 //#define ABOVE_NORMAL_PRIORITY_CLASS  32768
 #endif
 
+// FIXME: These defines need to be converted to a scoped enumeration
 #define TH_RUNNING	0
 #define TH_REQWAIT	1
 #define TH_WAITING	2

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -779,7 +779,7 @@ void SoftReset(void)
 }
 
 // Message handler for the About box.
-BOOL CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+BOOL CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -799,7 +799,7 @@ BOOL CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 }
 
 // Message handler for function key help.
-BOOL CALLBACK FunctionKeys(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+BOOL CALLBACK FunctionKeys(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -1029,7 +1029,7 @@ void LoadPack(void)
 	_beginthreadex( nullptr, 0, &CartLoad, CreateEvent( nullptr, FALSE, FALSE, nullptr ), 0, &threadID );
 }
 
-unsigned __stdcall CartLoad(void *Dummy)
+unsigned __stdcall CartLoad(void* /*Dummy*/)
 {
 	LoadCart();
 	EmuState.EmulationRunning=TRUE;

--- a/_xDebug.cpp
+++ b/_xDebug.cpp
@@ -36,17 +36,17 @@ void _xDbgTrace(const void * pFile, const int iLine, const void * pFormat, ...)
 	fflush(stdout);
 }
 #else
-void _xDbgTrace(const void * pFile, const int iLine, const void * pFormat, ...)
+void _xDbgTrace(const char* pFile, const int iLine, const char* pFormat, ...)
 {
 	va_list		args;
 	char temp[1024];
 
 	va_start(args, pFormat);
 
-	sprintf(temp, "%s(%d) : ", (char *)pFile, iLine);
+	sprintf(temp, "%s(%d) : ", pFile, iLine);
 	OutputDebugString(temp);
 
-	vsprintf(temp, (char *)pFormat, args);
+	vsprintf(temp, pFormat, args);
 	OutputDebugString(temp);
 
 	va_end(args);

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -203,7 +203,7 @@ __declspec(dllexport) void ModuleStatus(char *status)
 //  Dll export run config dialog
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void ModuleConfig(unsigned char MenuID)
+__declspec(dllexport) void ModuleConfig(unsigned char /*MenuID*/)
 {
     HWND owner = GetActiveWindow();
     CreateDialog(g_hDLL,(LPCTSTR)IDD_PROPPAGE,owner,(DLGPROC)Config);
@@ -314,7 +314,7 @@ void SaveConfig(void)
 //   IDC_TEXTMODE  Translate CR <> CRLF if checked
 //-----------------------------------------------------------------------
 
-LRESULT CALLBACK Config(HWND hDlg,UINT msg,WPARAM wParam,LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg,UINT msg,WPARAM wParam,LPARAM /*lParam*/)
 {
     int button;
     HWND hCtl;

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -29,6 +29,8 @@
 // Local Functions
 //------------------------------------------------------------------------
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 // Transfer points for menu callback and cpu assert interrupt
 typedef void (*DYNAMICMENUCALLBACK)(const char * ,int, int);
 typedef void (*ASSERTINTERUPT)(unsigned char, unsigned char);

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -17,21 +17,20 @@
 // (Virtual Color Computer). If not see <http://www.gnu.org/licenses/>.
 //
 //------------------------------------------------------------------
-
 #ifndef __ACIA_H_
 #define __ACIA_H_
 
 // FIXME: This should be defined on the command line
 #define DIRECTINPUT_VERSION 0x0800
-
-constexpr auto MAX_LOADSTRING = 200u;
-
 #include <windows.h>
 #include <windowsx.h>
 #include <stdio.h>
 #include <conio.h>
 #include <dinput.h>
 #include "resource.h"
+
+constexpr auto MAX_LOADSTRING = 200u;
+
 
 // Dynamic menu control
 // FIXME: These need to be turned into an enum and the signature of functions

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -22,7 +22,7 @@
 
 // FIXME: This should be defined on the command line
 #define DIRECTINPUT_VERSION 0x0800
-#include <windows.h>
+#include <Windows.h>
 #include <windowsx.h>
 #include <stdio.h>
 #include <conio.h>

--- a/acia/console.cpp
+++ b/acia/console.cpp
@@ -46,7 +46,6 @@ void console_cleol();
 void console_cleob();
 void console_cr();
 void console_eraseline();
-int  console_trans_color(int);
 void console_background(int);
 void console_forground(int);
 
@@ -139,7 +138,7 @@ int console_read(char * buf, int len) {
     }
 
     // If not line mode loop until at least one key press is found
-    while (1) {
+    for(;;) {
 
         // If Event buffer is empty load it (blocks)
         if (Event_Cnt < 1) {

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -159,7 +159,7 @@ void sc6551_close()
 //------------------------------------------------------------------------
 // Input thread
 //------------------------------------------------------------------------
-DWORD WINAPI sc6551_input_thread(LPVOID param)
+DWORD WINAPI sc6551_input_thread(LPVOID /*param*/)
 {
 	// FIXME: This is needed and should not be commented out. Wrap it conditional
 	// either here or in the debug log functions.
@@ -199,7 +199,7 @@ DWORD WINAPI sc6551_input_thread(LPVOID param)
 //------------------------------------------------------------------------
 // Output thread.
 //------------------------------------------------------------------------
-DWORD WINAPI sc6551_output_thread(LPVOID param)
+DWORD WINAPI sc6551_output_thread(LPVOID /*param*/)
 {
     Wcnt = 0;
     OutWptr = OutBuf;

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -39,14 +39,14 @@ unsigned char CmdReg;
 unsigned char CtlReg;
 
 // Input
-#define IBUFSIZ 1024
+constexpr auto IBUFSIZ = 1024u;
 DWORD WINAPI sc6551_input_thread(LPVOID);
 char InBuf[IBUFSIZ];
 char *InRptr = InBuf;
 int Icnt = 0;
 
 // Output
-#define OBUFSIZ 1024
+constexpr auto OBUFSIZ = 1024u;
 DWORD WINAPI sc6551_output_thread(LPVOID);
 char OutBuf[OBUFSIZ];
 char *OutWptr = OutBuf;

--- a/acia/tcpip.cpp
+++ b/acia/tcpip.cpp
@@ -24,8 +24,8 @@
 
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "acia.h"
 #include "../logger.h"

--- a/audio.h
+++ b/audio.h
@@ -24,7 +24,6 @@ void FlushAudioBuffer ( unsigned int *,unsigned int);
 void ResetAudio (void);
 unsigned char PauseAudio(unsigned char Pause);
 int GetFreeBlockCount(void);
-int GetAuxBlockCount(void);
 void PurgeAuxBuffer(void);
 unsigned int GetSoundStatus(void);
 struct SndCardList

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -111,9 +111,9 @@ unsigned char dw_status( void )
         // check for input data waiting
 
         if (retry | (dwSocket == 0) | (InReadPos == InWritePos))
-                return(0);
+                return 0;
         else
-                return(1);
+                return 1;
 }
 
 
@@ -130,7 +130,7 @@ unsigned char dw_read( void )
 
         BytesReadSince++;
 
-        return(dwdata);
+        return dwdata;
 }
 
 
@@ -160,7 +160,7 @@ int dw_write( char dwdata)
 	              WriteLog(msg,TOCONS);
 	     }
 
-        return(0);
+        return 0;
 }
 
 
@@ -186,7 +186,7 @@ void killDWTCPThread(void)
 int dw_setaddr(char *bufdwaddr)
 {
         strcpy(dwaddress,bufdwaddr);
-        return(0);
+        return 0;
 }
 
 
@@ -201,7 +201,7 @@ int dw_setport(char *bufdwport)
                 killDWTCPThread();
         }
 
-        return(0);
+        return 0;
 }
 
 
@@ -285,7 +285,7 @@ unsigned __stdcall DWTCPThread(void *Dummy)
         {
                 WriteLog("WSAStartup() failed, DWTCPConnection thread exiting\n",TOCONS);
                 WSACleanup();
-                return(0);
+                return 0;
         }
         
         
@@ -346,7 +346,7 @@ unsigned __stdcall DWTCPThread(void *Dummy)
         dwSocket = 0;
 
         _endthreadex(0);
-        return(0);
+        return 0;
 }
 
 
@@ -455,9 +455,9 @@ void SetDWTCPConnectionEnable(unsigned int enable)
 			// read status
 			case 0x41:
 				if (dw_status() != 0)
-					return(2);
+					return 2;
 				else
-					return(0);
+					return 0;
 				break;
 			// read data 
 			case 0x42:
@@ -479,7 +479,7 @@ void SetDWTCPConnectionEnable(unsigned int enable)
 	{
 		
 		PakSetCart=Pointer;
-		return(0);
+		return 0;
 	}
 
 	__declspec(dllexport) unsigned char PakMemRead8(unsigned short Address)
@@ -731,5 +731,5 @@ unsigned char LoadExtRom( char *FilePath)	//Returns 1 on if loaded
 		RetVal = 1;
 		fclose(rom_handle);
 	}
-	return(RetVal);
+	return RetVal;
 }

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -1,13 +1,13 @@
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <process.h>
 #include <stdio.h>
-#include "..\logger.h"
+#include "../logger.h"
 #include "becker.h"
 #include "resource.h" 
-#include "..\fileops.h"
+#include "../fileops.h"
 
 // socket
 static SOCKET dwSocket = 0;

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -13,6 +13,7 @@
 static SOCKET dwSocket = 0;
 
 // vcc stuff
+// FIXME: These typedefs are also duplicated everywhere and need to be consolidated in one place.
 typedef void (*SETCART)(unsigned char);
 typedef void (*SETCARTPOINTER)(SETCART);
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);

--- a/becker/becker.h
+++ b/becker/becker.h
@@ -1,9 +1,11 @@
 #ifndef __BECKER_H__
 #define __BECKER_H__
 
+#ifndef __cplusplus
 #define bool int
 #define true 1
 #define false 0
+#endif
 
 // functions
 void MemWrite(unsigned char,unsigned short );

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -56,7 +56,7 @@ AudioHistory gAudioHistory[AudioHistorySize];
 int gAudioHistoryCount = 0;
 #endif
 
-#define RENDERS_PER_BLINK_TOGGLE 16
+constexpr auto RENDERS_PER_BLINK_TOGGLE = 16u;
 
 //****************************************
 	static double SoundInterupt=0;

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -232,7 +232,7 @@ float RenderFrame (SystemState *RFState)
 
 	if (!(FrameCounter % RFState->FrameSkip))
 	{
-		if (LockScreen(RFState))
+		if (LockScreen())
 			return 0;
 	}
 
@@ -267,7 +267,7 @@ float RenderFrame (SystemState *RFState)
 	{
 		DrawBottomBoarder[RFState->BitDepth](RFState);
 		UnlockScreen(RFState);
-		SetBoarderChange(0);
+		SetBoarderChange();
 	}
 
 	// Bottom Border continues but is offscreen

--- a/config.cpp
+++ b/config.cpp
@@ -137,7 +137,7 @@ unsigned char TapeFastLoad = 1;
 char Tmodes[4][10]={"STOP","PLAY","REC","STOP"};
 static int NumberOfSoundCards=0;
 
-#define MAXSOUNDCARDS 12
+constexpr auto MAXSOUNDCARDS = 12u;
 static SndCardList SoundCards[MAXSOUNDCARDS];
 
 CHARFORMAT CounterText;
@@ -152,7 +152,7 @@ const char * const keyNames[] = {
 		"'","Comma",".","/","CapsLk","Shift","Ctrl","Alt","Space","Enter",
 		"Insert","Delete","Home","End","PgUp","PgDown","Left","Right",
 		"Up","Down","F1","F2"};
-#define SCAN_TRANS_COUNT 84
+constexpr auto SCAN_TRANS_COUNT = 84u;
 unsigned char _TranslateDisp2Scan[SCAN_TRANS_COUNT];
 unsigned char _TranslateScan2Disp[SCAN_TRANS_COUNT] = {
 		0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,32,38,20,33,35,40,36,24,30,

--- a/config.cpp
+++ b/config.cpp
@@ -1568,7 +1568,7 @@ LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lPar
 /********************************************/
 /*               Paths Config               */
 /********************************************/
-LRESULT CALLBACK Paths(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Paths(HWND /*hDlg*/, UINT /*message*/, WPARAM /*wParam*/, LPARAM /*lParam*/)
 {
 	return 1;
 }

--- a/config.cpp
+++ b/config.cpp
@@ -482,7 +482,7 @@ void OpenCpuConfig() {
 	SetFocus(hCpuDlg);
 }
 
-LRESULT CALLBACK CpuConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK CpuConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	short int Ramchoice[4] = {IDC_128K,IDC_512K,IDC_2M,IDC_8M};
 	short int Cpuchoice[2] = {IDC_6809,IDC_6309};
@@ -685,7 +685,7 @@ void OpenTapeConfig() {
 	ShowWindow(hTapeDlg,SW_SHOWNORMAL);
 	SetFocus(hTapeDlg);
 }
-LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	CounterText.cbSize = sizeof(CHARFORMAT);
 	CounterText.dwMask = CFM_BOLD | CFM_COLOR ;
@@ -808,7 +808,7 @@ void OpenAudioConfig() {
 	SetFocus(hAudioDlg);
 }
 
-LRESULT CALLBACK AudioConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK AudioConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	int Index;
 	static STRConfig tmpcfg;
@@ -933,7 +933,7 @@ void OpenDisplayConfig() {
 	SetFocus(hDisplayDlg);
 }
 
-LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	static STRConfig tmpcfg;
 	switch (message) {
@@ -1071,7 +1071,7 @@ void OpenInputConfig() {
 	ShowWindow(hInputDlg,SW_SHOWNORMAL);
 	SetFocus(hInputDlg);
 }
-LRESULT CALLBACK InputConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK InputConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
     switch (message) {
     case WM_INITDIALOG:
@@ -1199,7 +1199,7 @@ void OpenJoyStickConfig() {
 	SetFocus(hJoyStickDlg);
 }
 
-LRESULT CALLBACK JoyStickConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK JoyStickConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	static STRConfig tmpcfg;
     static JoyStick TempLeftJS, TempRightJS;
@@ -1504,7 +1504,7 @@ void OpenBitBangerConfig() {
 	ShowWindow(hBitBangerDlg,SW_SHOWNORMAL);
 	SetFocus(hBitBangerDlg);
 }
-LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message) {
 	case WM_INITDIALOG: //IDC_PRINTMON

--- a/config.h
+++ b/config.h
@@ -37,14 +37,12 @@ void SetIniFilePath(const char *);
 void SetKeyMapFilePath(const char *);
 char * AppDirectory();
 char * GetKeyMapFilePath();
-char * KeyMapFiledir();
 
 int GetPaletteType();
 enum PALETTETYPE {PALETTE_ORIG=0, PALETTE_UPD=1, PALETTE_NTSC=2};
 
 const VCC::Rect& GetIniWindowRect();
 int GetRememberSize();
-void SetConfigPath(int, string);
 void SwapJoySticks();
 
 void DecreaseOverclockSpeed();
@@ -54,7 +52,6 @@ void SetOverclock(unsigned char);
 // Openers for config dialogs
 void OpenAudioConfig();
 void OpenCpuConfig();
-void OpenMiscConfig();
 void OpenDisplayConfig();
 void OpenInputConfig();
 void OpenJoyStickConfig();

--- a/defines.h
+++ b/defines.h
@@ -35,15 +35,15 @@ constexpr auto SAMPLESPERFRAME = 262u;
 
 
 //CPU 
-#define FRAMESPERSECORD (double)59.923	//The coco really runs at about 59.923 Frames per second
-#define LINESPERSCREEN (double)262
-#define NANOSECOND (double)1000000000
-#define COLORBURST (double)3579545 
-#define AUDIOBUFFERS 12
+constexpr auto FRAMESPERSECORD = 59.923;	//The coco really runs at about 59.923 Frames per second
+constexpr auto LINESPERSCREEN = 262.0;
+constexpr auto NANOSECOND = 1000000000.0;
+constexpr auto COLORBURST = 3579545.0;
+constexpr auto AUDIOBUFFERS = 12u;
 //Misc
-#define MAX_LOADSTRING 100
-#define QUERY 255
-#define INDEXTIME ((LINESPERSCREEN * TARGETFRAMERATE)/5)
+constexpr auto MAX_LOADSTRING = 100u;
+constexpr auto QUERY = 255u;
+constexpr auto INDEXTIME = ((LINESPERSCREEN * TARGETFRAMERATE) / 5);
 
 struct SystemState;
 
@@ -86,6 +86,7 @@ namespace VCC
         }
     };
 
+	// FIXME: Remove this and use std::array
     //
     // bounds checking array type
     //

--- a/fileops.h
+++ b/fileops.h
@@ -29,7 +29,7 @@ BOOL PathRemoveFileSpec(char *);
 BOOL PathRemoveExtension(char *);
 char* PathFindExtension(char *);
 DWORD WritePrivateProfileInt(LPCTSTR, LPCTSTR, int, LPCTSTR);
-BOOL FilePrintf(HANDLE, const void *, ...);
+BOOL FilePrintf(HANDLE, const char*, ...);
 
 #ifdef __cplusplus
 	}

--- a/hd6309.h
+++ b/hd6309.h
@@ -28,11 +28,4 @@ VCC::CPUState HD6309GetState();
 void HD6309SetBreakpoints(const std::vector<unsigned short>& breakpoints);
 void HD6309SetTraceTriggers(const std::vector<unsigned short>& triggers);
 
-void HD6309Init_s(void);
-int  HD6309Exec_s( int);
-void HD6309Reset_s(void);
-void HD6309AssertInterupt_s(InterruptSource, Interrupt);
-void HD6309DeAssertInterupt_s(InterruptSource, Interrupt);
-void HD6309ForcePC_s(unsigned short);
-
 #endif

--- a/iobus.cpp
+++ b/iobus.cpp
@@ -214,7 +214,7 @@ void port_write(unsigned char data,unsigned short addr)
 		case 0xDD:
 		case 0xDE:
 		case 0xDF:
-			sam_write(data,port);	//MC6883 S.A.M. address range $FFC0-$FFDF
+			sam_write(port);	//MC6883 S.A.M. address range $FFC0-$FFDF
 		break;
 
 		case 0x90:

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -79,18 +79,18 @@ extern int JS_Ramp_Clock=0;
 static int JS_Ramp_On;
 
 // Hires ramp constants. Determined during testing
-#define TANDYRAMPMIN   1200
-#define TANDYRAMPMAX  10950
-#define TANDYRAMPMUL     37
-#define CCMAXRAMPMIN    800
-#define CCMAXRAMPMAX  14000
-#define CCMAXRAMPMUL     21
+constexpr auto TANDYRAMPMIN  = 1200u;
+constexpr auto TANDYRAMPMAX  = 10950u;
+constexpr auto TANDYRAMPMUL  = 37u;
+constexpr auto CCMAXRAMPMIN  = 800u;
+constexpr auto CCMAXRAMPMAX  = 14000u;
+constexpr auto CCMAXRAMPMUL  = 21u;
 
 static int sticktarg = 0;    // Target stick cycle count
 
 // Joystick values  (0-16383)
-#define STICKMAX 16383
-#define STICKMID 8191
+constexpr auto STICKMAX = 16383u;
+constexpr auto STICKMID = 8191u;
 unsigned int LeftStickX = STICKMID;
 unsigned int LeftStickY = STICKMID;
 unsigned int RightStickX = STICKMID;

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -367,7 +367,7 @@ unsigned int
 get_pot_value(unsigned char pot)
 {
 #ifndef _M_ARM
-    DIJOYSTATE2 Stick1;
+	DIJOYSTATE2 Stick1 = { 0 };
 
     // Poll left joystick if attached
     if (LeftJS.UseMouse==3) {

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -239,7 +239,7 @@ inline int vccJoystickType() {
 /*****************************************************************************/
 // Called by mc6821 when $FF20 is written
 void
-vccJoystickStartTandy(unsigned char data, unsigned char next)
+vccJoystickStartTandy(unsigned char next)
 {
 	if (vccJoystickType() == 2) {
         if ( next == 2 ) {

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -150,7 +150,7 @@ int EnumerateJoysticks(void)
 
 /*****************************************************************************/
 #ifndef _M_ARM
-BOOL CALLBACK enumCallback(const DIDEVICEINSTANCE* instance, VOID* context)
+BOOL CALLBACK enumCallback(const DIDEVICEINSTANCE* instance, VOID* /*context*/)
 {
     HRESULT hr;
     hr = di->CreateDevice(instance->guidInstance, &Joysticks[JoyStickIndex],nullptr);
@@ -184,7 +184,7 @@ bool InitJoyStick (unsigned char StickNumber)
 
 /*****************************************************************************/
 #ifndef _M_ARM
-BOOL CALLBACK enumAxesCallback(const DIDEVICEOBJECTINSTANCE* instance, VOID* context)
+BOOL CALLBACK enumAxesCallback(const DIDEVICEOBJECTINSTANCE* instance, VOID* /*context*/)
 {
     DIPROPRANGE propRange;
     propRange.diph.dwSize = sizeof(DIPROPRANGE);

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -238,8 +238,7 @@ inline int vccJoystickType() {
 
 /*****************************************************************************/
 // Called by mc6821 when $FF20 is written
-void
-vccJoystickStartTandy(unsigned char next)
+void vccJoystickStartTandy(unsigned char next)
 {
 	if (vccJoystickType() == 2) {
         if ( next == 2 ) {

--- a/joystickinput.h
+++ b/joystickinput.h
@@ -59,7 +59,7 @@ unsigned char SetMouseStatus(unsigned char,unsigned char);
 void joystick(unsigned int, unsigned int);
 void SetButtonStatus(unsigned char, unsigned char);
 void SetStickNumbers(unsigned char, unsigned char);
-void vccJoystickStartTandy(unsigned char, unsigned char);
+void vccJoystickStartTandy(unsigned char);
 void vccJoystickStartCCMax();
 
 #ifdef __cplusplus

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -64,7 +64,8 @@ bool GetNextScanInPasteQueue(unsigned char col);
 /*****************************************************************************/
 
 // key translation table maximum size, (arbitrary) most of the layouts are < 80 entries
-#define KBTABLE_ENTRY_COUNT 100
+constexpr auto KBTABLE_ENTRY_COUNT = 100u;
+// FIXME: These defines should either be a scoped enumeration or removed and boolean values used.
 #define KEY_DOWN	1
 #define KEY_UP		0
 

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -59,7 +59,7 @@ This file is part of VCC (Virtual Color Computer).
 
 unsigned char SetMouseStatus(unsigned char, unsigned char);
 bool pasting = false;  //Are the keyboard functions in the middle of a paste operation?
-bool GetNextScanInPasteQueue(unsigned char col);
+bool GetNextScanInPasteQueue();
 
 /*****************************************************************************/
 //	Global variables
@@ -115,7 +115,7 @@ vccKeyboardGetScan(unsigned char Col)
 
 	ret_val = 0;
 
-	GetNextScanInPasteQueue(Col);
+	GetNextScanInPasteQueue();
 
 	temp = ~Col; //Get colums
 	mask = 1;
@@ -555,7 +555,7 @@ void PasteIntoQueue(const std::string& txt)
 }
 
 
-bool GetNextScanInPasteQueue(unsigned char col)
+bool GetNextScanInPasteQueue()
 {
 	if (CurrentPasteState == PasteState::Idle)
 	{

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -46,9 +46,11 @@ This file is part of VCC (Virtual Color Computer).
 #include "keyboardLayout.h"
 #include "config.h"
 
-#include <queue>
-
 #include "xDebug.h"
+
+#include <queue>
+#include <sstream>
+
 
 /*****************************************************************************/
 /*
@@ -552,7 +554,6 @@ void PasteIntoQueue(const std::string& txt)
 	SetPaste(true);
 }
 
-#include <sstream>
 
 bool GetNextScanInPasteQueue(unsigned char col)
 {

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -242,7 +242,7 @@ void _vccKeyboardUpdateRolloverTable()
 //	@param Status Key status - kEventKeyDown/kEventKeyUp
 /*****************************************************************************/
 
-void vccKeyboardHandleKey(unsigned char key, unsigned char ScanCode, keyevent_e keyState)
+void vccKeyboardHandleKey(unsigned char ScanCode, keyevent_e keyState)
 {
 	//If requested, abort pasting operation.
 	if (ScanCode == 0x01 || ScanCode == 0x43 || ScanCode == 0x3F) { pasting = false; }
@@ -586,7 +586,7 @@ bool GetNextScanInPasteQueue()
 		{
 			// Lower Shift key and get the next.
 			PasteInputQueue.pop();
-			vccKeyboardHandleKey(0x36, 0x36, kEventKeyDown);
+			vccKeyboardHandleKey(0x36, kEventKeyDown);
 			next = PasteInputQueue.front();
 			ShiftPaste = true;
 		}
@@ -595,11 +595,11 @@ bool GetNextScanInPasteQueue()
 		{
 			// Lower Control key and get the next.
 			PasteInputQueue.pop();
-			vccKeyboardHandleKey(0x1D, 0x1D, kEventKeyDown);
+			vccKeyboardHandleKey(0x1D, kEventKeyDown);
 			next = PasteInputQueue.front();
 			CtrlPaste = true;
 		}
-		vccKeyboardHandleKey(next, next, kEventKeyDown);
+		vccKeyboardHandleKey(next, kEventKeyDown);
 		CurrentPasteState = KeyUp;
 		break;
 	}
@@ -608,10 +608,10 @@ bool GetNextScanInPasteQueue()
 	{
 		// Raise key that was down.
 		unsigned char last = PasteInputQueue.front();
-		vccKeyboardHandleKey(last, last, kEventKeyUp);
+		vccKeyboardHandleKey(last, kEventKeyUp);
 		// Raise shift or control if either were down
-		if (ShiftPaste) vccKeyboardHandleKey(0x36, 0x36, kEventKeyUp);
-		if (CtrlPaste)  vccKeyboardHandleKey(0x1D, 0x1D, kEventKeyUp);
+		if (ShiftPaste) vccKeyboardHandleKey(0x36, kEventKeyUp);
+		if (CtrlPaste)  vccKeyboardHandleKey(0x1D, kEventKeyUp);
 		ShiftPaste = CtrlPaste = false;
 		PasteInputQueue.pop();
 		CurrentPasteState = CheckDone;

--- a/keyboard.h
+++ b/keyboard.h
@@ -75,7 +75,7 @@ extern "C"
 {
 #endif
 	void			vccKeyboardBuildRuntimeTable(keyboardlayout_e keyBoardLayout);
-	void			vccKeyboardHandleKey(unsigned char, unsigned char, keyevent_e keyState);
+	void			vccKeyboardHandleKey(unsigned char, keyevent_e keyState);
 	unsigned char	vccKeyboardGetScan(unsigned char);
 #ifdef __cplusplus
 }

--- a/keyboardEdit.cpp
+++ b/keyboardEdit.cpp
@@ -103,7 +103,7 @@ char *GenKeymapLine(keytranslationentry_t *);
 
 // Lookup functions for keyname tables
 static struct CoCoKey * cctable_rowcol_lookup(unsigned char, unsigned char);
-static struct CoCoKey * cctable_keyid_lookup(int);
+static struct CoCoKey * cctable_keyid_lookup();
 static struct CoCoKey * cocotable_keyname_lookup(const char *);
 static struct PCScanCode * scantable_scancode_lookup(int);
 static struct PCScanCode * scantable_keyname_lookup(const char *);
@@ -535,8 +535,7 @@ CoCoKey * cocotable_keyname_lookup(const char * keyname)
 //-----------------------------------------------------
 // Lookup CoCo key by button id.  Sequential search.
 //-----------------------------------------------------
-static struct 
-CoCoKey * cctable_keyid_lookup(int id) 
+static struct CoCoKey * cctable_keyid_lookup() 
 {
 	struct CoCoKey *p;
 	if (CC_KeySelected) {
@@ -670,7 +669,7 @@ BOOL SetCustomKeymap() {
 		// If no entry and no coco key to map do nothing
 		if ( (CC_KeySelected + CC_ModSelected) == 0 ) return TRUE;
 
-		p = cctable_keyid_lookup(CC_KeySelected);
+		p = cctable_keyid_lookup();
 		int len = 0;
 	    pKeyTran = keyTranslationsCustom;
 
@@ -709,7 +708,7 @@ BOOL SetCustomKeymap() {
 
 	// Update custom translation table
     if (CC_KeySelected != 0) {  // BtnId
-		p = cctable_keyid_lookup(CC_KeySelected);
+		p = cctable_keyid_lookup();
 		if (p) {
 			pKeyTran->Row1 = 1<<(p->row);
 		    pKeyTran->Col1 = p->col;
@@ -857,7 +856,7 @@ void ShowCoCoKey()
 
 	// Show coco keys names in editbox
 	if (CC_KeySelected) {
-        p = cctable_keyid_lookup(CC_KeySelected);
+        p = cctable_keyid_lookup();
 		if (p != nullptr) {
 			if (p->label != nullptr) {
 			    keytxt = p->label;

--- a/keyboardLayout.h
+++ b/keyboardLayout.h
@@ -25,7 +25,7 @@
 
 #include "keyboard.h"
 
-#define MAX_CTRANSTBLSIZ 150
+constexpr auto MAX_CTRANSTBLSIZ = 150u;
 
 /*****************************************************************************/
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -23,7 +23,7 @@
 #include <stdarg.h>
 #include <io.h>
 #include <fcntl.h>
-#include <sys\stat.h>
+#include <sys/stat.h>
 #include "logger.h"
 
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -26,8 +26,6 @@
 #include <sys\stat.h>
 #include "logger.h"
 
-#define TOCONS 0
-#define TOFILE 1
 
 static HANDLE hLog_Out = nullptr;
 DWORD dummy;

--- a/logger.cpp
+++ b/logger.cpp
@@ -49,12 +49,12 @@ void WriteLog(const char *Message, unsigned char Type) {
 }
 
 // PrintLogC - Put formatted string to the console
-void PrintLogC(const void * fmt, ...)
+void PrintLogC(const char* fmt, ...)
 {
     va_list args;
     char msg[512];
     va_start(args, fmt);
-    vsnprintf(msg, 512, (char *)fmt, args);
+    vsnprintf(msg, 512, fmt, args);
     va_end(args);
 
     if (hLog_Out == nullptr) {
@@ -66,12 +66,12 @@ void PrintLogC(const void * fmt, ...)
 }
 
 // PrintLogF - Put formatted string to the log file
-void PrintLogF(const void * fmt, ...)
+void PrintLogF(const char* fmt, ...)
 {
     va_list args;
     char msg[512];
     va_start(args, fmt);
-    vsnprintf(msg, 512, (char *)fmt, args);
+    vsnprintf(msg, 512, fmt, args);
     va_end(args);
 
     int oflag = _O_CREAT | _O_APPEND | _O_RDWR;

--- a/logger.h
+++ b/logger.h
@@ -29,8 +29,8 @@ This file is part of VCC (Virtual Color Computer).
 #define TOFILE 1
 
 void WriteLog(const char *, unsigned char);
-void PrintLogC(const void * fmt, ...);
-void PrintLogF(const void * fmt, ...);
+void PrintLogC(const char* fmt, ...);
+void PrintLogF(const char* fmt, ...);
 void OpenLogFile(const char * filename);
 
 // Debug logging if USE_LOGGING is defined

--- a/logger.h
+++ b/logger.h
@@ -20,6 +20,11 @@ This file is part of VCC (Virtual Color Computer).
 #ifndef __LOGGER_H__
 #define __LOGGER_H__
 
+// FIXME: At the very least these need to be turned into a scoped enum and the
+// signature of functions that use them updated. A better option would be to
+// properly abstract the logging to these values are not necessary. Also the
+// notion of the callsite selecting the output device is not ideal so maybe
+// just replace it with something more effective.
 #define TOCONS 0
 #define TOFILE 1
 

--- a/mc6821.cpp
+++ b/mc6821.cpp
@@ -267,7 +267,7 @@ void pia1_write(unsigned char data,unsigned char port)
 	case 0: // cpu write FF20
 		if (dda)
 		{
-            vccJoystickStartTandy(regb[port],data);
+            vccJoystickStartTandy(data);
             regb[port]=data;
 			CaptureBit((regb[0]&2)>>1);
 			if (GetMuxState() == 0)

--- a/mc6821.h
+++ b/mc6821.h
@@ -29,7 +29,6 @@ void ClosePrintFile(void);
 void SetSerialParams(unsigned char);
 void SetMonState(BOOL);
 unsigned char VDG_Mode(void);
-void kb_tap(unsigned int,unsigned int,unsigned int);
 void irq_hs(int);
 void irq_fs(int);
 void AssertCart(void);

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -17,11 +17,11 @@ Copyright 2015 by Joseph Forgione
 */
 // This is an expansion module for the Vcc Emulator. It simulated the functions of the TRS-80 Multi-Pak Interface
 
-#include <windows.h>
+#include <Windows.h>
 #include <iostream>
 #include "stdio.h"
 #include "resource.h"
-#include <commctrl.h>
+#include <CommCtrl.h>
 #include "mpi.h"
 #include "../fileops.h"
 #include "../DialogOps.h"
@@ -403,7 +403,7 @@ LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*l
 		}
 		UpdateSlotSelect(SwitchSlot);
 		return TRUE;
-		break;
+
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
 		case IDC_SELECT1:
@@ -513,7 +513,6 @@ unsigned char MountModule(unsigned char Slot,const char *ModuleName)
 	{
 	case 0: //File doesn't exist
 		return 0;
-	break;
 
 	case 2: //ROM image
 		UnloadModule(Slot);

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -106,7 +106,7 @@ LRESULT CALLBACK MpiConfigDlg(HWND,UINT,WPARAM,LPARAM);
 
 unsigned char MountModule(unsigned char,const char *);
 void UnloadModule(unsigned char);
-void UpdateCartDLL(unsigned char,char *);
+void UpdateCartDLL(unsigned char slot);
 void LoadConfig(void);
 void WriteConfig(void);
 void ReadModuleParms(unsigned char,char *);
@@ -290,7 +290,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void PakMemWrite8(unsigned char Data,unsigned short Address)
+	__declspec(dllexport) void PakMemWrite8(unsigned char /*Data*/,unsigned short /*Address*/)
 	{
 
 		return;
@@ -382,7 +382,7 @@ void CenterDialog(HWND hDlg)
 	SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
-LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 
 	switch (message) {
@@ -480,7 +480,7 @@ void UpdateSlotContent(int Slot)
 		return;
 	}
 
-	UpdateCartDLL(Slot,ModulePaths[Slot]);
+	UpdateCartDLL(Slot);
 	SendDlgItemMessage(hConfDlg,EDITBOXS[Slot],WM_SETTEXT,0,(LPARAM)SlotLabel[Slot]);
 	if ((strcmp(ModuleNames[Slot],"Empty") != 0) || hinstLib[Slot])
 		SendDlgItemMessage(hConfDlg,INSBOXS[Slot],WM_SETTEXT,0,(LPARAM)"X");
@@ -628,7 +628,7 @@ void UnloadModule(unsigned char Slot)
 	return;
 }
 
-void UpdateCartDLL(unsigned char Slot,char *DllPath)
+void UpdateCartDLL(unsigned char Slot)
 {
 	if ((strcmp(ModuleNames[Slot],"Empty") != 0) || hinstLib[Slot]) {
 		UnloadModule(Slot);

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -520,13 +520,13 @@ unsigned char MountModule(unsigned char Slot,const char *ModuleName)
 		ExtRomPointers[Slot]=(unsigned char *)malloc(0x40000);
 		if (ExtRomPointers[Slot]==nullptr)
 		{
-			MessageBox(0,"Rom pointer is NULL","Error",0);
+			MessageBox(nullptr,"Rom pointer is NULL","Error",0);
 			return 0; //Can Allocate RAM
 		}
 		rom_handle=fopen(MountName,"rb");
 		if (rom_handle==nullptr)
 		{
-			MessageBox(0,"File handle is NULL","Error",0);
+			MessageBox(nullptr,"File handle is NULL","Error",0);
 			return 0;
 		}
 		while ((feof(rom_handle)==0) & (index<0x40000))
@@ -573,7 +573,7 @@ unsigned char MountModule(unsigned char Slot,const char *ModuleName)
 		if (GetModuleNameCalls[Slot] == nullptr)
 		{
 			UnloadModule(Slot);
-			MessageBox(0,"Not a valid Module","Ok",0);
+			MessageBox(nullptr,"Not a valid Module","Ok",0);
 			return 0; //Error Not a Vcc Module
 		}
 		GetModuleNameCalls[Slot](ModuleNames[Slot],CatNumber[Slot],DynamicMenuCallbackCalls[Slot]); //Need to add address of local Dynamic menu callback function!
@@ -791,7 +791,7 @@ void BuildDynaMenu(void)
 {
 	// DynamicMenuCallback() resides in VCC pakinterface. Make sure we have it's address
 	if (DynamicMenuCallback == nullptr) {
-		MessageBox(0,"MPI internal menu error","Ok",0);
+		MessageBox(nullptr,"MPI internal menu error","Ok",0);
 		return;
 	}
 

--- a/mpi/mpi.h
+++ b/mpi/mpi.h
@@ -21,8 +21,8 @@ This file is part of VCC (Virtual Color Computer).
 #include "../MachineDefs.h"
 
 //Misc
-#define MAX_LOADSTRING 100
-#define QUERY 255
+constexpr auto MAX_LOADSTRING = 100u;
+constexpr auto QUERY = 255u;
 
 // FIXME: These need to be turned into an enum and the signature of functions
 // that use them updated. These are also duplicated everywhere and need to be
@@ -31,6 +31,8 @@ This file is part of VCC (Virtual Color Computer).
 #define SLAVE 1
 #define STANDALONE 2
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 typedef void (*GETNAME)(char *,char *,DYNAMICMENUCALLBACK); 
 typedef void (*CONFIGIT)(unsigned char); 

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -47,7 +47,7 @@ BOOL WINAPI DllMain(
 
 extern "C" 
 {          
-	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,DYNAMICMENUCALLBACK Temp)
+	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,DYNAMICMENUCALLBACK /*Temp*/)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);		
@@ -78,7 +78,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char PackPortRead(unsigned char Port)
+	__declspec(dllexport) unsigned char PackPortRead(unsigned char /*Port*/)
 	{
 		return 0;
 	}

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -19,7 +19,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <stdio.h>
 #include "defines.h"
 #include "resource.h" 
-#include "..\fileops.h"
+#include "../fileops.h"
 
 // FIXME: These typedefs are duplicated across more if not all projects and
 // need to be consolidated in one place.

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -21,6 +21,8 @@ This file is part of VCC (Virtual Color Computer).
 #include "resource.h" 
 #include "..\fileops.h"
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*SETCART)(unsigned char);
 typedef void (*SETCARTPOINTER)(SETCART);
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -15,7 +15,7 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "defines.h"
 #include "resource.h" 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -393,7 +393,7 @@ int InsertModule (char *ModulePath)
 Load a ROM pack
 return total bytes loaded, or 0 on failure
 */
-int load_ext_rom(const char filename[MAX_PATH])
+int load_ext_rom(const char *filename)
 {
 	constexpr size_t PAK_MAX_MEM = 0x40000;
 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -72,6 +72,8 @@ static unsigned int BankedCartOffset=0;
 static char DllPath[256]="";
 static unsigned short ModualParms=0;
 static HINSTANCE hinstLib = nullptr;
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 typedef void (*GETNAME)(char *,char *,DYNAMICMENUCALLBACK);
 typedef void (*CONFIGIT)(unsigned char);

--- a/sdc/cloud9.cpp
+++ b/sdc/cloud9.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 *																		*
 ************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include "cloud9.h"
 
 static 	SYSTEMTIME now;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -817,7 +817,7 @@ void UpdateFlashItem(int index)
 void SelectCardBox(void)
 {
     // Prompt user for path
-    BROWSEINFO bi = { 0 };
+    BROWSEINFO bi = { nullptr };
     bi.hwndOwner = GetActiveWindow();
     bi.lpszTitle = "Set the SD card path";
     bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NONEWFOLDERBUTTON;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -134,12 +134,12 @@
 #include <cstdio>
 #include <cerrno>
 #include <cstring>
-#include <windows.h>
+#include <Windows.h>
 #include <windowsx.h>
-#include <shlwapi.h>
+#include <Shlwapi.h>
 #pragma warning(push)
 #pragma warning(disable:4091)
-#include <shlobj.h>
+#include <ShlObj.h>
 #pragma warning(pop)
 #include <stdio.h>
 #include <ctype.h>

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -824,7 +824,7 @@ void SelectCardBox(void)
 
     // Start from user home diretory
     SHGetSpecialFolderLocation
-        (nullptr,CSIDL_PROFILE,(LPITEMIDLIST *) &bi.pidlRoot);
+        (nullptr,CSIDL_PROFILE, const_cast<LPITEMIDLIST*>(& bi.pidlRoot));
 
     LPITEMIDLIST pidl = SHBrowseForFolder(&bi);
     if (pidl != nullptr) {

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -159,6 +159,8 @@
 // Functions
 //======================================================================
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*ASSERTINTERUPT) (unsigned char,unsigned char);
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 typedef unsigned char (*MEMREAD8)(unsigned short);

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -35,8 +35,6 @@ using Surface32 = VCC::VideoArray<unsigned int, 640 * 480>;
 void SetupDisplay(void); //This routine gets called every time a software video register get updated.
 void MakeRGBPalette (void);
 void MakeCMPpalette(void);
-bool  DDFailedCheck(HRESULT hr, char *szMessage);
-char *DDErrorString(HRESULT hr);
 void RenderPMODE4NTSC(Surface32 surface32, size_t surfaceDest, int XpitchDest, const unsigned char* cocoSrc, char scanLines);
 
 //extern STRConfig CurrentConfig;

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -9716,7 +9716,7 @@ void SetGimeBoarderColor(unsigned char data)
 	return;
 }
 
-void SetBoarderChange (unsigned char data)
+void SetBoarderChange ()
 {
 	if (BoarderChange >0)
 		BoarderChange--;

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -53,7 +53,7 @@ void GimeInit(void);
 void GimeReset(void);
 void SetVideoBank(unsigned char);
 unsigned char SetMonitorType(unsigned char );
-void SetBoarderChange (unsigned char);
+void SetBoarderChange ();
 int GetBytesPerRow(void);
 unsigned char GetHorizontalBorderSize();
 unsigned short GetDisplayedPixelsPerLine();

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -66,6 +66,8 @@ static unsigned char Lpf[4]={192,199,225,225}; // 2 is really undefined but I go
 static unsigned char VcenterTable[4] = { 25,19,8,8 };
 static unsigned char TopOffScreenTable[4] = { 11,14,11,11 };
 static unsigned char BottomOffScreenTable[4] = { 5,1,5,5 };
+
+// FIXME: These should be a scoped enumeration
 #define MRGB	1
 #define MCMP	0
 

--- a/tcc1014mmu.h
+++ b/tcc1014mmu.h
@@ -44,18 +44,17 @@ void GetMMUPage(size_t page, std::array<unsigned char, 8192>& outBuffer);
 void MemWrite8(unsigned char,unsigned short );
 void MemWrite16(unsigned short,unsigned short );
 
-unsigned short MemRead16(short unsigned int);
-unsigned char MemRead8(short unsigned int);
-unsigned char SafeMemRead8(short unsigned int);
+unsigned short MemRead16(unsigned short);
+unsigned char MemRead8(unsigned short);
+unsigned char SafeMemRead8(unsigned short);
 unsigned char * MmuInit(unsigned char);
 unsigned char *	Getint_rom_pointer(void);
-unsigned char * Getext_rom_pointer(void);
 unsigned short GetMem(unsigned long);
 void SetMem(unsigned long, unsigned short);
 bool MemCheckWrite(unsigned short address);
 
 void __fastcall fMemWrite8(unsigned char,unsigned short );
-unsigned char __fastcall fMemRead8(short unsigned int);
+unsigned char __fastcall fMemRead8(unsigned short);
 
 void SetMapType(unsigned char);
 void LoadRom(void);
@@ -67,7 +66,6 @@ void SetVectors(unsigned char);
 void MmuReset(void);
 void SetDistoRamBank(unsigned char);
 void SetMmuPrefix(unsigned char);
-void SetCartMMU (unsigned char);
 unsigned char * Get_mem_pointer(void);
 
 // FIXME: These need to be turned into an enum and the signature of functions

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -36,9 +36,9 @@ static unsigned char EnhancedFIRQFlag=0,EnhancedIRQFlag=0;
 static int InteruptTimer=0;
 void SetInit0(unsigned char);
 void SetInit1(unsigned char);
-void SetGimeIRQStearing(unsigned char);
+void SetGimeIRQStearing();
 void SetGimeFIRQStearing(unsigned char);
-void SetTimerMSB(unsigned char);
+void SetTimerMSB();
 void SetTimerLSB(unsigned char);
 unsigned char GetInit0(unsigned char port);
 static unsigned char IRQStearing[8]={0,0,0,0,0,0,0,0};
@@ -72,7 +72,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x92:
-		SetGimeIRQStearing(data);
+		SetGimeIRQStearing();
 		break;
 
 	case 0x93:
@@ -80,7 +80,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x94:
-		SetTimerMSB(data);
+		SetTimerMSB();
 		break;
 
 	case 0x95:
@@ -213,7 +213,7 @@ unsigned char GetInit0(unsigned char port)
 	return data;
 }
 
-void SetGimeIRQStearing(unsigned char data) //92
+void SetGimeIRQStearing() //92
 {
 	// FIXME: GimeIRQStearing for CART (bit 0)
 
@@ -266,7 +266,7 @@ void SetGimeFIRQStearing(unsigned char data) //93
 	return;
 }
 
-void SetTimerMSB(unsigned char data) //94
+void SetTimerMSB() //94
 {
 	unsigned short Temp;
 	Temp=((GimeRegisters[0x94] <<8)+ GimeRegisters[0x95]) & 4095;

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -37,10 +37,10 @@ static int InteruptTimer=0;
 void SetInit0(unsigned char);
 void SetInit1(unsigned char);
 void SetGimeIRQStearing();
-void SetGimeFIRQStearing(unsigned char);
+void SetGimeFIRQStearing();
 void SetTimerMSB();
-void SetTimerLSB(unsigned char);
-unsigned char GetInit0(unsigned char port);
+void SetTimerLSB();
+unsigned char GetInit0();
 static unsigned char IRQStearing[8]={0,0,0,0,0,0,0,0};
 static unsigned char FIRQStearing[8]={0,0,0,0,0,0,0,0};
 static unsigned char LastIrq = 0, LastFirq = 0;
@@ -76,7 +76,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x93:
-		SetGimeFIRQStearing(data);
+		SetGimeFIRQStearing();
 		break;
 
 	case 0x94:
@@ -84,7 +84,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x95:
-		SetTimerLSB(data);
+		SetTimerLSB();
 		break;
 
 	case 0x96:
@@ -207,7 +207,7 @@ void SetInit1(unsigned char data)
 	return;
 }
 
-unsigned char GetInit0(unsigned char port)
+unsigned char GetInit0()
 {
 	unsigned char data=0;
 	return data;
@@ -239,7 +239,7 @@ void SetGimeIRQStearing() //92
 	return;
 }
 
-void SetGimeFIRQStearing(unsigned char data) //93
+void SetGimeFIRQStearing() //93
 {
 	// FIXME: GimeFIRQStearing for CART (bit 0)
 
@@ -274,7 +274,7 @@ void SetTimerMSB() //94
 	return;	
 }
 
-void SetTimerLSB(unsigned char data) //95
+void SetTimerLSB() //95
 {
 	unsigned short Temp;
 	Temp=((GimeRegisters[0x94] <<8)+ GimeRegisters[0x95]) & 4095;

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -368,7 +368,7 @@ unsigned char sam_read(unsigned char port) //SAM don't talk much :)
 
 	return 0;
 }
-void sam_write(unsigned char data ,unsigned char port)
+void sam_write(unsigned char port)
 {
 	unsigned char mask=0;
 	unsigned char reg=0;

--- a/tcc1014registers.h
+++ b/tcc1014registers.h
@@ -28,7 +28,7 @@ void GimeAssertVertInterupt(void);
 void GimeAssertTimerInterupt(void);
 void GimeAssertCartInterupt(void);
 unsigned char sam_read(unsigned char);
-void sam_write(unsigned char,unsigned char);
+void sam_write(unsigned char);
 void mc6883_reset();
 unsigned char VDG_Offset(void);
 unsigned char VDG_Modes(void);

--- a/xDebug.h
+++ b/xDebug.h
@@ -19,7 +19,7 @@ extern "C"
 {
 #endif
 	
-	void		_xDbgTrace(const void * pFile, const int iLine, const void * pFormat, ...);
+	void		_xDbgTrace(const char* pFile, const int iLine, const char* pFormat, ...);
 	
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR includes the following changes to clean up the code base.

- Convert #defines to `constexpr`. Added `FIXME` notes for those which need to be converted to scoped enumerations.
- Removed some unnecessary casts, replaced dangerous c-style casts to `reinterpret_cast` or `const_cast` where necessary.
- Updated member function definitions to make them `const`.
- Removed unused parameters or commented out their names.
- Removed function declarations with no associate definition.
- Changed `\` to `/` in #include paths (a single `\` is not a valid character in the include path).
- Fixed #include paths to use the case-correct name of files and directories.
- Change use of `0` literal to `nullptr`.
- Added member initialization to `struct` and `class` definitions.
- Changed type of parameters from `void*` to `const char*` where to match the expected type.
- Remove `move` operation when returning value in GMC pak.
- Remove superfluous parentheses.
- Add `#ifdef` wrapper around `bool`, `false`, and `true` to prevent them from being defined in C++.

The removal of some parameters has the potential to impact observable behavior as the call sites had the be adjusted to compensate for the change in function signature.