### PR TITLE
Code clean up part 4

### DIFF
--- a/Audio.cpp
+++ b/Audio.cpp
@@ -265,7 +265,7 @@ int GetSoundCardList (SndCardList *List)
 	return CardCount;
 }
 
-BOOL CALLBACK DSEnumCallback(LPGUID lpGuid,LPCSTR lpcstrDescription,LPCSTR lpcstrModule,LPVOID lpContext)          
+BOOL CALLBACK DSEnumCallback(LPGUID lpGuid,LPCSTR lpcstrDescription,LPCSTR /*lpcstrModule*/,LPVOID /*lpContext*/)          
 {
 	strncpy(Cards[CardCount].CardName,lpcstrDescription,63);
 	Cards[CardCount++].Guid=lpGuid;

--- a/Audio.cpp
+++ b/Audio.cpp
@@ -34,7 +34,7 @@ This file is part of VCC (Virtual Color Computer).
 
 using AuxBufferType = VCC::Array<VCC::Array<uint32_t, AUDIO_RATE / 60>, 6>;
 
-#define MAXCARDS	12
+constexpr auto MAXCARDS = 12u;
 //PlayBack
 static LPDIRECTSOUND	lpds;           // directsound interface pointer
 static DSBUFFERDESC		dsbd;           // directsound description

--- a/Audio.cpp
+++ b/Audio.cpp
@@ -157,7 +157,7 @@ int SoundInit (HWND main_window_handle,const _GUID * Guid,unsigned int Rate)
 
 void FlushAudioBuffer(unsigned int *Abuffer,unsigned int Lenth)
 {
-	unsigned char *Abuffer2=(unsigned char *)Abuffer;
+	const unsigned char *Abuffer2=(unsigned char *)Abuffer;
 
 	if (!InitPassed || AudioPause || !Abuffer)
 		return;

--- a/Audio.cpp
+++ b/Audio.cpp
@@ -292,7 +292,7 @@ int SoundDeInit(void)
 	return 0;
 }
 
-int SoundInInit (HWND main_window_handle,const _GUID * Guid)
+int SoundInInit (const _GUID * Guid)
 {
 	hr=DirectSoundCaptureCreate(Guid, &lpdsin, nullptr);
 	if (hr!=DS_OK)

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -77,7 +77,7 @@ namespace VCC
 		for (size_t i = 0; i < samples; ++i)
 		{
 			auto p = inBuffer + i * width + width - 1;
-			int sample = (int)*(int8_t*)p;
+			int sample = *p;
 			outBuffer[i] = (uint8_t)(sample + CAS_SILENCE);
 		}
 	}
@@ -87,7 +87,7 @@ namespace VCC
 		for (size_t i = 0; i < samples; ++i)
 		{
 			auto p = inBuffer + i * width + width - 1;
-			uint8_t sample = *(uint8_t*)p;
+			uint8_t sample = *p;
 			outBuffer[i] = sample;
 		}
 	}
@@ -97,7 +97,7 @@ namespace VCC
 		for (size_t i = 0; i < samples; ++i)
 		{
 			auto p = inBuffer + i * width;
-			float sample = *(float*)p;
+			float sample = *reinterpret_cast<const float*>(p);
 			outBuffer[i] = (uint8_t)(sample * 128) + 256 / 2;
 		}
 	}

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -218,7 +218,7 @@ void UpdateTapeStatus(char* status, int max)
 		StalledCtr++;
 	}
 	if (TotalSize > 0 && StalledCtr < 1000)
-		snprintf(status, max, " | Tape:%05d (%d%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
+		snprintf(status, max, " | Tape:%05ul (%ul%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
 }
 
 void SetTapeMode(unsigned char Mode)	//Handles button pressed from Dialog

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -218,7 +218,7 @@ void UpdateTapeStatus(char* status, int max)
 		StalledCtr++;
 	}
 	if (TotalSize > 0 && StalledCtr < 1000)
-		snprintf(status, max, " | Tape:%05ul (%ul%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
+		snprintf(status, max, " | Tape:%05lu (%lu%%)", TapeOffset, (TapeOffset + 50) * 100 / TotalSize);
 }
 
 void SetTapeMode(unsigned char Mode)	//Handles button pressed from Dialog

--- a/CommandLine.cpp
+++ b/CommandLine.cpp
@@ -101,9 +101,9 @@ static char *NxtTokenPtr;
 // CmdString:  The third arg to WinMain()
 //-------------------------------------------------------------------
 
-int GetCmdLineArgs(char *CmdString) 
+int GetCmdLineArgs(const char *CmdString) 
 {
-    char *token;      // token pointer (to item in command string)
+	const char *token;      // token pointer (to item in command string)
     int  argnum = 0;  // non-option argument number
     int  len;         // len of a chr string
 
@@ -200,7 +200,7 @@ char * ParseCmdString(const char *CmdString, const char *ValueRequired)
     static char option[256];  // Used to append value to option
     int quoted;
     char *token;
-    char *value;
+	const char *value;
 
     // Initial call sets command string. Subsequent calls expect a NULL
     if (CmdString) {                   

--- a/CommandLine.cpp
+++ b/CommandLine.cpp
@@ -85,7 +85,7 @@ This file is part of VCC (Virtual Color Computer).
 // Define global command line settings
 struct CmdLineArguments CmdArg;
 
-#define SEPMARK 3  //To mark spaces as separators
+constexpr auto SEPMARK = 3u;  //To mark spaces as separators
 
 char *ParseCmdString(const char *, const char *); 
 char *GetNextToken ();

--- a/CommandLine.h
+++ b/CommandLine.h
@@ -20,8 +20,8 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 // Declare global variables defined by GetCmdLineArgs
-#define CL_MAX_PATH 256
-#define CL_MAX_PASTE 256
+constexpr auto CL_MAX_PATH = 256u;
+constexpr auto CL_MAX_PASTE = 256u;
 struct CmdLineArguments {
 	char QLoadFile[CL_MAX_PATH];
 	char IniFile[CL_MAX_PATH];
@@ -34,6 +34,8 @@ extern struct CmdLineArguments CmdArg;
 int  GetCmdLineArgs(char * lpCmdLine);
 
 // Errors returned
+// FIXME: These need to be turned into a scoped enum and the signature of functions
+// that use them updated.
 #define CL_ERR_UNKOPT 1  // Unknown option found
 #define CL_ERR_XTRARG 2  // Too many arguments
 

--- a/CommandLine.h
+++ b/CommandLine.h
@@ -31,7 +31,7 @@ struct CmdLineArguments {
 extern struct CmdLineArguments CmdArg;
 
 // Get Settings from Command line string 
-int  GetCmdLineArgs(char * lpCmdLine);
+int  GetCmdLineArgs(const char * lpCmdLine);
 
 // Errors returned
 // FIXME: These need to be turned into a scoped enum and the signature of functions

--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -485,7 +485,7 @@ namespace VCC { namespace Debugger
 		MemWrite8(memWrite.value, memWrite.addr);
 	}
 
-	bool Debugger::Halt_Enabled()
+	bool Debugger::Halt_Enabled() const
 	{
 		return Halt_Enabled_TF;
 	}
@@ -495,7 +495,7 @@ namespace VCC { namespace Debugger
 		Halt_Enabled_TF = flag;
 	}
 
-	bool Debugger::Break_Enabled()
+	bool Debugger::Break_Enabled() const
 	{
 		return Break_Enabled_TF;
 	}

--- a/Debugger.h
+++ b/Debugger.h
@@ -111,9 +111,9 @@ namespace VCC { namespace Debugger
 		// haltpoints to avoid conflict with the mechanism used by the source
 		// code debugger)  BREAK instruction is page two opcodes 0x113E and the
 		// HALT instruction is opcode 0x15.
-		bool Break_Enabled();
+		bool Break_Enabled() const;
 		void Enable_Break(bool);
-		bool Halt_Enabled();
+		bool Halt_Enabled() const;
 		void Enable_Halt(bool);
 
 	protected:
@@ -146,8 +146,8 @@ namespace VCC { namespace Debugger
 	private:
 
 		mutable CriticalSection			Section_;
-		bool							HasPendingCommand_;
-		ExecutionMode					PendingCommand_;
+		bool							HasPendingCommand_ = false;
+		ExecutionMode					PendingCommand_ = ExecutionMode::Halt;
 		breakpointsbuffer_type			Breakpoints_;
 		bool							BreakpointsChanged_ = false;
 		CPUState						ProcessorState_;

--- a/DebuggerUtils.h
+++ b/DebuggerUtils.h
@@ -38,6 +38,9 @@ namespace VCC
 			DeleteCriticalSection(&Section_);
 		}
 
+		CriticalSection(const CriticalSection&) = delete;
+		CriticalSection& operator=(const CriticalSection&) = delete;
+
 		void Lock()
 		{
 			EnterCriticalSection(&Section_);

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -95,13 +95,13 @@ void FileDialog::setpath(const char * NewPath) {
 }
 
 // Get a copy of the selected file path
-void FileDialog::getpath(char * PathCopy, int maxsize) {
+void FileDialog::getpath(char * PathCopy, int maxsize) const {
     if (PathCopy == nullptr || Path == nullptr || maxsize < 1) return;
 	strncpy(PathCopy,Path,maxsize);
 }
 
 // Get a copy of the selected file path with unix dir delimiters
-void FileDialog::getupath(char * PathCopy, int maxsize) {
+void FileDialog::getupath(char * PathCopy, int maxsize) const {
     if (PathCopy == nullptr || Path == nullptr || maxsize < 1) return;
     int i = 0;
     while (Path[i] != '\0' && i < maxsize - 1) {
@@ -121,7 +121,7 @@ char * FileDialog::path() {
 }
 
 // FileDialog::getdir() returns the directory portion of the file path
-void FileDialog::getdir(char * Dir, int maxsize) {
+void FileDialog::getdir(char * Dir, int maxsize) const {
     if (Dir == nullptr || Path == nullptr || maxsize < 1) return;
 	strncpy(Dir,Path,maxsize);
 	if (char * p = strrchr(Dir,'\\')) *p = '\0';

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -113,7 +113,8 @@ void FileDialog::getupath(char * PathCopy, int maxsize) const {
 }
 
 // Get a pointer to the selected file path
-char * FileDialog::path() {
+const char *FileDialog::path() const
+{
 	return Path;
 }
 

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -39,9 +39,6 @@ FileDialog::FileDialog() {
 	ofn.Flags = OFN_HIDEREADONLY;
 }
 
-// FileDialog destructor does nothing
-FileDialog::~FileDialog() { }
-
 // FileDialog::show calls GetOpenFileName() or GetSaveFileName()
 bool FileDialog::show(BOOL Save, HWND Owner) {
 

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -57,9 +57,9 @@ public:
 	void setFilter(const char * Filter);
 	void setFlags(unsigned int Flags);
 	void setTitle(const char * Title);
-	void getdir(char * Dir, int maxsize = MAX_PATH);
-	void getpath(char * Path, int maxsize = MAX_PATH);
-	void getupath(char * Path, int maxsize = MAX_PATH);
+	void getdir(char * Dir, int maxsize = MAX_PATH) const;
+	void getpath(char * Path, int maxsize = MAX_PATH) const;
+	void getupath(char * Path, int maxsize = MAX_PATH) const;
 	char * path();
 private:
 	OPENFILENAME ofn;

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -49,7 +49,7 @@ void CloseCartDialog(HWND hDlg);
 class FileDialog {
 public:
 	FileDialog();
-	~FileDialog();
+
 	bool show(BOOL Save = FALSE, HWND Owner = nullptr);
 	void setpath(const char * Path);
 	void setDefExt(const char * DefExt);

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -60,7 +60,7 @@ public:
 	void getdir(char * Dir, int maxsize = MAX_PATH) const;
 	void getpath(char * Path, int maxsize = MAX_PATH) const;
 	void getupath(char * Path, int maxsize = MAX_PATH) const;
-	char * path();
+	const char *path() const;
 private:
 	OPENFILENAME ofn;
 	char Path[MAX_PATH] = {};

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -319,7 +319,7 @@ void DisplayFlip(SystemState *DFState)	// Double buffering flip
 	return;
 }
 
-unsigned char LockScreen(const SystemState *LSState)
+unsigned char LockScreen()
 {
 	if (!g_Display) 
 		return 0;
@@ -365,7 +365,7 @@ void DoCls(SystemState *CLStatus)
 {
 	unsigned short x=0,y=0;
 
-	if(LockScreen(CLStatus))
+	if(LockScreen())
 		return;
 	switch (CLStatus->BitDepth)
 	{

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -346,7 +346,7 @@ void SetStatusBarText(const char *TextBuffer,const SystemState *STState)
 {
 	if (!STState->FullScreen)
 	{
-		SendMessage(hwndStatusBar,WM_SETTEXT,0,(LPARAM)(LPCSTR)TextBuffer);
+		SendMessage(hwndStatusBar,WM_SETTEXT,0, reinterpret_cast<LPARAM>(TextBuffer));
 		SendMessage(hwndStatusBar,WM_SIZE,0,0);
 	}
 	else

--- a/DirectDrawInterface.h
+++ b/DirectDrawInterface.h
@@ -39,6 +39,4 @@ POINT GetForcedAspectBorderPadding();
 void CloseScreen();
 void DumpScreenshot();
 
-#define MAX_LOADSTRING 100
-
 #endif

--- a/DirectDrawInterface.h
+++ b/DirectDrawInterface.h
@@ -21,7 +21,6 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 
 BOOL InitInstance(HINSTANCE,int);
-BOOL InitDrawSurface(bool );
 void UnlockScreen(SystemState *);
 unsigned char LockScreen(const SystemState *);
 void SetStatusBarText(const char *,const SystemState *);

--- a/DirectDrawInterface.h
+++ b/DirectDrawInterface.h
@@ -22,7 +22,7 @@ This file is part of VCC (Virtual Color Computer).
 
 BOOL InitInstance(HINSTANCE,int);
 void UnlockScreen(SystemState *);
-unsigned char LockScreen(const SystemState *);
+unsigned char LockScreen();
 void SetStatusBarText(const char *,const SystemState *);
 int GetRenderWindowStatusBarHeight();
 bool CreateDDWindow(SystemState *);

--- a/DirectX.cpp
+++ b/DirectX.cpp
@@ -406,7 +406,7 @@ namespace VCC
         return Result(OK);
     }
 
-    void DirectX::GetSurfaceArea(Rect* rect)
+    void DirectX::GetSurfaceArea(Rect* rect) const
     {
         rect->x = 0;
         rect->y = 0;
@@ -414,7 +414,7 @@ namespace VCC
         rect->h = 480;
     }
 
-    void DirectX::GetDisplayArea(Rect* rect)
+    void DirectX::GetDisplayArea(Rect* rect) const
     {
         using namespace Detail;
         rect->x = (float)ForcedAspectBorderPadding.x;
@@ -423,7 +423,7 @@ namespace VCC
         rect->h = 480;
     }
 
-    void DirectX::CheckSurfaces()
+    void DirectX::CheckSurfaces() const
     {
         using namespace Detail;
 

--- a/DirectX.h
+++ b/DirectX.h
@@ -55,9 +55,9 @@ namespace VCC
 
         ISystemState* state;
 
-        void GetDisplayArea(Rect* rect);
-        void GetSurfaceArea(Rect* rect);
-        void CheckSurfaces();
+        void GetDisplayArea(Rect* rect) const;
+        void GetSurfaceArea(Rect* rect) const;
+        void CheckSurfaces() const;
     };
 }
 

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -706,7 +706,7 @@ bool IsBreakpoint(int realaddr)
 /*******************************************************/
 void FindHaltpoints()
 {
-    std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+    auto it = mHaltpoints.begin();
     while (it != mHaltpoints.end()) {
         int adr = it->first;
         // If decoded with CPU addressing convert haltpoint to CPU address
@@ -883,7 +883,7 @@ void RefreshHPlist()
     if (hBrkpDlg == nullptr) return;
     SendDlgItemMessage(hBrkpDlg,IDC_LIST_BREAKPOINTS,LB_RESETCONTENT,0,0);
     if (mHaltpoints.size() > 0) {
-        std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+		auto it = mHaltpoints.begin();
         while (it != mHaltpoints.end()) {
             int realaddr = it->first;
             Haltpoint hp = it->second;
@@ -917,7 +917,7 @@ void ListHaltpoints()
 /*******************************************************/
 void KillHaltpoints()
 {
-    std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+	auto it = mHaltpoints.begin();
     while (it != mHaltpoints.end()) {
         int realaddr = it->first;
         Haltpoint hp = it->second;
@@ -937,7 +937,7 @@ void KillHaltpoints()
 void ApplyHaltpoints(bool flag)
 {
     // Iterate over all defined haltpoints
-    std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+	auto it = mHaltpoints.begin();
     while (it != mHaltpoints.end()) {
         int realaddr = it->first;
         Haltpoint hp = it->second;
@@ -1028,7 +1028,7 @@ void DecodeAddr()
 
     // Convert real address to offset and block for disassemble
     if (RealAdrMode) {
-        blk = (unsigned) adr >> 13;
+        blk = adr >> 13;
         adr = adr & 0x1FFF;
     }
 

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -494,7 +494,7 @@ LRESULT CALLBACK SubTextDlgProc(HWND hCtl,UINT msg,WPARAM wPrm,LPARAM lPrm)
 /*    Breakpoints list Dialog Processing          */
 /**************************************************/
 INT_PTR CALLBACK BreakpointsDlgProc
-    (HWND hDlg,UINT msg,WPARAM wPrm,LPARAM lPrm)
+    (HWND hDlg,UINT msg,WPARAM wPrm,LPARAM /*lPrm*/)
 {
     int sel;
     HWND hList;

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -102,7 +102,6 @@ int errDisplayTimer = 0;
 
 // String functions used for decode
 std::string PadRight(std::string const&,size_t);
-std::string OpFDB(int,std::string,std::string,std::string);
 std::string FmtLine(
 	int adr,
 	const std::string& ins,

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -170,7 +170,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawBorder(HDC hdc, LPRECT clientRect)
+	void DrawBorder(HDC hdc, LPCRECT clientRect)
 	{
 		RECT rect = *clientRect;
 
@@ -178,7 +178,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		HBRUSH brush = (HBRUSH)GetStockObject(WHITE_BRUSH);
 		FillRect(hdc, &rect, brush);
 
-		HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+		HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
 		SelectObject(hdc, pen);
 
 		// Draw the border.
@@ -210,7 +210,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 
 		std::stringstream ss;
 		ss << samples << " Samples Collected";
-		DrawText(hdc, (LPCSTR)ss.str().c_str(), ss.str().size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+		DrawText(hdc, ss.str().c_str(), ss.str().size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
 		DeleteObject(hFont);
 	}
@@ -231,13 +231,13 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		SelectObject(hdc, hFont);
 
 		std::string s = "Press Enable to start collection";
-		DrawText(hdc, (LPCSTR)s.c_str(), s.size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+		DrawText(hdc, s.c_str(), s.size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
 		DeleteObject(hFont);
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawSamples(HDC hdc, LPRECT clientRect)
+	void DrawSamples(HDC hdc, LPCRECT clientRect)
 	{
 		long samples = EmuState.Debugger.GetTraceSamples();
 
@@ -270,7 +270,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 			CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, FIXED_PITCH, TEXT("Consolas"));
 		SelectObject(hdc, hFont);
 
-		HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+		HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
 		SelectObject(hdc, pen);
 
 		EmuState.Debugger.LockTrace();
@@ -292,18 +292,11 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Running a 6309 CPU?
 		if (Is6309)
 		{
-			std::vector<std::string>::iterator itHeader;
-			std::vector<int>::iterator itColumn;
+			headers.emplace(headers.begin() + 9, "W");
+			columns.emplace(columns.begin() + 9, 30);
 
-			itHeader = headers.begin();
-			itHeader = headers.insert(itHeader + 9, "W");
-			itColumn = columns.begin();
-			itColumn = columns.insert(itColumn + 9, 30);
-
-			itHeader = headers.end();
-			itHeader = headers.insert(itHeader, "MD");
-			itColumn = columns.end();
-			itColumn = columns.insert(itColumn, 30);
+			headers.emplace_back("MD");
+			columns.emplace_back(30);
 		}
 
 		int x = 10;
@@ -622,7 +615,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawExecutionTrace(HDC hdc, LPRECT clientRect)
+	void DrawExecutionTrace(HDC hdc, LPCRECT clientRect)
 	{
 		// Draw the border.
 		DrawBorder(hdc, clientRect);
@@ -1116,7 +1109,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		//	offset, nlines, count, _trace.size());
 
 		char* pos = line;
-		char* end = pos + lineSize;
+		const char* end = pos + lineSize;
 		DWORD dummy;
 
 		auto Flush = [&]()

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -192,7 +192,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawSamplingInProgress(HDC hdc, LPRECT clientRect)
+	void DrawSamplingInProgress(HDC hdc)
 	{
 		status = TraceStatus::Collecting;
 
@@ -216,7 +216,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawNoSamplesCollected(HDC hdc, LPRECT clientRect)
+	void DrawNoSamplesCollected(HDC hdc)
 	{
 		status = TraceStatus::Empty;
 
@@ -244,7 +244,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Nothing collected yet?
 		if (samples == 0)
 		{
-			DrawNoSamplesCollected(hdc, clientRect);
+			DrawNoSamplesCollected(hdc);
 			return;
 		}
 
@@ -633,7 +633,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Show tracing is in progress.
 		if (tracing)
 		{
-			DrawSamplingInProgress(hdc, clientRect);
+			DrawSamplingInProgress(hdc);
 			return;
 		}
 

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -1244,7 +1244,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 //-------------------------------------------------------------------------------
 // Export to file dialog
 //-------------------------------------------------------------------------------
-	INT_PTR CALLBACK ExportTraceProc(HWND hDlg,UINT uMsg,WPARAM wPrm,LPARAM lPrm) {
+	INT_PTR CALLBACK ExportTraceProc(HWND hDlg,UINT uMsg,WPARAM wPrm,LPARAM /*lPrm*/) {
 		switch (uMsg) {
 		case WM_INITDIALOG:
 			SetDlgItemInt(hDlg,IDC_EDIT_START,ExportStart,FALSE);

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -296,7 +296,7 @@ void dw_open( void )
 }
 
 // TCP connection thread
-unsigned __stdcall dw_thread(void *Dummy)
+unsigned __stdcall dw_thread(void* /*Dummy*/)
 {
 	_DLOG("dw_thread %d\n",dwEnabled);
 	WSADATA wsaData;

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -23,8 +23,8 @@
 //#define USE_LOGGING
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <process.h>
 #include <stdio.h>
 #include "../logger.h"

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -27,7 +27,7 @@
 #include <windows.h>
 #include <process.h>
 #include <stdio.h>
-#include "..\logger.h"
+#include "../logger.h"
 #include "becker.h"
 
 #define BUFFER_SIZE 512
@@ -37,7 +37,7 @@
 //------------------------------------------------------
 // local functions
 //------------------------------------------------------
-int dw_open(char *,unsigned short);
+void dw_open();
 void dw_close();
 unsigned char dw_status(void);
 unsigned char dw_read(void);

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -78,7 +78,7 @@ static float WriteSpeed = 0;
 // Should default to "127.0.0.1" and "65504"
 //------------------------------------------------------
 
-int becker_sethost(char *bufdwaddr, char *bufdwport)
+int becker_sethost(const char *bufdwaddr, const char *bufdwport)
 {
 	strcpy(dwaddress,bufdwaddr);
 	dwsport = (unsigned short) atoi(bufdwport);
@@ -256,7 +256,7 @@ void dw_open( void )
 	curport = dwsport;
 
 	// resolve hostname
-	LPHOSTENT dwSrvHost= gethostbyname(dwaddress);
+	const auto dwSrvHost= gethostbyname(dwaddress);
         
 	if (dwSrvHost == nullptr) {
 	// invalid hostname/no dns

--- a/FD502/becker.h
+++ b/FD502/becker.h
@@ -2,7 +2,7 @@
 #define __BECKER_H__
 
 void becker_enable(bool);                        // enable or disable
-int becker_sethost(char *, char *);              // server ip address, port
+int becker_sethost(const char *, const char *);  // server ip address, port
 unsigned char becker_read(unsigned short);       // coco port
 void becker_write(unsigned char,unsigned short); // value, coco port
 void becker_status(char *);                      // becker status for status line

--- a/FD502/distortc.cpp
+++ b/FD502/distortc.cpp
@@ -15,11 +15,10 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "windows.h"
-#include "stdio.h"
-#include "stdlib.h"
+#include <Windows.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "distoRTC.h"
-#include "windows.h"
 
 /* Table description:							   Bit3  Bit2  Bit1  Bit0
 Write to $FF51 read from $FF50

--- a/FD502/distortc.cpp
+++ b/FD502/distortc.cpp
@@ -18,7 +18,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "distoRTC.h"
+#include "distortc.h"
 
 /* Table description:							   Bit3  Bit2  Bit1  Bit0
 Write to $FF51 read from $FF50

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -40,11 +40,13 @@ This file is part of VCC (Virtual Color Computer).
 #include "becker.h"
 #endif
 
-#define EXTROMSIZE 16384
+constexpr auto EXTROMSIZE = 16384u;
 
 using namespace std;
 
 extern DiskInfo Drive[5];
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*PAKINTERUPT)(unsigned char, unsigned char);

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -599,7 +599,7 @@ long CreateDiskHeader(char *FileName,unsigned char Type,unsigned char Tracks,uns
 	unsigned short TrackSize=0x1900;
 	unsigned char IgnoreDensity=0,SingleDensity=0,HeaderSize=0;
 	unsigned long BytesWritten=0,FileSize=0;
-	hr=CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,0,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,0);
+	hr=CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,nullptr,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,nullptr);
 	if (hr==INVALID_HANDLE_VALUE)
 		return 1; //Failed to create File
 
@@ -653,9 +653,9 @@ long CreateDiskHeader(char *FileName,unsigned char Type,unsigned char Tracks,uns
 		break;
 
 	}
-	SetFilePointer(hr,0,0,FILE_BEGIN);
+	SetFilePointer(hr,0,nullptr,FILE_BEGIN);
 	WriteFile(hr,HeaderBuffer,HeaderSize,&BytesWritten,nullptr);
-	SetFilePointer(hr,FileSize-1,0,FILE_BEGIN);
+	SetFilePointer(hr,FileSize-1,nullptr,FILE_BEGIN);
 	WriteFile(hr,&Dummy,1,&BytesWritten,nullptr);
 	CloseHandle(hr);
 	return 0;

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 #pragma warning( disable : 4800 ) // For legacy builds
 
 //#define USE_LOGGING
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include <iostream>
 #include "resource.h"
@@ -310,7 +310,6 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 			SendDlgItemMessage (hDlg,IDC_BECKER_PORT,WM_SETTEXT,0,(LPARAM)(LPCSTR)BeckerPort);
 
 			return TRUE;
-		break;
 
 		case WM_COMMAND:
 			switch (LOWORD(wParam))
@@ -513,7 +512,6 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
 		case WM_CLOSE:
 			EndDialog(hDlg,LOWORD(wParam));  //Modal dialog
 			return TRUE;
-			break;
 
 		case WM_INITDIALOG:
 			for (temp=0;temp<=2;temp++)
@@ -585,7 +583,6 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
 					return FALSE;
 			}
 			return TRUE;
-		break;
 	}
     return FALSE;
 }

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -73,7 +73,7 @@ LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
 LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
 void LoadConfig(void);
 void SaveConfig(void);
-long CreateDiskHeader(char *,unsigned char,unsigned char,unsigned char);
+long CreateDiskHeader(const char *,unsigned char,unsigned char,unsigned char);
 void Load_Disk(unsigned char);
 void CenterDialog(HWND hDlg);
 
@@ -82,7 +82,7 @@ static HINSTANCE g_hinstDLL;
 static unsigned long RealDisks=0;
 long CreateDisk (unsigned char);
 static char TempFileName[MAX_PATH]="";
-unsigned char LoadExtRom( unsigned char,char *);
+unsigned char LoadExtRom( unsigned char, const char *);
 
 int BeckerEnabled=0;
 char BeckerAddr[MAX_PATH]="";
@@ -169,7 +169,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();
@@ -587,7 +587,7 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
     return FALSE;
 }
 
-long CreateDiskHeader(char *FileName,unsigned char Type,unsigned char Tracks,unsigned char DblSided)
+long CreateDiskHeader(const char *FileName,unsigned char Type,unsigned char Tracks,unsigned char DblSided)
 {
 	HANDLE hr=nullptr;
 	unsigned char Dummy=0;
@@ -748,7 +748,7 @@ void SaveConfig(void)
 	return;
 }
 
-unsigned char LoadExtRom( unsigned char RomType,char *FilePath)	//Returns 1 on if loaded
+unsigned char LoadExtRom( unsigned char RomType,const char *FilePath)	//Returns 1 on if loaded
 {
 
 	FILE *rom_handle=nullptr;

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -265,7 +265,7 @@ void CenterDialog(HWND hDlg)
     SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
-LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	static unsigned char temp=0,temp2=0;
 	long ChipChoice[3]={IDC_EXTROM,IDC_TRSDOS,IDC_RGB};
@@ -500,7 +500,7 @@ long CreateDisk (unsigned char Disk)
 	return 0;
 }
 
-LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	unsigned char temp=0,temp2=0;
 	static unsigned char NewDiskType=JVC,NewDiskTracks=2,DblSided=1;

--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -32,6 +32,8 @@ void BuildDynaMenu(void);
 #define SLAVE 1
 #define STANDALONE 2
 
+// FIXME: These need to be turned into a scoped enum and the signature of functions
+// that use them updated.
 #define External 0
 #define TandyDisk 1
 #define RGBDisk 2

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -297,10 +297,10 @@ unsigned char MountDisk(char *FileName,unsigned char disk)
 
 	if (Drive[disk].RawDrive==0)
 	{
-		Drive[disk].FileHandle = CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+		Drive[disk].FileHandle = CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 		if (Drive[disk].FileHandle==INVALID_HANDLE_VALUE)
 		{	//Can't open read/write might be read only
-			Drive[disk].FileHandle = CreateFile(FileName,GENERIC_READ,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+			Drive[disk].FileHandle = CreateFile(FileName,GENERIC_READ,0,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 			Drive[disk].WriteProtect=0xFF;
 		}
 		if (Drive[disk].FileHandle==INVALID_HANDLE_VALUE)

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -31,7 +31,7 @@ This file is part of VCC (Virtual Color Computer).
 *																				*
 ********************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <winioctl.h>

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -51,7 +51,7 @@ unsigned char WriteBytetoSector (unsigned char);
 unsigned char WriteBytetoTrack  (unsigned char);
 unsigned char (*WriteBytetoDisk)(unsigned char)=&WriteBytetoSector;
 
-unsigned char MountDisk(char *,unsigned char);
+unsigned char MountDisk(const char *filename,unsigned char);
 void DispatchCommand(unsigned char);
 void DecodeControlReg(unsigned char);
 void SetType1Flags(unsigned char);
@@ -59,12 +59,12 @@ void SetType2Flags(unsigned char);
 void SetType3Flags(unsigned char);
 
 long ReadSector (unsigned char,unsigned char,unsigned char,unsigned char *);
-long WriteSector(unsigned char,unsigned char,unsigned char,unsigned char *,long);
+long WriteSector(unsigned char,unsigned char,unsigned char,const unsigned char *,long);
 long ReadTrack  (unsigned char,unsigned char,unsigned char,unsigned char *);
-long WriteTrack (unsigned char,unsigned char,unsigned char,unsigned char *);
+long WriteTrack (unsigned char,unsigned char,unsigned char,const unsigned char *);
 
 unsigned short ccitt_crc16(unsigned short crc, const unsigned char *, unsigned short );
-long GetSectorInfo (SectorInfo *,unsigned char *);
+long GetSectorInfo (SectorInfo *,const unsigned char *);
 void CommandDone(void);
 extern unsigned char PhysicalDriveA,PhysicalDriveB;
 bool FormatTrack (HANDLE , BYTE , BYTE,BYTE );
@@ -241,7 +241,7 @@ void DecodeControlReg(unsigned char Tmp)
 	return;
 }
 
-int mount_disk_image(char filename[MAX_PATH],unsigned char drive)
+int mount_disk_image(const char *filename,unsigned char drive)
 {
 	unsigned int Temp=0;
 	Temp=MountDisk(filename,drive);
@@ -273,7 +273,7 @@ void DiskStatus(char *Status)
 	return;
 }
 
-unsigned char MountDisk(char *FileName,unsigned char disk)
+unsigned char MountDisk(const char *FileName,unsigned char disk)
 {
 	unsigned long BytesRead=0;
 	unsigned char HeaderBlock[HEADERBUFFERSIZE]="";
@@ -399,7 +399,7 @@ long ReadSector (unsigned char Side,	//0 or 1
 	DWORD dwRet;
 	FD_SEEK_PARAMS sp;
 	unsigned char Ret=0;
-	unsigned char *pva=nullptr;
+	const unsigned char *pva=nullptr;
 //************************
 
 	if (Drive[CurrentDisk].FileHandle==nullptr)
@@ -473,7 +473,7 @@ long ReadSector (unsigned char Side,	//0 or 1
 long WriteSector (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
 					unsigned char Sector,	//1 to 18 could be 0 to 17
-					unsigned char *WriteBuffer, //)
+				    const unsigned char *WriteBuffer, //)
 					long BytestoWrite)
 {
 	unsigned long BytesWritten=0,Result=0,BytesRead=0;
@@ -484,7 +484,7 @@ long WriteSector (	unsigned char Side,		//0 or 1
 	DWORD dwRet;
 	FD_SEEK_PARAMS sp;
 	unsigned char Ret=0;
-	unsigned char *pva=nullptr;
+	const unsigned char *pva=nullptr;
 	SectorInfo CurrentSector;
 	if ( (Drive[CurrentDisk].FileHandle==nullptr) | ((Side+1) > Drive[CurrentDisk].Sides) )
 		return 0;
@@ -547,7 +547,7 @@ long WriteSector (	unsigned char Side,		//0 or 1
 long WriteTrack (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
 					unsigned char /*Dummy*/,	//Sector Value unused
-					unsigned char *WriteBuffer)
+					const unsigned char *WriteBuffer)
 {
 	unsigned char xTrack=0,xSide=0,xSector=0,xLenth=0;
 	unsigned short BufferIndex=0,WriteIndex=0,IdamIndex=0;
@@ -1255,7 +1255,7 @@ unsigned char SetTurboDisk( unsigned char Tmp)
 	return TurboMode;
 }
 
-long GetSectorInfo (SectorInfo *Sector,unsigned char *TempBuffer)
+long GetSectorInfo (SectorInfo *Sector,const unsigned char *TempBuffer)
 {
 	unsigned short Temp1=0,Temp2=0;
 	unsigned char Density=0;

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -42,10 +42,10 @@ This file is part of VCC (Virtual Color Computer).
 #include "fdrawcmd.h"	// http://simonowen.com/fdrawcmd/
 /****************Fuction Protos for this Module************/
 
-unsigned char GetBytefromSector (unsigned char);
-unsigned char GetBytefromAddress(unsigned char);
-unsigned char GetBytefromTrack  (unsigned char);
-unsigned char (*GetBytefromDisk)(unsigned char)=&GetBytefromSector;
+unsigned char GetBytefromSector ();
+unsigned char GetBytefromAddress();
+unsigned char GetBytefromTrack  ();
+unsigned char (*GetBytefromDisk)()=&GetBytefromSector;
 
 unsigned char WriteBytetoSector (unsigned char);
 unsigned char WriteBytetoTrack  (unsigned char);
@@ -136,7 +136,7 @@ unsigned char disk_io_read(unsigned char port)
 			if (CurrentCommand==IDLE)
 				temp=DataReg;
 			else
-				temp=GetBytefromDisk(0);
+				temp=GetBytefromDisk();
 			break;
 
 		case 0x40:	//Control Register can't be read
@@ -546,7 +546,7 @@ long WriteSector (	unsigned char Side,		//0 or 1
 
 long WriteTrack (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
-					unsigned char Dummy,	//Sector Value unused
+					unsigned char /*Dummy*/,	//Sector Value unused
 					unsigned char *WriteBuffer)
 {
 	unsigned char xTrack=0,xSide=0,xSector=0,xLenth=0;
@@ -646,7 +646,7 @@ long WriteTrack (	unsigned char Side,		//0 or 1
 
 long ReadTrack (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
-					unsigned char Dummy,	//Sector Value unused
+					unsigned char /*Dummy*/,	//Sector Value unused
 					unsigned char *WriteBuffer)
 {
 	unsigned long BytesRead=0,Result=0;
@@ -811,7 +811,7 @@ void PingFdc(void)
 			if (IOWaiter>WAITTIME)
 			{
 				LostDataFlag=1;
-				GetBytefromSector(0);
+				GetBytefromSector();
 			}
 		break;
 
@@ -830,7 +830,7 @@ void PingFdc(void)
 			if (IOWaiter>WAITTIME)
 			{
 				LostDataFlag=1;
-				GetBytefromAddress (0);	
+				GetBytefromAddress ();	
 			}
 		break;
 
@@ -841,7 +841,7 @@ void PingFdc(void)
 			if (IOWaiter>WAITTIME)
 			{
 				LostDataFlag=1;
-				GetBytefromTrack(0);
+				GetBytefromTrack();
 			}
 		break;
 
@@ -981,7 +981,7 @@ void DispatchCommand(unsigned char Tmp)
 	return;
 }
 
-unsigned char GetBytefromSector (unsigned char Tmp)
+unsigned char GetBytefromSector ()
 {
 	unsigned char RetVal=0;
 
@@ -1020,7 +1020,7 @@ unsigned char GetBytefromSector (unsigned char Tmp)
 	return RetVal;
 }
 
-unsigned char GetBytefromAddress (unsigned char Tmp)
+unsigned char GetBytefromAddress ()
 {
 	unsigned char RetVal=0;
 	unsigned short Crc=0;
@@ -1080,7 +1080,7 @@ unsigned char GetBytefromAddress (unsigned char Tmp)
 	return RetVal;
 }
 
-unsigned char GetBytefromTrack (unsigned char Tmp)
+unsigned char GetBytefromTrack ()
 {
 	unsigned char RetVal=0;
 

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -51,13 +51,13 @@ struct DiskInfo
 
 struct SectorInfo
 {
-	unsigned char Track;
-	unsigned char Side;
-	unsigned char Sector;
-	unsigned short Lenth;
-	unsigned short CRC;
-	long DAM;
-	unsigned char Density;
+	unsigned char Track = 0;
+	unsigned char Side = 0;
+	unsigned char Sector = 0;
+	unsigned short Lenth = 0;
+	unsigned short CRC = 0;
+	long DAM = 0;
+	unsigned char Density = 0;
 };
 
 

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -20,7 +20,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 unsigned char disk_io_read(unsigned char port);
 void disk_io_write(unsigned char data,unsigned char port);	
-int mount_disk_image(char *,unsigned char );
+int mount_disk_image(const char *,unsigned char );
 void unmount_disk_image(unsigned char drive);
 void DiskStatus(char *);
 void PingFdc(void);

--- a/Fileops.cpp
+++ b/Fileops.cpp
@@ -122,13 +122,13 @@ DWORD WritePrivateProfileInt(LPCTSTR SectionName,LPCTSTR KeyName,int KeyValue,LP
 	return(WritePrivateProfileString(SectionName,KeyName,Buffer,IniFileName));
 }
 
-BOOL FilePrintf(HANDLE hFile, const void * fmt, ...)
+BOOL FilePrintf(HANDLE hFile, const char* fmt, ...)
 {
 	DWORD dummy;
 	va_list args;
 	char msg[512];
 	va_start(args, fmt);
-	vsnprintf(msg, 512, (char *)fmt, args);
+	vsnprintf(msg, 512, fmt, args);
 	va_end(args);
 	return WriteFile(hFile,msg,strlen(msg),&dummy,nullptr);
 }

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -14,9 +14,7 @@ Cartridge* Cartridge::m_Singleton(nullptr);
 Cartridge::Cartridge(std::string name, std::string catalogId)
 	:
 	m_Name(move(name)),
-	m_CatalogId(move(catalogId)),
-	AssetCartridgeLinePtr(detail::NullAssetCartridgeLine),
-	AddMenuItemPtr(detail::NullAddMenuItem)
+	m_CatalogId(move(catalogId))
 {
 	if (m_Singleton)
 	{

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -41,7 +41,7 @@ void Cartridge::LoadConfiguration(const std::string& /*filename*/)
 }
 
 
-void Cartridge::LoadMenu()
+void Cartridge::LoadMenuItems()
 {
 }
 
@@ -72,7 +72,7 @@ void Cartridge::SetConfigurationPath(std::string path)
 {
 	m_ConfigurationPath = move(path);
 	LoadConfiguration(m_ConfigurationPath);
-	LoadMenu();
+	LoadMenuItems();
 }
 
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -40,23 +40,23 @@ protected:
 		StandAlone
 	};
 
-	void AssetCartridgeLine(bool state)
+	void AssetCartridgeLine(bool state) const
 	{
 		AssetCartridgeLinePtr(state);
 	}
 
-	void AddMenuSeparator()
+	void AddMenuSeparator() const
 	{
 		AddMenuItem("", 6000, ItemType::Head);
 	}
 
-	void AddMenuItem(const std::string& name, int id, ItemType type)
+	void AddMenuItem(const std::string& name, int id, ItemType type) const
 	{
 		AddMenuItemPtr(name.c_str(), id, static_cast<int>(type));
 	}
 
 	virtual void LoadConfiguration(const std::string& filename);
-	virtual void LoadMenu();
+	virtual void LoadMenuItems();
 
 
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CartridgeTrampolines.h"
+#include "detail/default_handlers.h"
 #include <string>
 
 
@@ -80,6 +81,6 @@ private:
 	std::string			m_Name;
 	std::string			m_CatalogId;
 	std::string			m_ConfigurationPath;
-	SETCART				AssetCartridgeLinePtr;
-	DYNAMICMENUCALLBACK AddMenuItemPtr;
+	SETCART				AssetCartridgeLinePtr = detail::NullAssetCartridgeLine;
+	DYNAMICMENUCALLBACK AddMenuItemPtr = detail::NullAddMenuItem;
 };

--- a/GMC/GMC.h
+++ b/GMC/GMC.h
@@ -7,6 +7,8 @@
 #define GMC_EXPORT
 #endif
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void(*SETCART)(unsigned char);
 typedef void(*SETCARTPOINTER)(SETCART);
 typedef void(*DYNAMICMENUCALLBACK)(const char *, int, int);

--- a/GMC/GMCCartridge.cpp
+++ b/GMC/GMCCartridge.cpp
@@ -57,7 +57,7 @@ void GMCCartridge::OnMenuItemSelected(unsigned char menuId)
 			"ROM Selected",
 			MB_OK);
 
-		m_Configuration.SetActiveRom(selectedFile.data());
+		m_Configuration.SetActiveRom(selectedFile);
 
 		AssetCartridgeLine(false);
 		AssetCartridgeLine(true);

--- a/GMC/GMCCartridge.cpp
+++ b/GMC/GMCCartridge.cpp
@@ -1,10 +1,6 @@
 #include "GMCCartridge.h"
 #include <Windows.h>
 
-#undef AddMenuSeparator
-
-#undef AddMenuItem
-#undef LoadMenu
 
 GMCCartridge::GMCCartridge()
 	: Cartridge("Game Master Catridge", "SN76489")
@@ -18,7 +14,7 @@ void GMCCartridge::LoadConfiguration(const std::string& filename)
 }
 
 
-void GMCCartridge::LoadMenu()
+void GMCCartridge::LoadMenuItems()
 {
 	AddMenuItem("", 0, ItemType::Head);
 	AddMenuSeparator();

--- a/GMC/GMCCartridge.h
+++ b/GMC/GMCCartridge.h
@@ -12,7 +12,6 @@ public:
 	GMCCartridge();
 
 	void LoadConfiguration(const std::string& filename) override;
-	void LoadMenu() override;
 
 	std::string GetStatusMessage() const override;
 	void OnMenuItemSelected(unsigned char menuId) override;
@@ -21,6 +20,12 @@ public:
 	unsigned char OnReadMemory(unsigned short address) const override;
 	void OnWritePort(unsigned char port, unsigned char data) override;
 	unsigned char OnReadPort(unsigned char port) const override;
+
+
+protected:
+
+	void LoadMenuItems() override;
+
 
 private:
 

--- a/GMC/ROM.cpp
+++ b/GMC/ROM.cpp
@@ -1,6 +1,6 @@
 #include "ROM.h"
 #include <fstream>
-#include <windows.h>
+#include <Windows.h>
 using namespace std;
 
 bool ROM::Load(std::string filename)

--- a/GMC/detail/default_handlers.h
+++ b/GMC/detail/default_handlers.h
@@ -1,0 +1,5 @@
+namespace detail
+{
+	void NullAssetCartridgeLine(unsigned char);
+	void NullAddMenuItem(const char*, int, int);
+}

--- a/GMC/gmc.vcxproj
+++ b/GMC/gmc.vcxproj
@@ -259,6 +259,7 @@
   <ItemGroup>
     <ClInclude Include="CartridgeTrampolines.h" />
     <ClInclude Include="Configuration.h" />
+    <ClInclude Include="detail\default_handlers.h" />
     <ClInclude Include="GMC.h" />
     <ClInclude Include="Cartridge.h" />
     <ClInclude Include="GMCCartridge.h" />

--- a/GMC/gmc.vcxproj.filters
+++ b/GMC/gmc.vcxproj.filters
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Cartridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CartridgeTrampolines.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Configuration.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="GMCCartridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ROM.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="sn76496.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="detail\default_handlers.h">
+      <Filter>Header Files\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="Cartridge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CartridgeTrampolines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Configuration.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GMC.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GMCCartridge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ROM.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="sn76496.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Resource Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{91041c29-a58e-47d1-be3c-2181e226240f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{1bc76e3c-f021-4d3d-9abc-d398f3daab81}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\detail">
+      <UniqueIdentifier>{9281fe40-ccf9-438e-b774-607516e595a9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{c2b09bad-8285-4ea1-9cde-aaaa010a2925}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="GMC.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/GMC/main.cpp
+++ b/GMC/main.cpp
@@ -1,5 +1,5 @@
 #include "GMCCartridge.h"
-#include <windows.h>
+#include <Windows.h>
 
 GMCCartridge theCart;
 
@@ -41,7 +41,7 @@ std::string SelectROMFile()
 		selectedPath.clear();
 	}
 
-	return move(selectedPath);
+	return selectedPath;
 }
 
 

--- a/GMC/sn76496.cpp
+++ b/GMC/sn76496.cpp
@@ -285,7 +285,7 @@ void SN76489Device::write(uint8_t data)
 	}
 }
 
-inline bool SN76489Device::in_noise_mode()
+inline bool SN76489Device::in_noise_mode() const
 {
 	return ((m_register[6] & 4) != 0);
 }

--- a/GMC/sn76496.cpp
+++ b/GMC/sn76496.cpp
@@ -143,14 +143,6 @@
 
 
 SN76489Device::SN76489Device()
-	: m_feedback_mask(0x4000)
-	, m_period_divider(6.11f)
-	, m_whitenoise_tap1(0x01)
-	, m_whitenoise_tap2(0x02)
-	, m_negate(false)	//	Was true!
-	, m_stereo(false)
-	, m_ncr_style_psg(false)
-	, m_sega_style_psg(true)
 {}
 
 

--- a/GMC/sn76496.cpp
+++ b/GMC/sn76496.cpp
@@ -142,13 +142,6 @@
 #define MAX_OUTPUT 0x7fff
 
 
-SN76489Device::SN76489Device()
-{}
-
-
-
-
-
 void SN76489Device::device_start()
 {
 	for (int i = 0; i < 8; i += 2)

--- a/GMC/sn76496.h
+++ b/GMC/sn76496.h
@@ -28,25 +28,25 @@ private:
 	void            countdown_cycles();
 
 
-	const int32_t	m_feedback_mask;    // mask for feedback
-	const int32_t	m_whitenoise_tap1;  // mask for white noise tap 1 (higher one, usually bit 14)
-	const int32_t	m_whitenoise_tap2;  // mask for white noise tap 2 (lower one, usually bit 13)
-	const bool		m_negate;           // output negate flag
-	const bool		m_stereo;           // whether we're dealing with stereo or not
-	const float		m_period_divider;   // period divider
-	const bool		m_ncr_style_psg;    // flag to ignore writes to regs 1,3,5,6,7 with bit 7 low
-	const bool		m_sega_style_psg;   // flag to make frequency zero acts as if it is one more than max (0x3ff+1) or if it acts like 0; the initial register is pointing to 0x3 instead of 0x0; the volume reg is preloaded with 0xF instead of 0x0
+	const int32_t	m_feedback_mask = 0x4000;	// mask for feedback
+	const int32_t	m_whitenoise_tap1 = 0x01;	// mask for white noise tap 1 (higher one, usually bit 14)
+	const int32_t	m_whitenoise_tap2 = 0x02;	// mask for white noise tap 2 (lower one, usually bit 13)
+	const bool		m_negate = false;			// output negate flag
+	const bool		m_stereo = false;			// whether we're dealing with stereo or not
+	const float		m_period_divider = 6.11f;	// period divider
+	const bool		m_ncr_style_psg = false;	// flag to ignore writes to regs 1,3,5,6,7 with bit 7 low
+	const bool		m_sega_style_psg = true;	// flag to make frequency zero acts as if it is one more than max (0x3ff+1) or if it acts like 0; the initial register is pointing to 0x3 instead of 0x0; the volume reg is preloaded with 0xF instead of 0x0
 
-	int32_t         m_vol_table[16];    // volume table (for 4-bit to db conversion)
+	int32_t         m_vol_table[16] = { 0 };	// volume table (for 4-bit to db conversion)
 
-	bool            m_ready_state;
-	int32_t         m_cycles_to_ready;  // number of cycles until the READY line goes active
-	int32_t         m_register[8];      // registers
-	int32_t         m_last_register;    // last register written
-	uint32_t        m_RNG;              // noise generator LFSR
-	int32_t         m_stereo_mask;      // the stereo output mask
-	int32_t         m_period[4];        // Length of 1/2 of waveform
-	int32_t         m_volume[4];        // db volume of voice 0-2 and noise
-	int32_t         m_count[4];         // Position within the waveform
-	int32_t         m_output[4];        // 1-bit output of each channel, pre-volume
+	bool            m_ready_state = false;
+	int32_t         m_cycles_to_ready = 0;	// number of cycles until the READY line goes active
+	int32_t         m_register[8] = { 0 };	// registers
+	int32_t         m_last_register = 0;	// last register written
+	uint32_t        m_RNG = 0;				// noise generator LFSR
+	int32_t         m_stereo_mask = 0;		// the stereo output mask
+	int32_t         m_period[4] = { 0 };	// Length of 1/2 of waveform
+	int32_t         m_volume[4] = { 0 };	// db volume of voice 0-2 and noise
+	int32_t         m_count[4] = { 0 };		// Position within the waveform
+	int32_t         m_output[4] = { 0 };	// 1-bit output of each channel, pre-volume
 };

--- a/GMC/sn76496.h
+++ b/GMC/sn76496.h
@@ -10,7 +10,7 @@ public:
 
 	using stream_sample_t = unsigned short;
 
-	SN76489Device();
+	SN76489Device() = default;
 	virtual ~SN76489Device() = default;
 
 	virtual void device_start();

--- a/GMC/sn76496.h
+++ b/GMC/sn76496.h
@@ -11,6 +11,7 @@ public:
 	using stream_sample_t = unsigned short;
 
 	SN76489Device();
+	virtual ~SN76489Device() = default;
 
 	virtual void device_start();
 	virtual void write(uint8_t data);
@@ -23,7 +24,7 @@ protected:
 
 private:
 
-	inline bool     in_noise_mode();
+	inline bool     in_noise_mode() const;
 	void            countdown_cycles();
 
 

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -51,7 +51,7 @@ This file is part of VCC (Virtual Color Computer).
 *   Note: This is not an issue for Vcc.
 ****************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "cc3vhd.h"
 #include "harddisk.h"

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -56,7 +56,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "cc3vhd.h"
 #include "harddisk.h"
 #include "defines.h"
-#include "..\fileops.h"
+#include "../fileops.h"
 
 typedef union {
     unsigned int All;

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -102,15 +102,15 @@ int MountHD(const char* FileName, int drive)
     DMAaddress.word = 0;
     HardDrive[drive] = CreateFile( FileName,
                                    GENERIC_READ | GENERIC_WRITE,
-                                   0,0,OPEN_EXISTING,
-                                   FILE_ATTRIBUTE_NORMAL,0);
+                                   0,nullptr,OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL,nullptr);
 
     // If can't open read/write try read only.
     if (HardDrive[drive] == INVALID_HANDLE_VALUE) {
         HardDrive[drive] = CreateFile( FileName,
                                        GENERIC_READ,
-                                       0,0,OPEN_EXISTING,
-                                       FILE_ATTRIBUTE_NORMAL,0);
+                                       0,nullptr,OPEN_EXISTING,
+                                       FILE_ATTRIBUTE_NORMAL,nullptr);
         WpHD[drive]=1; // drive is write protected
     }
 
@@ -162,7 +162,7 @@ void HDcommand(unsigned char Command) {
         }
 
         // Seek desired sector
-        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,0,FILE_BEGIN);
+        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,nullptr,FILE_BEGIN);
 
         // Read it; zero fill if past end of file
         ReadFile(HardDrive[DriveSelect],SectorBuffer,SECTORSIZE,&BytesMoved,nullptr);
@@ -199,7 +199,7 @@ void HDcommand(unsigned char Command) {
         }
 
         // Seek desired sector
-        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,0,FILE_BEGIN);
+        SetFilePointer(HardDrive[DriveSelect],SectorOffset.All,nullptr,FILE_BEGIN);
 
         // Write it
         WriteFile(HardDrive[DriveSelect],SectorBuffer,SECTORSIZE,&BytesMoved,nullptr);

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -87,7 +87,7 @@ unsigned long BytesMoved=0;
 
 void HDcommand(unsigned char);
 
-int MountHD(char FileName[MAX_PATH], int drive)
+int MountHD(const char* FileName, int drive)
 {
     drive = drive&1;  // Drive can be 0 or 1
 

--- a/HardDisk/cc3vhd.h
+++ b/HardDisk/cc3vhd.h
@@ -35,19 +35,20 @@ void VhdReset(void);
 #define SLAVE 1
 #define STANDALONE 2
 
-//#define DRIVESIZE 130
-#define DRIVESIZE 512 // Mb
-#define MAX_SECTOR DRIVESIZE*1024*1024
-#define SECTORSIZE 256
+constexpr auto DRIVESIZE = 512u; // Mb
+constexpr auto MAX_SECTOR = DRIVESIZE * 1024 * 1024;
+constexpr auto SECTORSIZE = 256u;
 
-#define HD_OK        0
-#define HD_PWRUP    -1
-#define HD_INVLD    -2
-#define HD_NODSK     4
-#define HD_WP        5
+// FIXME: These need should probably be turned into a scoped enum.
+constexpr auto HD_OK	= 0;
+constexpr auto HD_PWRUP	= -1;
+constexpr auto HD_INVLD	= -2;
+constexpr auto HD_NODSK	= 4;
+constexpr auto HD_WP	= 5;
 
-#define SECTOR_READ     0
-#define SECTOR_WRITE    1
-#define DISK_FLUSH      2
+// FIXME: These need should probably be turned into a scoped enum.
+constexpr auto SECTOR_READ	= 0u;
+constexpr auto SECTOR_WRITE	= 1u;
+constexpr auto DISK_FLUSH	= 2u;
 
 #endif

--- a/HardDisk/cc3vhd.h
+++ b/HardDisk/cc3vhd.h
@@ -22,7 +22,7 @@ along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licens
 // cc3vhd.h
 
 void UnmountHD(int);
-int MountHD(char [256], int);
+int MountHD(const char*, int);
 unsigned char IdeRead(unsigned char);
 void IdeWrite (unsigned char, unsigned char);
 void DiskStatus(char *);

--- a/HardDisk/cloud9.cpp
+++ b/HardDisk/cloud9.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 *																		*
 ************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include "cloud9.h"
 
 static 	SYSTEMTIME now;

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -155,7 +155,7 @@ void CenterDialog(HWND hDlg)
     SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
-LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
     switch (message)
     {
@@ -404,7 +404,7 @@ void BuildDynaMenu(void)
 
 
 // Dialog for creating a new hard disk
-LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
     unsigned int hdsize=DEF_HD_SIZE;
     switch (message)

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -29,7 +29,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "../DialogOps.h"
 #include "../MachineDefs.h"
 
-#define DEF_HD_SIZE 132480
+constexpr auto DEF_HD_SIZE = 132480u;
 
 static char VHDfile0[MAX_PATH] { 0 };
 static char VHDfile1[MAX_PATH] { 0 };
@@ -38,6 +38,8 @@ static char NewVHDfile[MAX_PATH];
 static char IniFile[MAX_PATH]  { 0 };
 static char HardDiskPath[MAX_PATH];
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -246,7 +246,7 @@ extern "C"
 extern "C"
 {
     __declspec(dllexport) void
-    SetIniPath (char *IniFilePath)
+    SetIniPath (const char *IniFilePath)
     {
         strcpy(IniFile,IniFilePath);
         LoadConfig();

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -437,7 +437,7 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 int CreateDisk(HWND hDlg, int hdsize)
 {
     HANDLE hr=CreateFile( NewVHDfile, GENERIC_READ | GENERIC_WRITE,
-                          0,0,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,0);
+                          0,nullptr,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,nullptr);
     if (hr==INVALID_HANDLE_VALUE) {
         *NewVHDfile='\0';
         MessageBox(hDlg,"Can't create File","Error",0);
@@ -445,7 +445,7 @@ int CreateDisk(HWND hDlg, int hdsize)
     }
 
     if (hdsize>0) {
-        SetFilePointer(hr, hdsize * 1024, 0, FILE_BEGIN);
+        SetFilePointer(hr, hdsize * 1024, nullptr, FILE_BEGIN);
         SetEndOfFile(hr);
     }
 

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -18,7 +18,7 @@ This file is part of VCC (Virtual Color Computer).
 
 // hardisk.cpp : Defines the entry point for the DLL application.
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include<iostream>
 #include "resource.h"

--- a/MMUMonitor.cpp
+++ b/MMUMonitor.cpp
@@ -87,7 +87,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 	// Draw the Monitor Window
-	void DrawMMUMonitor(HDC hdc, LPRECT clientRect)
+	void DrawMMUMonitor(HDC hdc, LPCRECT clientRect)
 	{
 		RECT rect = *clientRect;
 
@@ -95,8 +95,8 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		HBRUSH brush = (HBRUSH)GetStockObject(WHITE_BRUSH);
 		FillRect(hdc, &rect, brush);
 
-		HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, rgbGray);
-		HPEN thickPen = (HPEN)CreatePen(PS_SOLID, 2, rgbGray);
+		HPEN pen = CreatePen(PS_SOLID, 1, rgbGray);
+		HPEN thickPen = CreatePen(PS_SOLID, 2, rgbGray);
 
 		HFONT hFont = CreateFont(14, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE,
 		                         DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,

--- a/MachineDefs.h
+++ b/MachineDefs.h
@@ -9,24 +9,24 @@ namespace VCC
 	struct CPUState
 	{
 		//  
-		unsigned char DP;
-		unsigned char CC;
-		unsigned char MD;
+		unsigned char DP = 0;
+		unsigned char CC = 0;
+		unsigned char MD = 0;
 		//
-		unsigned char A;
-		unsigned char B;
-		unsigned char E;
-		unsigned char F;
-		unsigned short X;
-		unsigned short Y;
-		unsigned short U;
-		unsigned short S;
-		unsigned short PC;
-		unsigned short V;
+		unsigned char A = 0;
+		unsigned char B = 0;
+		unsigned char E = 0;
+		unsigned char F = 0;
+		unsigned short X = 0;
+		unsigned short Y = 0;
+		unsigned short U = 0;
+		unsigned short S = 0;
+		unsigned short PC = 0;
+		unsigned short V = 0;
 		//
-		bool IsNative6309;
-		bool phyAddr;               // Decode using block relative addressing
-		unsigned short block;       // Physical address = PC + block * 0x2000
+		bool IsNative6309 = false;
+		bool phyAddr = false;		// Decode using block relative addressing
+		unsigned short block = 0;	// Physical address = PC + block * 0x2000
 	};
 
 	// Trace Events
@@ -54,19 +54,19 @@ namespace VCC
 	// CPU Execution Tracing
 	struct CPUTrace
 	{
-		TraceEvent event;					// Trace Event type
-		int frame;							// Frame being rendered
-		int line;							// Line being rendered
-		long cycleTime;						// Time since Trace start in CPU cycles
-		unsigned short pc;					// Program Counter at time of event
+		TraceEvent event = TraceEvent::Instruction;	// Trace Event type
+		int frame = 0;						// Frame being rendered
+		int line = 0;						// Line being rendered
+		long cycleTime = 0;					// Time since Trace start in CPU cycles
+		unsigned short pc = 0;				// Program Counter at time of event
 		std::vector<unsigned char> bytes;	// Op code bytes
 		std::string instruction;			// Instruction
 		std::string operand;				// Instruction Operand
 		CPUState startState;				// CPU State before instruction
 		CPUState endState;					// CPU State after instruction
-		int execCycles;						// Number of cycles indicated by emulator
-		int decodeCycles;					// Number of cycles from OpDecoder
-		int emulationState;					// State switch in emulation cycles
+		int execCycles = 0;					// Number of cycles indicated by emulator
+		int decodeCycles = 0;				// Number of cycles from OpDecoder
+		int emulationState = 0;				// State switch in emulation cycles
 		std::vector<double> emulator;		// Emulation Tracing
 	};
 

--- a/MemoryMap.cpp
+++ b/MemoryMap.cpp
@@ -40,8 +40,8 @@ void FlashDialogWindow();
 void WriteMemory(int,unsigned char);
 void SetBackBuffer(const RECT&);
 void CreateScrollBar(const RECT&);
-void DrawForm(HDC,LPRECT);
-void DrawMemory(HDC,LPRECT);
+void DrawForm(HDC,LPCRECT);
+void DrawMemory(HDC,LPCRECT);
 void SetEditPosition(int,int);
 void LocateMemory();
 void CommitValue();
@@ -77,7 +77,7 @@ AddrMode AddrMode_ = AddrMode::NotSet;
 
 int MemSize = 0;
 int memoryOffset = 0;
-static unsigned char *Rom = nullptr;
+unsigned char *Rom = nullptr;
 bool Editing = false;
 int editAddress = 0;
 
@@ -349,7 +349,7 @@ void CreateScrollBar(const RECT& Rect)
 //------------------------------------------------------------------
 // Draw display form with header and vert guide lines
 //------------------------------------------------------------------
-void DrawForm(HDC hdc,LPRECT clientRect)
+void DrawForm(HDC hdc,LPCRECT clientRect)
 {
 	int top = clientRect->top;
 	int lft = clientRect->left;
@@ -395,7 +395,7 @@ void DrawForm(HDC hdc,LPRECT clientRect)
 //------------------------------------------------------------------
 // Fill memory data on form
 //------------------------------------------------------------------
-void DrawMemory(HDC hdc, LPRECT clientRect)
+void DrawMemory(HDC hdc, LPCRECT clientRect)
 {
 	int top = clientRect->top;
 	int lft = clientRect->left;
@@ -646,7 +646,7 @@ void InitializeDialog(HWND hDlg)
 		SetMemType();
 
 		// Set display pen color
-		HPEN pen = (HPEN) CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+		HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
 		SelectObject(BackBuf.DeviceContext, pen);
 		DeleteObject(pen);
 

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -466,13 +466,13 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	std::string OpCodeTables::ToInterRegister(unsigned char reg)
+	std::string OpCodeTables::ToInterRegister(unsigned char reg) const
 	{
 		std::vector<std::string> regs = { "D", "X", "Y", "U", "S", "PC", "W", "V", "A", "B", "CC", "DP", "0", "0", "E", "F" };
 		return regs[reg];
 	}
 
-	std::string OpCodeTables::ToRegister(unsigned char postbyte)
+	std::string OpCodeTables::ToRegister(unsigned char postbyte) const
 	{
 		int reg = (postbyte & 0b01100000) >> 5;
 		switch (reg)
@@ -489,7 +489,7 @@ namespace VCC { namespace Debugger
 		return "?";
 	}
 
-	std::string OpCodeTables::ToRelativeAddressString(int value, int oplen, int operandlen)
+	std::string OpCodeTables::ToRelativeAddressString(int value, int oplen, int operandlen) const
 	{
 		std::ostringstream fmt;
 
@@ -522,7 +522,7 @@ namespace VCC { namespace Debugger
 		return fmt.str();
 	}
 
-	int OpCodeTables::AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309)
+	int OpCodeTables::AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309) const
 	{
 		if (IsNative6309)
 		{

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -105,7 +105,7 @@ namespace VCC { namespace Debugger
 		case Indexed:
 			break;
 		case Relative:
-			trace.operand = ToRelativeAddressString(operand, opcode.oplen, operandLen);
+			trace.operand = ToRelativeAddressString(operand, operandLen);
 			break;
 		case Extended:
 			trace.operand = "$" + ToHexString(operand, 4);
@@ -305,7 +305,7 @@ namespace VCC { namespace Debugger
 
 		// All long branches are relative.
 		int operand = (trace.bytes[opcode.oplen] << 8) + trace.bytes[opcode.oplen + 1];
-		trace.operand = ToRelativeAddressString(operand, opcode.oplen, operandLen);
+		trace.operand = ToRelativeAddressString(operand, operandLen);
 
 		// No adjustment needed on 6309 
 		if (state.IsNative6309)
@@ -489,7 +489,7 @@ namespace VCC { namespace Debugger
 		return "?";
 	}
 
-	std::string OpCodeTables::ToRelativeAddressString(int value, int oplen, int operandlen) const
+	std::string OpCodeTables::ToRelativeAddressString(int value, int operandlen) const
 	{
 		std::ostringstream fmt;
 

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -26,7 +26,7 @@
 
 namespace VCC { namespace Debugger
 {
-	bool OpCodeTables::ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		bool valid = true;
 		trace.decodeCycles = state.IsNative6309 ? opcode.num6309cycles : opcode.num6809cycles;

--- a/OpCodeTables.cpp
+++ b/OpCodeTables.cpp
@@ -66,7 +66,7 @@ namespace VCC { namespace Debugger
 		return valid;
 	}
 
-	bool OpCodeTables::ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -134,7 +134,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -190,7 +190,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand)
+	bool OpCodeTables::GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand) const
 	{
 		// Convert to key.
 		std::string key = std::bitset<8>(postbyte).to_string();
@@ -198,7 +198,7 @@ namespace VCC { namespace Debugger
 		// MSB = 0?  5 bit offset.
 		if (key[0] == '0')
 		{
-			mode = IndexingModes["0RRnnnnn"];
+			mode = IndexingModes.at("0RRnnnnn");
 			operand = mode.form;
 
 			// Determine the register.
@@ -215,7 +215,7 @@ namespace VCC { namespace Debugger
 		// Try exact match.
 		if (IndexingModes.find(key) != IndexingModes.end())
 		{
-			mode = IndexingModes[key];
+			mode = IndexingModes.at(key);
 			operand = mode.form;
 			return true;
 		}
@@ -225,7 +225,7 @@ namespace VCC { namespace Debugger
 		key[2] = 'X';
 		if (IndexingModes.find(key) != IndexingModes.end())
 		{
-			mode = IndexingModes[key];
+			mode = IndexingModes.at(key);
 			operand = mode.form;
 			return true;
 		}
@@ -235,7 +235,7 @@ namespace VCC { namespace Debugger
 		key[2] = 'R';
 		if (IndexingModes.find(key) != IndexingModes.end())
 		{
-			mode = IndexingModes[key];
+			mode = IndexingModes.at(key);
 			operand = mode.form;
 			replace(operand, "R", ToRegister(postbyte));
 			return true;
@@ -245,13 +245,13 @@ namespace VCC { namespace Debugger
 		return false;
 	}
 
-	bool OpCodeTables::ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		trace.decodeCycles = AdjustCycles(opcode, 0, 0, state.IsNative6309);
 		return true;
 	}
 
-	bool OpCodeTables::ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -288,7 +288,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -373,7 +373,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Get the current PC.
 		unsigned short PC = state.PC;
@@ -406,7 +406,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		// Two rules:
 		//	1) DIVD executes in l fewer cycle if a two's-complement overflow occurs. 
@@ -460,7 +460,7 @@ namespace VCC { namespace Debugger
 		return true;
 	}
 
-	bool OpCodeTables::ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace)
+	bool OpCodeTables::ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const
 	{
 		trace.decodeCycles = AdjustCycles(opcode, 0, 0, state.IsNative6309);
 		return true;

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -916,7 +916,7 @@ namespace VCC { namespace Debugger
 			bool only6309;				// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
-		std::map<std::string, IndexModeInfo> IndexingModes = 
+		const std::map<std::string, IndexModeInfo> IndexingModes = 
 		{ 
 			{ "1RR00100", {"1RR00100", ",R",		0,	0,	0,	false } },
 			{ "0RRnnnnn", {"0RRnnnnn", "n,R",		1,	1,	0,	false } },
@@ -965,18 +965,18 @@ namespace VCC { namespace Debugger
 
 	protected:
 
-		bool ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
-		bool ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
+		bool ProcessNoAdjust(const OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessIndexModeAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessInterruptAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessStackAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessLongBranchAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessTFMAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
+		bool ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
 
 		int AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309) const;
 
-		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand);
+		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand) const;
 		std::string ToRegister(unsigned char postbyte) const;
 		std::string ToInterRegister(unsigned char reg) const;
 		std::string ToRelativeAddressString(int value, int oplen, int operandlen) const;

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -974,12 +974,12 @@ namespace VCC { namespace Debugger
 		bool ProcessDIVAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
 		bool ProcessWaitForSYNCAdjust(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
 
-		int AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309);
+		int AdjustCycles(OpCodeInfo& opcode, int cycles, int bytes, bool IsNative6309) const;
 
 		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand);
-		std::string ToRegister(unsigned char postbyte);
-		std::string ToInterRegister(unsigned char reg);
-		std::string ToRelativeAddressString(int value, int oplen, int operandlen);
+		std::string ToRegister(unsigned char postbyte) const;
+		std::string ToInterRegister(unsigned char reg) const;
+		std::string ToRelativeAddressString(int value, int oplen, int operandlen) const;
 
 	};
 }}

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -979,7 +979,7 @@ namespace VCC { namespace Debugger
 		bool GetIndexMode(unsigned char postbyte, IndexModeInfo& mode, std::string& operand) const;
 		std::string ToRegister(unsigned char postbyte) const;
 		std::string ToInterRegister(unsigned char reg) const;
-		std::string ToRelativeAddressString(int value, int oplen, int operandlen) const;
+		std::string ToRelativeAddressString(int value, int operandlen) const;
 
 	};
 }}

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -910,10 +910,10 @@ namespace VCC { namespace Debugger
 		{
 			std::string postbyte;		// 8-bit postbyte key
 			std::string form;			// Assembler form
-			int num6809cycles;			// Additional number of cycles (6809 only and 6309 in emulation)
-			int num6309cycles;			// Additional number of cycles (6309 native only)
-			int numbytes;				// Additional number of bytes
-			bool only6309;				// Valid only if running a 6309, in other words, invalid on a 6809
+			int num6809cycles = 0;		// Additional number of cycles (6809 only and 6309 in emulation)
+			int num6309cycles = 0;		// Additional number of cycles (6309 native only)
+			int numbytes = 0;			// Additional number of bytes
+			bool only6309 = 0;			// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
 		const std::map<std::string, IndexModeInfo> IndexingModes = 

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -961,7 +961,7 @@ namespace VCC { namespace Debugger
 	public:
 
 		// Calculate the exact number of cycles based on CPU state
-		bool ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace);
+		bool ProcessHeuristics(OpCodeInfo& opcode, const CPUState& state, CPUTrace& trace) const;
 
 	protected:
 

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -913,7 +913,7 @@ namespace VCC { namespace Debugger
 			int num6809cycles = 0;		// Additional number of cycles (6809 only and 6309 in emulation)
 			int num6309cycles = 0;		// Additional number of cycles (6309 native only)
 			int numbytes = 0;			// Additional number of bytes
-			bool only6309 = 0;			// Valid only if running a 6309, in other words, invalid on a 6809
+			bool only6309 = false;		// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
 		const std::map<std::string, IndexModeInfo> IndexingModes = 

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -916,7 +916,7 @@ namespace VCC { namespace Debugger
 			bool only6309 = false;		// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
-		const std::map<std::string, IndexModeInfo> IndexingModes = 
+		const std::map<std::string, IndexModeInfo, std::less<>> IndexingModes = 
 		{ 
 			{ "1RR00100", {"1RR00100", ",R",		0,	0,	0,	false } },
 			{ "0RRnnnnn", {"0RRnnnnn", "n,R",		1,	1,	0,	false } },

--- a/OpDecoder.cpp
+++ b/OpDecoder.cpp
@@ -119,7 +119,7 @@ namespace VCC { namespace Debugger
 		return TraceCaptured_.size();
 	}
 
-	OpDecoder::IRQType OpDecoder::ToIRQType(unsigned char irq)
+	OpDecoder::IRQType OpDecoder::ToIRQType(unsigned char irq) const
 	{
 		switch (irq)
 		{
@@ -133,7 +133,7 @@ namespace VCC { namespace Debugger
 		return IRQType();
 	}
 
-	bool OpDecoder::DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt)
+	bool OpDecoder::DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt) const
 	{
 		switch (irq)
 		{

--- a/OpDecoder.h
+++ b/OpDecoder.h
@@ -52,13 +52,13 @@ namespace VCC { namespace Debugger
 
 		size_t GetSampleCount() const;
 
-		IRQType ToIRQType(unsigned char irq);
+		IRQType ToIRQType(unsigned char irq) const;
 
 		bool DecodeInstruction(const CPUState& state, CPUTrace& trace);
 
 	protected:
 
-		bool DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt);
+		bool DecodeInterrupt(TraceEvent evt, IRQType irq, std::string& interrupt) const;
 		bool DecodeScreen(TraceEvent evt, std::string& screen);
 		bool DecodePage2Instruction(unsigned short PC, const CPUState& state, CPUTrace& trace);
 		bool DecodePage3Instruction(unsigned short PC, const CPUState& state, CPUTrace& trace);

--- a/OpenGL.cpp
+++ b/OpenGL.cpp
@@ -436,7 +436,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int GetSurface(Pixel** pixels)
+		int GetSurface(Pixel** pixels) const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 			*pixels = this->pixels;
@@ -469,7 +469,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int RenderText(const OpenGLFont* font, float x, float y, float size, const char* text)
+		int RenderText(const OpenGLFont* font, float x, float y, float size, const char* text) const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 
@@ -514,7 +514,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int Present()
+		int Present() const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 			wglMakeCurrent(hDC, hRC);
@@ -528,7 +528,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end)
+		int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end) const
 		{
 			*outFont = nullptr;
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
@@ -606,7 +606,7 @@ namespace VCC
 		}
 		#endif // USE_DEBUG_LINES
 
-		int RenderBox(float x, float y, float w, float h, Pixel color, bool filled)
+		int RenderBox(float x, float y, float w, float h, Pixel color, bool filled) const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 			float x2 = x + w;
@@ -658,7 +658,7 @@ namespace VCC
 	private:
 
 		// returns the box where display should be rendered
-		void GetDisplayArea(Rect* area)
+		void GetDisplayArea(Rect* area) const
 		{
 			area->w = (float)width;
 			area->h = (float)height;
@@ -683,14 +683,14 @@ namespace VCC
 			area->y = (height - area->h) / 2.0f;
 		}
 
-		void GetRenderArea(Rect* area)
+		void GetRenderArea(Rect* area) const
 		{
 			area->x = area->y = 0;
 			area->w = (float)width;
 			area->h = (float)height;
 		}
 
-		void GetSurfaceArea(Rect* area)
+		void GetSurfaceArea(Rect* area) const
 		{
 			area->x = area->y = 0;
 			area->w = (float)SurfaceWidth;

--- a/ProcessorState.cpp
+++ b/ProcessorState.cpp
@@ -60,7 +60,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
         LineTo(hdc, rx, ry + h);
     }
 
-    void DrawProcessorState(HDC hdc, LPRECT clientRect)
+    void DrawProcessorState(HDC hdc, LPCRECT clientRect)
     {
         RECT rect = *clientRect;
         Decoder = std::make_unique<OpDecoder>();
@@ -69,7 +69,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
         HBRUSH brush = (HBRUSH)GetStockObject(WHITE_BRUSH);
         FillRect(hdc, &rect, brush);
 
-        HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+        HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
         SelectObject(hdc, pen);
 
         // Draw the border.

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -21,6 +21,8 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 #include "memboard.h"
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -16,7 +16,7 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include "resource.h" 
 #include "defines.h"
 #include "memboard.h"

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -79,7 +79,6 @@ extern "C"
 			default:
 				return;
 		}	//End port switch		
-		return;
 	}
 }
 

--- a/Ramdisk/memboard.cpp
+++ b/Ramdisk/memboard.cpp
@@ -16,7 +16,7 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "memboard.h"
 

--- a/SourceDebug.cpp
+++ b/SourceDebug.cpp
@@ -81,7 +81,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 
 	bool LoadSource(const char* source)
 	{
-		SendDlgItemMessage(hWndSourceDebug, IDC_EDIT_SOURCE, WM_SETTEXT, 0, (LPARAM)(LPCSTR)source);
+		SendDlgItemMessage(hWndSourceDebug, IDC_EDIT_SOURCE, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(source));
 
 		int nLines = 0;
 		std::string loaded(std::to_string(nLines) + " lines loaded");
@@ -227,7 +227,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	{
 		Debugger::breakpointsbuffer_type breakpoints;
 
-		std::map<int, Breakpoint>::iterator it = mapBreakpoints.begin();
+		auto it = mapBreakpoints.begin();
 		while (it != mapBreakpoints.end())
 		{
 			Breakpoint bp = it->second;

--- a/SuperIDE/Fileops.cpp
+++ b/SuperIDE/Fileops.cpp
@@ -16,7 +16,7 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "fileops.h"
 
@@ -25,7 +25,7 @@ void ValidatePath(char *Path)
 	char FullExePath[MAX_PATH]="";
 	char TempPath[MAX_PATH]="";
 
-	GetModuleFileName(NULL,FullExePath,MAX_PATH);
+	GetModuleFileName(nullptr,FullExePath,MAX_PATH);
 	PathRemoveFileSpec(FullExePath);	//Get path to executable
 	strcpy(TempPath,Path);			
 	PathRemoveFileSpec(TempPath);		//Get path to Incomming file
@@ -37,26 +37,26 @@ void ValidatePath(char *Path)
 int CheckPath( char *Path)	//Return 1 on Error
 {
 	char TempPath[MAX_PATH]="";
-	HANDLE hr=NULL;
+	HANDLE hr=nullptr;
 
 	if ((strlen(Path)==0) | (strlen(Path) > MAX_PATH))
-		return(1);
-	hr=CreateFile(Path,NULL,FILE_SHARE_READ,NULL,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,NULL);
+		return 1;
+	hr=CreateFile(Path,nullptr,FILE_SHARE_READ,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 	if (hr==INVALID_HANDLE_VALUE) //File Doesn't exist
 	{
-		GetModuleFileName(NULL,TempPath,MAX_PATH);
+		GetModuleFileName(nullptr,TempPath,MAX_PATH);
 		PathRemoveFileSpec(TempPath);
 		if ( (strlen(TempPath)) + (strlen(Path)) > MAX_PATH)	//Resulting path is to large Bail.
-			return(1);
+			return 1;
 
 		strcat(TempPath,Path);
-		hr=CreateFile(TempPath,NULL,FILE_SHARE_READ,NULL,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,NULL);			
+		hr=CreateFile(TempPath,nullptr,FILE_SHARE_READ,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);			
 		if (hr ==INVALID_HANDLE_VALUE)
-			return(1);
+			return 1;
 		strcpy(Path,TempPath);
 	}
 	CloseHandle(hr);
-	return(0);
+	return 0;
 }
 // These are here to remove dependance on shlwapi.dll. ASCII only
 void PathStripPath ( char *TextBuffer)  
@@ -80,14 +80,14 @@ BOOL PathRemoveFileSpec(char *Path)
 {
 	short unsigned Index=strlen(Path),Lenth=Index;
 	if ( (Index==0) | (Index > MAX_PATH))
-		return(false);
+		return false;
 	
 	while ( (Index>0) & (Path[Index] != '\\') )
 		Index--;
 	while ( (Index>0) & (Path[Index] == '\\') )
 		Index--;
 	if (Index==0)
-		return(false);
+		return false;
 	Path[Index+2]=0;
 	return( !(strlen(Path) == Lenth));
 }		
@@ -96,7 +96,7 @@ BOOL PathRemoveExtension(char *Path)
 {
 	short unsigned Index=strlen(Path),Lenth=Index;
 	if ( (Index==0) | (Index > MAX_PATH))
-		return(false);
+		return false;
 	
 	while ( (Index>0) & (Path[Index--] != '.') );
 	Path[Index+1]=0;
@@ -105,7 +105,7 @@ BOOL PathRemoveExtension(char *Path)
 
 char* PathFindExtension(char *Path)
 {
-	short unsigned Index=strlen(Path),Lenth=Index;
+	short unsigned Index=strlen(Path);
 	if ( (Index==0) | (Index > MAX_PATH))
 		return(&Path[strlen(Path)+1]);
 	while ( (Index>0) & (Path[Index--] != '.') );

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -17,9 +17,9 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 #include "logger.h"
-#include "idebus.h"
+#include "IdeBus.h"
 #include <stdio.h>
-#include <windows.h>
+#include <Windows.h>
 
 static unsigned int Lba=0,LastLba;
 char Message[256]="";	//DEBUG

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -35,7 +35,7 @@ static HANDLE hDiskFile[2];
 static unsigned char DiskSelect=0,LbaEnabled=0;
 unsigned long BytesMoved=0;
 unsigned char BusyCounter=BUSYWAIT;
-HANDLE OpenDisk(char *,unsigned char);
+HANDLE OpenDisk(const char *,unsigned char);
 static unsigned short IDBlock[2][256];
 static unsigned char Mounted=0,ScanCount=0;
 static char CurrStatus[32]="IDE:Idle ";
@@ -270,7 +270,7 @@ void ByteSwap (char *String)
 	return;
 }
 
-HANDLE OpenDisk(char *ImageFile,unsigned char DiskNum)
+HANDLE OpenDisk(const char *ImageFile,unsigned char DiskNum)
 {
 	HANDLE hTemp=nullptr;
 	unsigned long FileSize=0;
@@ -333,7 +333,7 @@ void DiskStatus(char *Temp)
 	}
 	return;
 }
-unsigned char MountDisk(char *FileName,unsigned char DiskNumber)
+unsigned char MountDisk(const char *FileName,unsigned char DiskNumber)
 {
 	if (DiskNumber>1)
 		return FALSE;

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -81,7 +81,7 @@ void IdeRegWrite(unsigned char Reg,unsigned short Data)
 			{
 				if ((CurrentCommand==0x30) | (CurrentCommand==0x31))
 				{
-					SetFilePointer(hDiskFile[DiskSelect],Lba*512,0,FILE_BEGIN);
+					SetFilePointer(hDiskFile[DiskSelect],Lba*512,nullptr,FILE_BEGIN);
 					WriteFile(hDiskFile[DiskSelect],XferBuffer,512,&BytesMoved,nullptr);
 				}
 				BufferIndex=0;
@@ -213,7 +213,7 @@ void ExecuteCommand(void)
 			BufferLenth=512;
 			BufferIndex=0;
 			Registers.Status[DiskSelect]=DRQ|RDY;
-			SetFilePointer(hDiskFile[DiskSelect],Lba*512,0,FILE_BEGIN);
+			SetFilePointer(hDiskFile[DiskSelect],Lba*512,nullptr,FILE_BEGIN);
 			memset(XferBuffer,0,512);
 			ReadFile(hDiskFile[DiskSelect],XferBuffer,512,&BytesMoved,nullptr);
 			LastLba=Lba;
@@ -282,13 +282,13 @@ HANDLE OpenDisk(char *ImageFile,unsigned char DiskNum)
 
 	strncpy(SerialNumber,ImageFile,20);
 
-	hTemp=CreateFile( ImageFile,GENERIC_READ | GENERIC_WRITE,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+	hTemp=CreateFile( ImageFile,GENERIC_READ | GENERIC_WRITE,0,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
 	if (hTemp==INVALID_HANDLE_VALUE)
 		return hTemp;
 
 	Registers.Status[DiskNum]=RDY;
 	Registers.Error[DiskNum]=0;
-	FileSize=SetFilePointer(hTemp,0,0,FILE_END);
+	FileSize=SetFilePointer(hTemp,0,nullptr,FILE_END);
 	LbaSectors=FileSize>>9;
 	//Build Disk ID return Buffer
 	ByteSwap(Model);

--- a/SuperIDE/IdeBus.h
+++ b/SuperIDE/IdeBus.h
@@ -33,7 +33,7 @@ void IdeInit();
 void IdeRegWrite(unsigned char,unsigned short);
 unsigned short IdeRegRead(unsigned char);
 void DiskStatus(char *);
-unsigned char MountDisk(char *,unsigned char );
+unsigned char MountDisk(const char *,unsigned char );
 unsigned char DropDisk(unsigned char);
 void QueryDisk(unsigned char,char *);
 //Status 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -186,7 +186,7 @@ extern "C"
 
 extern "C" 
 {
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -31,6 +31,8 @@ This file is part of VCC (Virtual Color Computer).
 static char FileName[MAX_PATH] { 0 };
 static char IniFile[MAX_PATH]  { 0 };
 static char SuperIDEPath[MAX_PATH];
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef unsigned char (*MEMREAD8)(unsigned short);
 typedef void (*MEMWRITE8)(unsigned char,unsigned short);
 typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -219,7 +219,7 @@ void BuildDynaMenu(void)
 	DynamicMenuCallback("",1,0);
 }
 
-LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	unsigned char BTemp=0;
 	switch (message)

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -16,17 +16,17 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <windows.h>
+#include <Windows.h>
 #include "stdio.h"
 #include <iostream>
 #include "resource.h" 
 #include "defines.h"
-#include "Superide.h"
-#include "idebus.h"
+#include "SuperIDE.h"
+#include "IdeBus.h"
 #include "cloud9.h"
 #include "logger.h"
 #include "../fileops.h"
-#include "../dialogops.h"
+#include "../DialogOps.h"
 
 static char FileName[MAX_PATH] { 0 };
 static char IniFile[MAX_PATH]  { 0 };

--- a/SuperIDE/cloud9.cpp
+++ b/SuperIDE/cloud9.cpp
@@ -25,7 +25,7 @@ This file is part of VCC (Virtual Color Computer).
 *																		*
 ************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include "cloud9.h"
 
 static 	SYSTEMTIME now;

--- a/SuperIDE/logger.cpp
+++ b/SuperIDE/logger.cpp
@@ -37,7 +37,7 @@ void WriteLog(char *Message,unsigned char Type)
 			SetConsoleTitle("Logging Window"); 
 		}
 		sprintf(cTemp,"%s",Message);
-		WriteConsole(hout,cTemp,strlen(cTemp),&dummy,0);
+		WriteConsole(hout,cTemp,strlen(cTemp),&dummy,nullptr);
 		Counter++;
 		break;
 

--- a/SuperIDE/logger.cpp
+++ b/SuperIDE/logger.cpp
@@ -15,7 +15,7 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 
 #include "logger.h"

--- a/SuperIDE/logger.h
+++ b/SuperIDE/logger.h
@@ -20,6 +20,7 @@ This file is part of VCC (Virtual Color Computer).
 
 void WriteLog(char *,unsigned char);
 
+// FIXME: These should be a scoped enum
 #define TOCONS	0
 #define TOFILE	1
 

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -431,7 +431,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	        OEMscan = (unsigned char) ((lParam >> 16) & 0xFF);
             Extended=(lParam >> 24) & 1;
 		    if (Extended && (OEMscan!=DIK_NUMLOCK)) OEMscan += 0x80;
-			vccKeyboardHandleKey(kb_char,OEMscan,kEventKeyUp);
+			vccKeyboardHandleKey(OEMscan,kEventKeyUp);
 			
 			return 0;
 			break;
@@ -555,7 +555,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					// send shift and other keystrokes to the emulator if it is active
 					if ( EmuState.EmulationRunning )
 					{
-						vccKeyboardHandleKey(kb_char, OEMscan, kEventKeyDown);
+						vccKeyboardHandleKey(OEMscan, kEventKeyDown);
 						// Save key down in case focus is lost
 						save_key_down(kb_char,OEMscan);
 					}
@@ -666,8 +666,8 @@ void save_key_down(unsigned char kb_char, unsigned char OEMscan) {
 
 // Send key up events to keyboard handler for saved keys
 void raise_saved_keys() {
-	if (SC_save1) vccKeyboardHandleKey(KB_save1,SC_save1,kEventKeyUp);
-	if (SC_save2) vccKeyboardHandleKey(KB_save2,SC_save2,kEventKeyUp);
+	if (SC_save1) vccKeyboardHandleKey(SC_save1,kEventKeyUp);
+	if (SC_save2) vccKeyboardHandleKey(SC_save2,kEventKeyUp);
 	SC_save1 = 0;
 	SC_save2 = 0;
 	return;

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -99,7 +99,7 @@ LRESULT CALLBACK WndProc( HWND, UINT, WPARAM, LPARAM);
 void SoftReset(void);
 void LoadIniFile(void);
 void SaveConfig(void);
-unsigned __stdcall EmuLoop(void *);
+unsigned __stdcall EmuLoop(HANDLE hEvent);
 unsigned __stdcall CartLoad(void *);
 void (*CPUInit)(void)=nullptr;
 int  (*CPUExec)( int)=nullptr;
@@ -132,10 +132,10 @@ bool IsShiftKeyDown(void);
 
 //static CRITICAL_SECTION  FrameRender;
 /*--------------------------------------------------------------------------*/
-int APIENTRY WinMain(HINSTANCE hInstance,
-                     HINSTANCE hPrevInstance,
-                     LPSTR     lpCmdLine,
-                     int       nCmdShow)
+int APIENTRY WinMain(_In_ HINSTANCE hInstance,
+					  _In_opt_ HINSTANCE hPrevInstance,
+					  _In_ LPSTR    lpCmdLine,
+					  _In_ int       nCmdShow)
 {
 	MSG  Msg;
 
@@ -920,9 +920,8 @@ void SaveConfig(void) {
 	return;
 }
 
-unsigned __stdcall EmuLoop(void *Dummy)
+unsigned __stdcall EmuLoop(HANDLE hEvent)
 {
-	HANDLE hEvent = (HANDLE)Dummy;
 	static float FPS;
 	static unsigned int FrameCounter=0;	
 	CalibrateThrottle();

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -30,6 +30,7 @@ This file is part of VCC (Virtual Color Computer).
 //#define ABOVE_NORMAL_PRIORITY_CLASS  32768
 #endif
 
+// FIXME: These defines need to be converted to a scoped enumeration
 #define TH_RUNNING	0
 #define TH_REQWAIT	1
 #define TH_WAITING	2

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -779,7 +779,7 @@ void SoftReset(void)
 }
 
 // Message handler for the About box.
-BOOL CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+BOOL CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -799,7 +799,7 @@ BOOL CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 }
 
 // Message handler for function key help.
-BOOL CALLBACK FunctionKeys(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+BOOL CALLBACK FunctionKeys(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -1029,7 +1029,7 @@ void LoadPack(void)
 	_beginthreadex( nullptr, 0, &CartLoad, CreateEvent( nullptr, FALSE, FALSE, nullptr ), 0, &threadID );
 }
 
-unsigned __stdcall CartLoad(void *Dummy)
+unsigned __stdcall CartLoad(void* /*Dummy*/)
 {
 	LoadCart();
 	EmuState.EmulationRunning=TRUE;

--- a/_xDebug.cpp
+++ b/_xDebug.cpp
@@ -36,17 +36,17 @@ void _xDbgTrace(const void * pFile, const int iLine, const void * pFormat, ...)
 	fflush(stdout);
 }
 #else
-void _xDbgTrace(const void * pFile, const int iLine, const void * pFormat, ...)
+void _xDbgTrace(const char* pFile, const int iLine, const char* pFormat, ...)
 {
 	va_list		args;
 	char temp[1024];
 
 	va_start(args, pFormat);
 
-	sprintf(temp, "%s(%d) : ", (char *)pFile, iLine);
+	sprintf(temp, "%s(%d) : ", pFile, iLine);
 	OutputDebugString(temp);
 
-	vsprintf(temp, (char *)pFormat, args);
+	vsprintf(temp, pFormat, args);
 	OutputDebugString(temp);
 
 	va_end(args);

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -203,7 +203,7 @@ __declspec(dllexport) void ModuleStatus(char *status)
 //  Dll export run config dialog
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void ModuleConfig(unsigned char MenuID)
+__declspec(dllexport) void ModuleConfig(unsigned char /*MenuID*/)
 {
     HWND owner = GetActiveWindow();
     CreateDialog(g_hDLL,(LPCTSTR)IDD_PROPPAGE,owner,(DLGPROC)Config);
@@ -314,7 +314,7 @@ void SaveConfig(void)
 //   IDC_TEXTMODE  Translate CR <> CRLF if checked
 //-----------------------------------------------------------------------
 
-LRESULT CALLBACK Config(HWND hDlg,UINT msg,WPARAM wParam,LPARAM lParam)
+LRESULT CALLBACK Config(HWND hDlg,UINT msg,WPARAM wParam,LPARAM /*lParam*/)
 {
     int button;
     HWND hCtl;

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -29,6 +29,8 @@
 // Local Functions
 //------------------------------------------------------------------------
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 // Transfer points for menu callback and cpu assert interrupt
 typedef void (*DYNAMICMENUCALLBACK)(const char * ,int, int);
 typedef void (*ASSERTINTERUPT)(unsigned char, unsigned char);

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -71,7 +71,7 @@ char AciaFileWrPath[MAX_PATH]; // Path for file writes
 
 static unsigned char Rom[8192];
 void (*AssertInt)(unsigned char, unsigned char);
-unsigned char LoadExtRom(char *);
+unsigned char LoadExtRom(const char *);
 
 //------------------------------------------------------------------------
 //  DLL Entry point
@@ -150,7 +150,7 @@ __declspec(dllexport) unsigned char PakMemRead8(unsigned short Address)
 //-----------------------------------------------------------------------
 // Load Rom. Returns 1 if loaded
 //-----------------------------------------------------------------------
-unsigned char LoadExtRom(char *FilePath)
+unsigned char LoadExtRom(const char *FilePath)
 {
     FILE *file;
     int cnt = 0;
@@ -215,7 +215,7 @@ __declspec(dllexport) void ModuleConfig(unsigned char /*MenuID*/)
 // Dll export VCC ini file path and load settings
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void SetIniPath (char *IniFilePath)
+__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 {
     strcpy(IniFile,IniFilePath);
     LoadConfig();
@@ -580,7 +580,7 @@ void com_close() {
 }
 
 // com_write will block until some data is written or error
-int com_write(char * buf, int len) {
+int com_write(const char * buf, int len) {
     switch (AciaComType) {
     case COM_CONSOLE:
         return console_write(buf,len);

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -17,21 +17,20 @@
 // (Virtual Color Computer). If not see <http://www.gnu.org/licenses/>.
 //
 //------------------------------------------------------------------
-
 #ifndef __ACIA_H_
 #define __ACIA_H_
 
 // FIXME: This should be defined on the command line
 #define DIRECTINPUT_VERSION 0x0800
-
-constexpr auto MAX_LOADSTRING = 200u;
-
 #include <windows.h>
 #include <windowsx.h>
 #include <stdio.h>
 #include <conio.h>
 #include <dinput.h>
 #include "resource.h"
+
+constexpr auto MAX_LOADSTRING = 200u;
+
 
 // Dynamic menu control
 // FIXME: These need to be turned into an enum and the signature of functions

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -89,31 +89,31 @@ extern void sc6551_write(unsigned char data, unsigned short port);
 // Comunications hooks
 extern int  com_open();
 extern void com_close();
-extern int  com_write(char*,int);
+extern int  com_write(const char*,int);
 extern int  com_read(char*,int);
 
 // Console
 extern int  console_open();
 extern void console_close();
 extern int  console_read(char*,int);
-extern int  console_write(char*,int);
+extern int  console_write(const char*,int);
 
 // File
 extern int  file_open();
 extern void file_close();
 extern int  file_read(char*,int);
-extern int  file_write(char*,int);
+extern int  file_write(const char*,int);
 
 // Tcpip
 extern int  tcpip_open();
 extern void tcpip_close();
 extern int  tcpip_read(char*,int);
-extern int  tcpip_write( char*,int);
+extern int  tcpip_write(const char*,int);
 
 // WinCom 
 extern int  wincom_open();
 extern void wincom_close();
 extern int  wincom_read(char*,int);
-extern int  wincom_write(char*,int);
+extern int  wincom_write(const char*,int);
 
 #endif

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -22,7 +22,7 @@
 
 // FIXME: This should be defined on the command line
 #define DIRECTINPUT_VERSION 0x0800
-#include <windows.h>
+#include <Windows.h>
 #include <windowsx.h>
 #include <stdio.h>
 #include <conio.h>

--- a/acia/console.cpp
+++ b/acia/console.cpp
@@ -46,7 +46,6 @@ void console_cleol();
 void console_cleob();
 void console_cr();
 void console_eraseline();
-int  console_trans_color(int);
 void console_background(int);
 void console_forground(int);
 
@@ -139,7 +138,7 @@ int console_read(char * buf, int len) {
     }
 
     // If not line mode loop until at least one key press is found
-    while (1) {
+    for(;;) {
 
         // If Event buffer is empty load it (blocks)
         if (Event_Cnt < 1) {

--- a/acia/console.cpp
+++ b/acia/console.cpp
@@ -261,7 +261,7 @@ int  SeqArgsNeeded = 0;
 int  SeqArgsCount = 0;
 char SeqArgs[8];
 
-int console_write(char *buf, int len) {
+int console_write(const char *buf, int len) {
 
     int cnt = 0;
     int chr;

--- a/acia/file.cpp
+++ b/acia/file.cpp
@@ -103,7 +103,7 @@ int file_read(char* buf,int siz)
 }
 
 // Write file.  If text skip LF chars and convert CR to CRLF
-int  file_write(char* buf,int siz)
+int  file_write(const char* buf,int siz)
 {
 	// FIXME: This is needed and should not be commented out. Wrap it conditional
 	// either here or in the debug log functions.

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -159,7 +159,7 @@ void sc6551_close()
 //------------------------------------------------------------------------
 // Input thread
 //------------------------------------------------------------------------
-DWORD WINAPI sc6551_input_thread(LPVOID param)
+DWORD WINAPI sc6551_input_thread(LPVOID /*param*/)
 {
 	// FIXME: This is needed and should not be commented out. Wrap it conditional
 	// either here or in the debug log functions.
@@ -199,7 +199,7 @@ DWORD WINAPI sc6551_input_thread(LPVOID param)
 //------------------------------------------------------------------------
 // Output thread.
 //------------------------------------------------------------------------
-DWORD WINAPI sc6551_output_thread(LPVOID param)
+DWORD WINAPI sc6551_output_thread(LPVOID /*param*/)
 {
     Wcnt = 0;
     OutWptr = OutBuf;

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -214,7 +214,7 @@ DWORD WINAPI sc6551_output_thread(LPVOID /*param*/)
             if (!Ilock.test_and_set()) {
                 StatReg &= ~StatTxE;
                 if (AciaComMode != COM_MODE_READ) {
-                    char * ptr = OutBuf;
+                    const char * ptr = OutBuf;
                     while (Wcnt > 0) {
                         int cnt = com_write(ptr,Wcnt);
 						// FIXME: This is needed and should not be commented out. Wrap it conditional

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -39,14 +39,14 @@ unsigned char CmdReg;
 unsigned char CtlReg;
 
 // Input
-#define IBUFSIZ 1024
+constexpr auto IBUFSIZ = 1024u;
 DWORD WINAPI sc6551_input_thread(LPVOID);
 char InBuf[IBUFSIZ];
 char *InRptr = InBuf;
 int Icnt = 0;
 
 // Output
-#define OBUFSIZ 1024
+constexpr auto OBUFSIZ = 1024u;
 DWORD WINAPI sc6551_output_thread(LPVOID);
 char OutBuf[OBUFSIZ];
 char *OutWptr = OutBuf;

--- a/acia/tcpip.cpp
+++ b/acia/tcpip.cpp
@@ -24,8 +24,8 @@
 
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "acia.h"
 #include "../logger.h"

--- a/acia/tcpip.cpp
+++ b/acia/tcpip.cpp
@@ -53,7 +53,7 @@ int tcpip_open()
     }
 
     // resolve hostname
-    LPHOSTENT host = gethostbyname(AciaTcpHost);
+    const auto host = gethostbyname(AciaTcpHost);
     if (host == nullptr) {
         tcpip_close();
         return -1;
@@ -110,7 +110,7 @@ int tcpip_read(char* buf, int siz)
 }
 
 //Write
-int tcpip_write(char* buf, int siz)
+int tcpip_write(const char* buf, int siz)
 {
     char CRLF[3]="\r\n";
 

--- a/acia/wincom.cpp
+++ b/acia/wincom.cpp
@@ -32,7 +32,7 @@ HANDLE hReadEvent;
 HANDLE hWriteEvent;
 HANDLE hComPort=INVALID_HANDLE_VALUE;
 
-int writeport(char *buf,int siz);
+int writeport(const char *buf,int siz);
 
 static unsigned int BaudRate;
 static unsigned int EnParity;
@@ -119,7 +119,7 @@ int wincom_read(char* buf,int siz)
 //=====================================================
 // Write to com port.  If text mode convert line endings
 //=====================================================
-int  wincom_write(char* buf,int siz)
+int  wincom_write(const char* buf,int siz)
 {
     int cnt = 0;
     if (hComPort == INVALID_HANDLE_VALUE) return -1;
@@ -130,7 +130,8 @@ int  wincom_write(char* buf,int siz)
         // here maximizes write sizes without re-buffering.
         while(cnt < siz) {
             // search for a CR or LF
-            char *ptr, *tbuf, chr;
+			const char* ptr, * tbuf;
+			char chr;
             int tsiz;
             ptr = tbuf = buf + cnt;
             for (tsiz = 0; tsiz < siz-cnt; tsiz++) {
@@ -162,7 +163,7 @@ int  wincom_write(char* buf,int siz)
 //=====================================================
 // Write function for overlapped I/O
 //=====================================================
-int writeport(char *buf,int siz) {
+int writeport(const char *buf,int siz) {
     OVERLAPPED ovl = {0};
     ovl.hEvent = hWriteEvent;
     DWORD cnt;

--- a/audio.h
+++ b/audio.h
@@ -24,7 +24,6 @@ void FlushAudioBuffer ( unsigned int *,unsigned int);
 void ResetAudio (void);
 unsigned char PauseAudio(unsigned char Pause);
 int GetFreeBlockCount(void);
-int GetAuxBlockCount(void);
 void PurgeAuxBuffer(void);
 unsigned int GetSoundStatus(void);
 struct SndCardList

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -111,9 +111,9 @@ unsigned char dw_status( void )
         // check for input data waiting
 
         if (retry | (dwSocket == 0) | (InReadPos == InWritePos))
-                return(0);
+                return 0;
         else
-                return(1);
+                return 1;
 }
 
 
@@ -130,7 +130,7 @@ unsigned char dw_read( void )
 
         BytesReadSince++;
 
-        return(dwdata);
+        return dwdata;
 }
 
 
@@ -160,7 +160,7 @@ int dw_write( char dwdata)
 	              WriteLog(msg,TOCONS);
 	     }
 
-        return(0);
+        return 0;
 }
 
 
@@ -186,7 +186,7 @@ void killDWTCPThread(void)
 int dw_setaddr(char *bufdwaddr)
 {
         strcpy(dwaddress,bufdwaddr);
-        return(0);
+        return 0;
 }
 
 
@@ -201,7 +201,7 @@ int dw_setport(char *bufdwport)
                 killDWTCPThread();
         }
 
-        return(0);
+        return 0;
 }
 
 
@@ -285,7 +285,7 @@ unsigned __stdcall DWTCPThread(void *Dummy)
         {
                 WriteLog("WSAStartup() failed, DWTCPConnection thread exiting\n",TOCONS);
                 WSACleanup();
-                return(0);
+                return 0;
         }
         
         
@@ -346,7 +346,7 @@ unsigned __stdcall DWTCPThread(void *Dummy)
         dwSocket = 0;
 
         _endthreadex(0);
-        return(0);
+        return 0;
 }
 
 
@@ -455,9 +455,9 @@ void SetDWTCPConnectionEnable(unsigned int enable)
 			// read status
 			case 0x41:
 				if (dw_status() != 0)
-					return(2);
+					return 2;
 				else
-					return(0);
+					return 0;
 				break;
 			// read data 
 			case 0x42:
@@ -479,7 +479,7 @@ void SetDWTCPConnectionEnable(unsigned int enable)
 	{
 		
 		PakSetCart=Pointer;
-		return(0);
+		return 0;
 	}
 
 	__declspec(dllexport) unsigned char PakMemRead8(unsigned short Address)
@@ -731,5 +731,5 @@ unsigned char LoadExtRom( char *FilePath)	//Returns 1 on if loaded
 		RetVal = 1;
 		fclose(rom_handle);
 	}
-	return(RetVal);
+	return RetVal;
 }

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -1,13 +1,13 @@
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <winsock2.h>
-#include <windows.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <process.h>
 #include <stdio.h>
-#include "..\logger.h"
+#include "../logger.h"
 #include "becker.h"
 #include "resource.h" 
-#include "..\fileops.h"
+#include "../fileops.h"
 
 // socket
 static SOCKET dwSocket = 0;

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -60,10 +60,10 @@ char msg[MAX_PATH];
 static boolean logging = false;
 
 static DYNAMICMENUCALLBACK DynamicMenuCallback = NULL;
-unsigned char LoadExtRom(char *);
+unsigned char LoadExtRom(const char *);
 void SetDWTCPConnectionEnable(unsigned int enable);
-int dw_setaddr(char *bufdwaddr);
-int dw_setport(char *bufdwport);
+int dw_setaddr(const char *bufdwaddr);
+int dw_setport(const char *bufdwport);
 void WriteLog(const char *Message,unsigned char Type);
 void BuildDynaMenu(void);
 void LoadConfig(void);
@@ -183,7 +183,7 @@ void killDWTCPThread(void)
 
 
 // set our hostname, called from config.c
-int dw_setaddr(char *bufdwaddr)
+int dw_setaddr(const char *bufdwaddr)
 {
         strcpy(dwaddress,bufdwaddr);
         return 0;
@@ -191,7 +191,7 @@ int dw_setaddr(char *bufdwaddr)
 
 
 // set our port, called from config.c
-int dw_setport(char *bufdwport)
+int dw_setport(const char *bufdwport)
 {
         dwsport = (unsigned short)atoi(bufdwport);
 
@@ -563,7 +563,7 @@ void BuildDynaMenu(void)
 		return;
 	}
 
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();
@@ -714,7 +714,7 @@ void SaveConfig(void)
 	return;
 }
 
-unsigned char LoadExtRom( char *FilePath)	//Returns 1 on if loaded
+unsigned char LoadExtRom( const char *FilePath)	//Returns 1 on if loaded
 {
 
 	FILE *rom_handle = NULL;

--- a/becker/becker.c
+++ b/becker/becker.c
@@ -13,6 +13,7 @@
 static SOCKET dwSocket = 0;
 
 // vcc stuff
+// FIXME: These typedefs are also duplicated everywhere and need to be consolidated in one place.
 typedef void (*SETCART)(unsigned char);
 typedef void (*SETCARTPOINTER)(SETCART);
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);

--- a/becker/becker.h
+++ b/becker/becker.h
@@ -1,9 +1,11 @@
 #ifndef __BECKER_H__
 #define __BECKER_H__
 
+#ifndef __cplusplus
 #define bool int
 #define true 1
 #define false 0
+#endif
 
 // functions
 void MemWrite(unsigned char,unsigned short );

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -113,7 +113,7 @@ std::string GetClipboardText();
 void HLINE(void);
 void VSYNC(unsigned char level);
 void HSYNC(unsigned char level);
-string CvtStrToSC(string);
+std::string CvtStrToSC(std::string);
 
 using namespace std;
 
@@ -947,7 +947,7 @@ std::string GetClipboardText()
 	if (!OpenClipboard(nullptr)) { MessageBox(nullptr, "Unable to open clipboard.", "Clipboard", 0); return {}; }
 	HANDLE hClip = GetClipboardData(CF_TEXT);
 	if (hClip == nullptr) { CloseClipboard(); MessageBox(nullptr, "No text found in clipboard.", "Clipboard", 0); return {}; }
-	char* tmp = static_cast<char*>(GlobalLock(hClip));
+	const char* tmp = static_cast<char*>(GlobalLock(hClip));
 	if (tmp == nullptr) {
 		CloseClipboard();  MessageBox(nullptr, "NULL Pointer", "Clipboard", 0); return {};
 	}

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -56,7 +56,7 @@ AudioHistory gAudioHistory[AudioHistorySize];
 int gAudioHistoryCount = 0;
 #endif
 
-#define RENDERS_PER_BLINK_TOGGLE 16
+constexpr auto RENDERS_PER_BLINK_TOGGLE = 16u;
 
 //****************************************
 	static double SoundInterupt=0;

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -232,7 +232,7 @@ float RenderFrame (SystemState *RFState)
 
 	if (!(FrameCounter % RFState->FrameSkip))
 	{
-		if (LockScreen(RFState))
+		if (LockScreen())
 			return 0;
 	}
 
@@ -267,7 +267,7 @@ float RenderFrame (SystemState *RFState)
 	{
 		DrawBottomBoarder[RFState->BitDepth](RFState);
 		UnlockScreen(RFState);
-		SetBoarderChange(0);
+		SetBoarderChange();
 	}
 
 	// Bottom Border continues but is offscreen

--- a/config.cpp
+++ b/config.cpp
@@ -137,7 +137,7 @@ unsigned char TapeFastLoad = 1;
 char Tmodes[4][10]={"STOP","PLAY","REC","STOP"};
 static int NumberOfSoundCards=0;
 
-#define MAXSOUNDCARDS 12
+constexpr auto MAXSOUNDCARDS = 12u;
 static SndCardList SoundCards[MAXSOUNDCARDS];
 
 CHARFORMAT CounterText;
@@ -152,7 +152,7 @@ const char * const keyNames[] = {
 		"'","Comma",".","/","CapsLk","Shift","Ctrl","Alt","Space","Enter",
 		"Insert","Delete","Home","End","PgUp","PgDown","Left","Right",
 		"Up","Down","F1","F2"};
-#define SCAN_TRANS_COUNT 84
+constexpr auto SCAN_TRANS_COUNT = 84u;
 unsigned char _TranslateDisp2Scan[SCAN_TRANS_COUNT];
 unsigned char _TranslateScan2Disp[SCAN_TRANS_COUNT] = {
 		0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,32,38,20,33,35,40,36,24,30,

--- a/config.cpp
+++ b/config.cpp
@@ -1568,7 +1568,7 @@ LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lPar
 /********************************************/
 /*               Paths Config               */
 /********************************************/
-LRESULT CALLBACK Paths(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Paths(HWND /*hDlg*/, UINT /*message*/, WPARAM /*wParam*/, LPARAM /*lParam*/)
 {
 	return 1;
 }

--- a/config.cpp
+++ b/config.cpp
@@ -80,36 +80,36 @@ LRESULT CALLBACK Paths(HWND, UINT, WPARAM, LPARAM);
 // Structure for some (but not all) Vcc settings
 struct STRConfig
 {
-	unsigned char	CPUMultiplyer;
-	unsigned short	MaxOverclock;
-	unsigned char	FrameSkip;
-	unsigned char	SpeedThrottle;
-	unsigned char	CpuType;
-	unsigned char	HaltOpcEnabled;   // 0x15   halt enabled
-	unsigned char	BreakOpcEnabled;  // 0x113E halt enabled
-	unsigned char	MonitorType;
-	unsigned char   PaletteType;
-	unsigned char	ScanLines;
-	unsigned char	Resize;
-	unsigned char	Aspect;
-	unsigned char	RememberSize;
+	unsigned char	CPUMultiplyer = 0;
+	unsigned short	MaxOverclock = 0;
+	unsigned char	FrameSkip = 0;
+	unsigned char	SpeedThrottle = 0;
+	unsigned char	CpuType = 0;
+	unsigned char	HaltOpcEnabled = 0;   // 0x15   halt enabled
+	unsigned char	BreakOpcEnabled = 0;  // 0x113E halt enabled
+	unsigned char	MonitorType = 0;
+	unsigned char   PaletteType = 0;
+	unsigned char	ScanLines = 0;
+	unsigned char	Resize = 0;
+	unsigned char	Aspect = 0;
+	unsigned char	RememberSize = 0;
 	Rect			WindowRect;
-	unsigned char	RamSize;
-	unsigned char	AutoStart;
-	unsigned char	CartAutoStart;
-	unsigned char	RebootNow;
-	unsigned char	SndOutDev;
-	unsigned char	KeyMap;
-	char			SoundCardName[64];
-	unsigned int	AudioRate;	// 0 = Mute
-	char			ModulePath[MAX_PATH];
-	char			PathtoExe[MAX_PATH];
-	char			FloppyPath[MAX_PATH];
-	char			CassPath[MAX_PATH];
-    unsigned char   ShowMousePointer;
-	unsigned char	UseExtCocoRom;
-	char        	ExtRomFile[MAX_PATH];
-	unsigned char   EnableOverclock;
+	unsigned char	RamSize = 0;
+	unsigned char	AutoStart = 0;
+	unsigned char	CartAutoStart = 0;
+	unsigned char	RebootNow = 0;
+	unsigned char	SndOutDev = 0;
+	unsigned char	KeyMap = 0;
+	char			SoundCardName[64] = { 0 };
+	unsigned int	AudioRate = 0;	// 0 = Mute
+	char			ModulePath[MAX_PATH] = { 0 };
+	char			PathtoExe[MAX_PATH] = { 0 };
+	char			FloppyPath[MAX_PATH] = { 0 };
+	char			CassPath[MAX_PATH] = { 0 };
+    unsigned char   ShowMousePointer = 0;
+	unsigned char	UseExtCocoRom = 0;
+	char        	ExtRomFile[MAX_PATH] = { 0 };
+	unsigned char   EnableOverclock = 0;
 };
 
 static STRConfig CurrentConfig;

--- a/config.cpp
+++ b/config.cpp
@@ -482,7 +482,7 @@ void OpenCpuConfig() {
 	SetFocus(hCpuDlg);
 }
 
-LRESULT CALLBACK CpuConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK CpuConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	short int Ramchoice[4] = {IDC_128K,IDC_512K,IDC_2M,IDC_8M};
 	short int Cpuchoice[2] = {IDC_6809,IDC_6309};
@@ -685,7 +685,7 @@ void OpenTapeConfig() {
 	ShowWindow(hTapeDlg,SW_SHOWNORMAL);
 	SetFocus(hTapeDlg);
 }
-LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK TapeConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	CounterText.cbSize = sizeof(CHARFORMAT);
 	CounterText.dwMask = CFM_BOLD | CFM_COLOR ;
@@ -808,7 +808,7 @@ void OpenAudioConfig() {
 	SetFocus(hAudioDlg);
 }
 
-LRESULT CALLBACK AudioConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK AudioConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	int Index;
 	static STRConfig tmpcfg;
@@ -933,7 +933,7 @@ void OpenDisplayConfig() {
 	SetFocus(hDisplayDlg);
 }
 
-LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK DisplayConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	static STRConfig tmpcfg;
 	switch (message) {
@@ -1071,7 +1071,7 @@ void OpenInputConfig() {
 	ShowWindow(hInputDlg,SW_SHOWNORMAL);
 	SetFocus(hInputDlg);
 }
-LRESULT CALLBACK InputConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK InputConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
     switch (message) {
     case WM_INITDIALOG:
@@ -1199,7 +1199,7 @@ void OpenJoyStickConfig() {
 	SetFocus(hJoyStickDlg);
 }
 
-LRESULT CALLBACK JoyStickConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK JoyStickConfig(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	static STRConfig tmpcfg;
     static JoyStick TempLeftJS, TempRightJS;
@@ -1504,7 +1504,7 @@ void OpenBitBangerConfig() {
 	ShowWindow(hBitBangerDlg,SW_SHOWNORMAL);
 	SetFocus(hBitBangerDlg);
 }
-LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK BitBanger(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message) {
 	case WM_INITDIALOG: //IDC_PRINTMON

--- a/config.h
+++ b/config.h
@@ -18,8 +18,8 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "defines.h"
-#include<iostream>
-using namespace std;
+#include <iostream>
+
 void LoadConfig(SystemState *);
 void InitSound();
 void LoadModule();

--- a/config.h
+++ b/config.h
@@ -37,14 +37,12 @@ void SetIniFilePath(const char *);
 void SetKeyMapFilePath(const char *);
 char * AppDirectory();
 char * GetKeyMapFilePath();
-char * KeyMapFiledir();
 
 int GetPaletteType();
 enum PALETTETYPE {PALETTE_ORIG=0, PALETTE_UPD=1, PALETTE_NTSC=2};
 
 const VCC::Rect& GetIniWindowRect();
 int GetRememberSize();
-void SetConfigPath(int, string);
 void SwapJoySticks();
 
 void DecreaseOverclockSpeed();
@@ -54,7 +52,6 @@ void SetOverclock(unsigned char);
 // Openers for config dialogs
 void OpenAudioConfig();
 void OpenCpuConfig();
-void OpenMiscConfig();
 void OpenDisplayConfig();
 void OpenInputConfig();
 void OpenJoyStickConfig();

--- a/defines.h
+++ b/defines.h
@@ -184,35 +184,35 @@ namespace VCC
 
 struct SystemState
 {
-    HWND			WindowHandle;
-    HWND			ConfigDialog;
+    HWND			WindowHandle = nullptr;
+    HWND			ConfigDialog = nullptr;
 
-    HINSTANCE		WindowInstance;
-    unsigned char	*RamBuffer;
-    unsigned short	*WRamBuffer;
-    std::atomic<unsigned char>	RamSize;
-    double			CPUCurrentSpeed;
-    unsigned char	DoubleSpeedMultiplyer;
-    unsigned char	DoubleSpeedFlag;
-    unsigned char	TurboSpeedFlag;
-    unsigned char	CpuType;
-    unsigned char	FrameSkip;
-    unsigned char	BitDepth;
-    unsigned char	Throttle;
-    unsigned char	*PTRsurface8;
-    unsigned short	*PTRsurface16;
-    unsigned int	*PTRsurface32;
-    long			SurfacePitch;
-    unsigned short	LineCounter;
-    unsigned char	ScanLines;
-    unsigned char	EmulationRunning;
-    unsigned char	ResetPending;
+    HINSTANCE		WindowInstance = nullptr;
+    unsigned char	*RamBuffer = nullptr;
+    unsigned short	*WRamBuffer = nullptr;
+    std::atomic<unsigned char>	RamSize = 0;
+    double			CPUCurrentSpeed = 0.0;
+    unsigned char	DoubleSpeedMultiplyer = 0;
+    unsigned char	DoubleSpeedFlag = 0;
+    unsigned char	TurboSpeedFlag = 0;
+    unsigned char	CpuType = 0;
+    unsigned char	FrameSkip = 0;
+    unsigned char	BitDepth = 0;
+    unsigned char	Throttle = 0;
+    unsigned char	*PTRsurface8 = nullptr;
+    unsigned short	*PTRsurface16 = nullptr;
+    unsigned int	*PTRsurface32 = nullptr;
+    long			SurfacePitch = 0;
+    unsigned short	LineCounter = 0;
+    unsigned char	ScanLines = 0;
+    unsigned char	EmulationRunning = 0;
+    unsigned char	ResetPending = 0;
     VCC::Size		WindowSize;
-    unsigned char	FullScreen;
-    bool        	Exiting;
-    unsigned char	MousePointer;
-    unsigned char	OverclockFlag;
-    char			StatusLine[256];
+    unsigned char	FullScreen = 0;
+    bool        	Exiting = false;
+    unsigned char	MousePointer = 0;
+    unsigned char	OverclockFlag = 0;
+	char			StatusLine[256] = { 0 };
 
 	// Debugger Package	
 	VCC::Debugger::Debugger Debugger;

--- a/defines.h
+++ b/defines.h
@@ -35,15 +35,15 @@ constexpr auto SAMPLESPERFRAME = 262u;
 
 
 //CPU 
-#define FRAMESPERSECORD (double)59.923	//The coco really runs at about 59.923 Frames per second
-#define LINESPERSCREEN (double)262
-#define NANOSECOND (double)1000000000
-#define COLORBURST (double)3579545 
-#define AUDIOBUFFERS 12
+constexpr auto FRAMESPERSECORD = 59.923;	//The coco really runs at about 59.923 Frames per second
+constexpr auto LINESPERSCREEN = 262.0;
+constexpr auto NANOSECOND = 1000000000.0;
+constexpr auto COLORBURST = 3579545.0;
+constexpr auto AUDIOBUFFERS = 12u;
 //Misc
-#define MAX_LOADSTRING 100
-#define QUERY 255
-#define INDEXTIME ((LINESPERSCREEN * TARGETFRAMERATE)/5)
+constexpr auto MAX_LOADSTRING = 100u;
+constexpr auto QUERY = 255u;
+constexpr auto INDEXTIME = ((LINESPERSCREEN * TARGETFRAMERATE) / 5);
 
 struct SystemState;
 
@@ -86,6 +86,7 @@ namespace VCC
         }
     };
 
+	// FIXME: Remove this and use std::array
     //
     // bounds checking array type
     //

--- a/fileops.h
+++ b/fileops.h
@@ -29,7 +29,7 @@ BOOL PathRemoveFileSpec(char *);
 BOOL PathRemoveExtension(char *);
 char* PathFindExtension(char *);
 DWORD WritePrivateProfileInt(LPCTSTR, LPCTSTR, int, LPCTSTR);
-BOOL FilePrintf(HANDLE, const void *, ...);
+BOOL FilePrintf(HANDLE, const char*, ...);
 
 #ifdef __cplusplus
 	}

--- a/hd6309.cpp
+++ b/hd6309.cpp
@@ -252,14 +252,14 @@ void HD6309Init(void)
 	xfreg16[6] = &W_REG;
 	xfreg16[7] = &V_REG;
 
-	ureg8[0]=(unsigned char*)&A_REG;		
-	ureg8[1]=(unsigned char*)&B_REG;		
-	ureg8[2]=(unsigned char*)&ccbits;
-	ureg8[3]=(unsigned char*)&dp.B.msb;
-	ureg8[4]=(unsigned char*)&z.B.msb;
-	ureg8[5]=(unsigned char*)&z.B.lsb;
-	ureg8[6]=(unsigned char*)&E_REG;
-	ureg8[7]=(unsigned char*)&F_REG;
+	ureg8[0] = &A_REG;		
+	ureg8[1] = &B_REG;		
+	ureg8[2] = &ccbits;
+	ureg8[3] = &dp.B.msb;
+	ureg8[4] = &z.B.msb;
+	ureg8[5] = &z.B.lsb;
+	ureg8[6] = &E_REG;
+	ureg8[7] = &F_REG;
 
 	//This handles the disparity between 6309 and 6809 Instruction timing
 	InsCycles[0][M65]=6;	//6-5
@@ -762,8 +762,8 @@ void Addr(void)
 			switch (Source)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
-			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 2:	        source16 = getcc(); break; // CC
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -832,7 +832,7 @@ void Adcr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -899,8 +899,8 @@ void Subr(void)
 			switch (Source)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
-			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 2:	        source16 = getcc(); break; // CC
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -968,8 +968,8 @@ void Sbcr(void)
 			switch (Source)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
-			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 2:	        source16 = getcc(); break; // CC
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1014,9 +1014,9 @@ void Andr(void)
 		temp8 = dest8 & source8;
 		switch (Dest)
 		{
-			case 2: 				setcc((unsigned char)temp8); break;
+			case 2: 				setcc(temp8); break;
 			case 4: case 5: break; // never assign to zero reg
-			default: 				*ureg8[Dest] = (unsigned char)temp8; break;
+			default: 				*ureg8[Dest] = temp8; break;
 		}
 		cc[N] = temp8 >> 7;
 		cc[Z] = ZTEST(temp8);
@@ -1036,7 +1036,7 @@ void Andr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1080,9 +1080,9 @@ void Orr(void)
 		temp8 = dest8 | source8;
 		switch (Dest)
 		{
-			case 2: 				setcc((unsigned char)temp8); break;
+			case 2: 				setcc(temp8); break;
 			case 4: case 5: break; // never assign to zero reg
-			default: 				*ureg8[Dest] = (unsigned char)temp8; break;
+			default: 				*ureg8[Dest] = temp8; break;
 		}
 		cc[N] = temp8 >> 7;
 		cc[Z] = ZTEST(temp8);
@@ -1102,7 +1102,7 @@ void Orr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1146,9 +1146,9 @@ void Eorr(void)
 		temp8 = dest8 ^ source8;
 		switch (Dest)
 		{
-			case 2: 				setcc((unsigned char)temp8); break;
+			case 2: 				setcc(temp8); break;
 			case 4: case 5: break; // never assign to zero reg
-			default: 				*ureg8[Dest] = (unsigned char)temp8; break;
+			default: 				*ureg8[Dest] = temp8; break;
 		}
 		cc[N] = temp8 >> 7;
 		cc[Z] = ZTEST(temp8);
@@ -1168,7 +1168,7 @@ void Eorr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1231,7 +1231,7 @@ void Cmpr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}

--- a/hd6309.h
+++ b/hd6309.h
@@ -28,11 +28,4 @@ VCC::CPUState HD6309GetState();
 void HD6309SetBreakpoints(const std::vector<unsigned short>& breakpoints);
 void HD6309SetTraceTriggers(const std::vector<unsigned short>& triggers);
 
-void HD6309Init_s(void);
-int  HD6309Exec_s( int);
-void HD6309Reset_s(void);
-void HD6309AssertInterupt_s(InterruptSource, Interrupt);
-void HD6309DeAssertInterupt_s(InterruptSource, Interrupt);
-void HD6309ForcePC_s(unsigned short);
-
 #endif

--- a/iobus.cpp
+++ b/iobus.cpp
@@ -214,7 +214,7 @@ void port_write(unsigned char data,unsigned short addr)
 		case 0xDD:
 		case 0xDE:
 		case 0xDF:
-			sam_write(data,port);	//MC6883 S.A.M. address range $FFC0-$FFDF
+			sam_write(port);	//MC6883 S.A.M. address range $FFC0-$FFDF
 		break;
 
 		case 0x90:

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -79,18 +79,18 @@ extern int JS_Ramp_Clock=0;
 static int JS_Ramp_On;
 
 // Hires ramp constants. Determined during testing
-#define TANDYRAMPMIN   1200
-#define TANDYRAMPMAX  10950
-#define TANDYRAMPMUL     37
-#define CCMAXRAMPMIN    800
-#define CCMAXRAMPMAX  14000
-#define CCMAXRAMPMUL     21
+constexpr auto TANDYRAMPMIN  = 1200u;
+constexpr auto TANDYRAMPMAX  = 10950u;
+constexpr auto TANDYRAMPMUL  = 37u;
+constexpr auto CCMAXRAMPMIN  = 800u;
+constexpr auto CCMAXRAMPMAX  = 14000u;
+constexpr auto CCMAXRAMPMUL  = 21u;
 
 static int sticktarg = 0;    // Target stick cycle count
 
 // Joystick values  (0-16383)
-#define STICKMAX 16383
-#define STICKMID 8191
+constexpr auto STICKMAX = 16383u;
+constexpr auto STICKMID = 8191u;
 unsigned int LeftStickX = STICKMID;
 unsigned int LeftStickY = STICKMID;
 unsigned int RightStickX = STICKMID;

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -367,7 +367,7 @@ unsigned int
 get_pot_value(unsigned char pot)
 {
 #ifndef _M_ARM
-    DIJOYSTATE2 Stick1;
+	DIJOYSTATE2 Stick1 = { 0 };
 
     // Poll left joystick if attached
     if (LeftJS.UseMouse==3) {

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -239,7 +239,7 @@ inline int vccJoystickType() {
 /*****************************************************************************/
 // Called by mc6821 when $FF20 is written
 void
-vccJoystickStartTandy(unsigned char data, unsigned char next)
+vccJoystickStartTandy(unsigned char next)
 {
 	if (vccJoystickType() == 2) {
         if ( next == 2 ) {

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -150,7 +150,7 @@ int EnumerateJoysticks(void)
 
 /*****************************************************************************/
 #ifndef _M_ARM
-BOOL CALLBACK enumCallback(const DIDEVICEINSTANCE* instance, VOID* context)
+BOOL CALLBACK enumCallback(const DIDEVICEINSTANCE* instance, VOID* /*context*/)
 {
     HRESULT hr;
     hr = di->CreateDevice(instance->guidInstance, &Joysticks[JoyStickIndex],nullptr);
@@ -184,7 +184,7 @@ bool InitJoyStick (unsigned char StickNumber)
 
 /*****************************************************************************/
 #ifndef _M_ARM
-BOOL CALLBACK enumAxesCallback(const DIDEVICEOBJECTINSTANCE* instance, VOID* context)
+BOOL CALLBACK enumAxesCallback(const DIDEVICEOBJECTINSTANCE* instance, VOID* /*context*/)
 {
     DIPROPRANGE propRange;
     propRange.diph.dwSize = sizeof(DIPROPRANGE);

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -238,8 +238,7 @@ inline int vccJoystickType() {
 
 /*****************************************************************************/
 // Called by mc6821 when $FF20 is written
-void
-vccJoystickStartTandy(unsigned char next)
+void vccJoystickStartTandy(unsigned char next)
 {
 	if (vccJoystickType() == 2) {
         if ( next == 2 ) {

--- a/joystickinput.h
+++ b/joystickinput.h
@@ -59,7 +59,7 @@ unsigned char SetMouseStatus(unsigned char,unsigned char);
 void joystick(unsigned int, unsigned int);
 void SetButtonStatus(unsigned char, unsigned char);
 void SetStickNumbers(unsigned char, unsigned char);
-void vccJoystickStartTandy(unsigned char, unsigned char);
+void vccJoystickStartTandy(unsigned char);
 void vccJoystickStartCCMax();
 
 #ifdef __cplusplus

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -64,7 +64,8 @@ bool GetNextScanInPasteQueue(unsigned char col);
 /*****************************************************************************/
 
 // key translation table maximum size, (arbitrary) most of the layouts are < 80 entries
-#define KBTABLE_ENTRY_COUNT 100
+constexpr auto KBTABLE_ENTRY_COUNT = 100u;
+// FIXME: These defines should either be a scoped enumeration or removed and boolean values used.
 #define KEY_DOWN	1
 #define KEY_UP		0
 

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -59,7 +59,7 @@ This file is part of VCC (Virtual Color Computer).
 
 unsigned char SetMouseStatus(unsigned char, unsigned char);
 bool pasting = false;  //Are the keyboard functions in the middle of a paste operation?
-bool GetNextScanInPasteQueue(unsigned char col);
+bool GetNextScanInPasteQueue();
 
 /*****************************************************************************/
 //	Global variables
@@ -115,7 +115,7 @@ vccKeyboardGetScan(unsigned char Col)
 
 	ret_val = 0;
 
-	GetNextScanInPasteQueue(Col);
+	GetNextScanInPasteQueue();
 
 	temp = ~Col; //Get colums
 	mask = 1;
@@ -555,7 +555,7 @@ void PasteIntoQueue(const std::string& txt)
 }
 
 
-bool GetNextScanInPasteQueue(unsigned char col)
+bool GetNextScanInPasteQueue()
 {
 	if (CurrentPasteState == PasteState::Idle)
 	{

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -46,9 +46,11 @@ This file is part of VCC (Virtual Color Computer).
 #include "keyboardLayout.h"
 #include "config.h"
 
-#include <queue>
-
 #include "xDebug.h"
+
+#include <queue>
+#include <sstream>
+
 
 /*****************************************************************************/
 /*
@@ -552,7 +554,6 @@ void PasteIntoQueue(const std::string& txt)
 	SetPaste(true);
 }
 
-#include <sstream>
 
 bool GetNextScanInPasteQueue(unsigned char col)
 {

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -322,56 +322,38 @@ int keyTransCompare(const void * e1, const void * e2)
 	// elem1 - elem2
 
 	// empty listing push to end
-	if (   entry1->ScanCode1 == 0
-		&& entry1->ScanCode2 == 0
-		&& entry2->ScanCode1 != 0
-		)
+	if (entry1->ScanCode1 == 0 && entry1->ScanCode2 == 0 && entry2->ScanCode1 != 0)
 	{
 		return 1;
 	}
-	else
-	if (   entry2->ScanCode1 == 0
-		&& entry2->ScanCode2 == 0
-		&& entry1->ScanCode1 != 0
-		)
+	else if (entry2->ScanCode1 == 0 && entry2->ScanCode2 == 0 && entry1->ScanCode1 != 0)
 	{
 		return -1;
 	}
-	else
 	// push shift/alt/control by themselves to the end
-	if (   entry1->ScanCode2 == 0
-		&& (   entry1->ScanCode1 == DIK_LSHIFT
-		    || entry1->ScanCode1 == DIK_LMENU
-		    || entry1->ScanCode1 == DIK_LCONTROL
-		   )
-		)
+	else if (
+		entry1->ScanCode2 == 0
+		&& (entry1->ScanCode1 == DIK_LSHIFT
+			|| entry1->ScanCode1 == DIK_LMENU
+			|| entry1->ScanCode1 == DIK_LCONTROL))
 	{
 		result = 1;
 	}
-	else
 	// push shift/alt/control by themselves to the end
-	if (   entry2->ScanCode2 == 0
-		&& (   entry2->ScanCode1 == DIK_LSHIFT
-		    || entry2->ScanCode1 == DIK_LMENU
-		    || entry2->ScanCode1 == DIK_LCONTROL
-			)
-		)
+	else if (entry2->ScanCode2 == 0
+		&& (entry2->ScanCode1 == DIK_LSHIFT
+			|| entry2->ScanCode1 == DIK_LMENU
+		    || entry2->ScanCode1 == DIK_LCONTROL))
 	{
 		result = -1;
 	}
-	else
 	// move double key combos in front of single ones
-	if (   entry1->ScanCode2 == 0
-		&& entry2->ScanCode2 != 0
-		)
+	else if (entry1->ScanCode2 == 0 && entry2->ScanCode2 != 0)
 	{
 		result = 1;
 	}
-	else
 	// move double key combos in front of single ones
-	if (   entry2->ScanCode2 == 0
-		&& entry1->ScanCode2 != 0
-		)
+	else if (entry2->ScanCode2 == 0 && entry1->ScanCode2 != 0)
 	{
 		result = -1;
 	}
@@ -414,7 +396,7 @@ void vccKeyboardBuildRuntimeTable(keyboardlayout_e keyBoardLayout)
 {
 	int Index1 = 0;
 	int Index2 = 0;
-	keytranslationentry_t *		keyLayoutTable = nullptr;
+	const keytranslationentry_t *		keyLayoutTable = nullptr;
 	keytranslationentry_t		keyTransEntry;
 
 	assert(keyBoardLayout >= 0 && keyBoardLayout < kKBLayoutCount);

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -242,7 +242,7 @@ void _vccKeyboardUpdateRolloverTable()
 //	@param Status Key status - kEventKeyDown/kEventKeyUp
 /*****************************************************************************/
 
-void vccKeyboardHandleKey(unsigned char key, unsigned char ScanCode, keyevent_e keyState)
+void vccKeyboardHandleKey(unsigned char ScanCode, keyevent_e keyState)
 {
 	//If requested, abort pasting operation.
 	if (ScanCode == 0x01 || ScanCode == 0x43 || ScanCode == 0x3F) { pasting = false; }
@@ -586,7 +586,7 @@ bool GetNextScanInPasteQueue()
 		{
 			// Lower Shift key and get the next.
 			PasteInputQueue.pop();
-			vccKeyboardHandleKey(0x36, 0x36, kEventKeyDown);
+			vccKeyboardHandleKey(0x36, kEventKeyDown);
 			next = PasteInputQueue.front();
 			ShiftPaste = true;
 		}
@@ -595,11 +595,11 @@ bool GetNextScanInPasteQueue()
 		{
 			// Lower Control key and get the next.
 			PasteInputQueue.pop();
-			vccKeyboardHandleKey(0x1D, 0x1D, kEventKeyDown);
+			vccKeyboardHandleKey(0x1D, kEventKeyDown);
 			next = PasteInputQueue.front();
 			CtrlPaste = true;
 		}
-		vccKeyboardHandleKey(next, next, kEventKeyDown);
+		vccKeyboardHandleKey(next, kEventKeyDown);
 		CurrentPasteState = KeyUp;
 		break;
 	}
@@ -608,10 +608,10 @@ bool GetNextScanInPasteQueue()
 	{
 		// Raise key that was down.
 		unsigned char last = PasteInputQueue.front();
-		vccKeyboardHandleKey(last, last, kEventKeyUp);
+		vccKeyboardHandleKey(last, kEventKeyUp);
 		// Raise shift or control if either were down
-		if (ShiftPaste) vccKeyboardHandleKey(0x36, 0x36, kEventKeyUp);
-		if (CtrlPaste)  vccKeyboardHandleKey(0x1D, 0x1D, kEventKeyUp);
+		if (ShiftPaste) vccKeyboardHandleKey(0x36, kEventKeyUp);
+		if (CtrlPaste)  vccKeyboardHandleKey(0x1D, kEventKeyUp);
 		ShiftPaste = CtrlPaste = false;
 		PasteInputQueue.pop();
 		CurrentPasteState = CheckDone;

--- a/keyboard.h
+++ b/keyboard.h
@@ -75,7 +75,7 @@ extern "C"
 {
 #endif
 	void			vccKeyboardBuildRuntimeTable(keyboardlayout_e keyBoardLayout);
-	void			vccKeyboardHandleKey(unsigned char, unsigned char, keyevent_e keyState);
+	void			vccKeyboardHandleKey(unsigned char, keyevent_e keyState);
 	unsigned char	vccKeyboardGetScan(unsigned char);
 #ifdef __cplusplus
 }

--- a/keyboardEdit.cpp
+++ b/keyboardEdit.cpp
@@ -103,7 +103,7 @@ char *GenKeymapLine(keytranslationentry_t *);
 
 // Lookup functions for keyname tables
 static struct CoCoKey * cctable_rowcol_lookup(unsigned char, unsigned char);
-static struct CoCoKey * cctable_keyid_lookup(int);
+static struct CoCoKey * cctable_keyid_lookup();
 static struct CoCoKey * cocotable_keyname_lookup(const char *);
 static struct PCScanCode * scantable_scancode_lookup(int);
 static struct PCScanCode * scantable_keyname_lookup(const char *);
@@ -535,8 +535,7 @@ CoCoKey * cocotable_keyname_lookup(const char * keyname)
 //-----------------------------------------------------
 // Lookup CoCo key by button id.  Sequential search.
 //-----------------------------------------------------
-static struct 
-CoCoKey * cctable_keyid_lookup(int id) 
+static struct CoCoKey * cctable_keyid_lookup() 
 {
 	struct CoCoKey *p;
 	if (CC_KeySelected) {
@@ -670,7 +669,7 @@ BOOL SetCustomKeymap() {
 		// If no entry and no coco key to map do nothing
 		if ( (CC_KeySelected + CC_ModSelected) == 0 ) return TRUE;
 
-		p = cctable_keyid_lookup(CC_KeySelected);
+		p = cctable_keyid_lookup();
 		int len = 0;
 	    pKeyTran = keyTranslationsCustom;
 
@@ -709,7 +708,7 @@ BOOL SetCustomKeymap() {
 
 	// Update custom translation table
     if (CC_KeySelected != 0) {  // BtnId
-		p = cctable_keyid_lookup(CC_KeySelected);
+		p = cctable_keyid_lookup();
 		if (p) {
 			pKeyTran->Row1 = 1<<(p->row);
 		    pKeyTran->Col1 = p->col;
@@ -857,7 +856,7 @@ void ShowCoCoKey()
 
 	// Show coco keys names in editbox
 	if (CC_KeySelected) {
-        p = cctable_keyid_lookup(CC_KeySelected);
+        p = cctable_keyid_lookup();
 		if (p != nullptr) {
 			if (p->label != nullptr) {
 			    keytxt = p->label;

--- a/keyboardEdit.cpp
+++ b/keyboardEdit.cpp
@@ -99,7 +99,7 @@ void  DoKeyDown(WPARAM,LPARAM);
 void  ShowMapError(int, const char *);
 void  SetDialogFocus(HWND);
 int   GetKeymapLine (char*, keytranslationentry_t *, int);
-char *GenKeymapLine(keytranslationentry_t *);
+const char *GenKeymapLine(const keytranslationentry_t *);
 
 // Lookup functions for keyname tables
 static struct CoCoKey * cctable_rowcol_lookup(unsigned char, unsigned char);
@@ -162,9 +162,9 @@ int LoadCustomKeyMap(const char* keymapfile)
 //-----------------------------------------------------
 int GetKeymapLine ( char* line, keytranslationentry_t * trans, int lnum)
 {
-    char *pStr;
-    static struct PCScanCode * pPCScanCode; 
-    static struct CoCoKey * pCoCoKey;
+	const char *pStr;
+    static struct PCScanCode * pPCScanCode; // FIXME: Why is this static?
+    static struct CoCoKey * pCoCoKey;		// FIXME: Why is this static?
 
     // pc scancode -> ScanCode1
     pStr = strtok(line, " \t\n\r");
@@ -259,7 +259,7 @@ int CloneStandardKeymap(int keymap)
 {
     int i = 0;
     keytranslationentry_t * dst = keyTranslationsCustom;
-    keytranslationentry_t * src;
+	const keytranslationentry_t * src;
     switch (keymap) {
     case kKBLayoutCoCo:
         src = keyTranslationsCoCo;
@@ -286,7 +286,7 @@ int CloneStandardKeymap(int keymap)
 //-----------------------------------------------------
 int SaveCustomKeyMap(const char* keymapfile) 
 {
-    keytranslationentry_t * pTran;
+	const keytranslationentry_t * pTran;
 	pTran = keyTranslationsCustom;
 
     FILE *omap;
@@ -355,11 +355,11 @@ int SaveCustomKeyMap(const char* keymapfile)
 //------------------------------------------------------
 // Convert translation record for keymap file
 //-----------------------------------------------------
-char * GenKeymapLine( keytranslationentry_t * pTran )
+const char * GenKeymapLine( const keytranslationentry_t * pTran )
 {
 	static char txt[64];
-	static struct PCScanCode * pSC; 
-    static struct CoCoKey * pCC; 
+	static struct PCScanCode * pSC;	// FIXME: Why is this static?
+    static struct CoCoKey * pCC;	// FIXME: Why is this static?
 	int CCmod = 0;
 	int PCmod = 0;
 
@@ -591,7 +591,7 @@ BOOL CALLBACK KeyMapProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         case IDCANCEL:
             if (KeyMapChanged) { 
                 LoadCustomKeyMap(GetKeyMapFilePath());
-                vccKeyboardBuildRuntimeTable((keyboardlayout_e) kKBLayoutCustom);
+                vccKeyboardBuildRuntimeTable(kKBLayoutCustom);
              }
             return EndDialog(hWnd,wParam);
         default:
@@ -662,7 +662,7 @@ BOOL SetCustomKeymap() {
 
 	int ModCol;
 	int ModRow;
-	static struct CoCoKey *p;
+	static struct CoCoKey *p;	// FIXME: Why is this static?
 
 	if (pKeyTran == nullptr) {
 
@@ -735,7 +735,7 @@ BOOL SetCustomKeymap() {
 
     // Update runtime table
 	if (GetKeyboardLayout() == kKBLayoutCustom)
-			vccKeyboardBuildRuntimeTable((keyboardlayout_e) kKBLayoutCustom);
+			vccKeyboardBuildRuntimeTable(kKBLayoutCustom);
 
 	// Disable set button
 	EnableWindow(GetDlgItem(hKeyMapDlg,IDC_SET_CUST_KEYMAP),FALSE);
@@ -835,7 +835,7 @@ void ShowCoCoKey()
 {
 	char str[64];
 	const char * keytxt = "";
-	struct CoCoKey *p;
+	const struct CoCoKey *p;
 
 	// set coco keyboard buttons 
 	if (CC_KeySelected != CoCoKeySet) {
@@ -945,7 +945,7 @@ void ShowPCkey()
 {
 	char str[64];
 	const char * keytxt = "";
-    struct PCScanCode * entry;
+    const struct PCScanCode * entry;
 	if (PC_KeySelected>0) { 
 		entry = scantable_scancode_lookup(PC_KeySelected);
 		if (entry == nullptr) {
@@ -965,7 +965,7 @@ void ShowPCkey()
 //-----------------------------------------------------
 void SetCoCokey()
 {
-    static struct CoCoKey * pCoCoKey;
+    static struct CoCoKey * pCoCoKey;	// FIXME: Why is this static?
 
 	// Clear selected coco keys
     CC_KeySelected = 0;

--- a/keyboardLayout.h
+++ b/keyboardLayout.h
@@ -25,7 +25,7 @@
 
 #include "keyboard.h"
 
-#define MAX_CTRANSTBLSIZ 150
+constexpr auto MAX_CTRANSTBLSIZ = 150u;
 
 /*****************************************************************************/
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -23,7 +23,7 @@
 #include <stdarg.h>
 #include <io.h>
 #include <fcntl.h>
-#include <sys\stat.h>
+#include <sys/stat.h>
 #include "logger.h"
 
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -26,8 +26,6 @@
 #include <sys\stat.h>
 #include "logger.h"
 
-#define TOCONS 0
-#define TOFILE 1
 
 static HANDLE hLog_Out = nullptr;
 DWORD dummy;

--- a/logger.cpp
+++ b/logger.cpp
@@ -49,12 +49,12 @@ void WriteLog(const char *Message, unsigned char Type) {
 }
 
 // PrintLogC - Put formatted string to the console
-void PrintLogC(const void * fmt, ...)
+void PrintLogC(const char* fmt, ...)
 {
     va_list args;
     char msg[512];
     va_start(args, fmt);
-    vsnprintf(msg, 512, (char *)fmt, args);
+    vsnprintf(msg, 512, fmt, args);
     va_end(args);
 
     if (hLog_Out == nullptr) {
@@ -66,12 +66,12 @@ void PrintLogC(const void * fmt, ...)
 }
 
 // PrintLogF - Put formatted string to the log file
-void PrintLogF(const void * fmt, ...)
+void PrintLogF(const char* fmt, ...)
 {
     va_list args;
     char msg[512];
     va_start(args, fmt);
-    vsnprintf(msg, 512, (char *)fmt, args);
+    vsnprintf(msg, 512, fmt, args);
     va_end(args);
 
     int oflag = _O_CREAT | _O_APPEND | _O_RDWR;

--- a/logger.h
+++ b/logger.h
@@ -29,8 +29,8 @@ This file is part of VCC (Virtual Color Computer).
 #define TOFILE 1
 
 void WriteLog(const char *, unsigned char);
-void PrintLogC(const void * fmt, ...);
-void PrintLogF(const void * fmt, ...);
+void PrintLogC(const char* fmt, ...);
+void PrintLogF(const char* fmt, ...);
 void OpenLogFile(const char * filename);
 
 // Debug logging if USE_LOGGING is defined

--- a/logger.h
+++ b/logger.h
@@ -20,6 +20,11 @@ This file is part of VCC (Virtual Color Computer).
 #ifndef __LOGGER_H__
 #define __LOGGER_H__
 
+// FIXME: At the very least these need to be turned into a scoped enum and the
+// signature of functions that use them updated. A better option would be to
+// properly abstract the logging to these values are not necessary. Also the
+// notion of the callsite selecting the output device is not ideal so maybe
+// just replace it with something more effective.
 #define TOCONS 0
 #define TOFILE 1
 

--- a/mc6809.cpp
+++ b/mc6809.cpp
@@ -532,7 +532,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case TST_D: //D
-		temp8=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		temp8=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(temp8);
 		cc[N]= NTEST8(temp8);
 		cc[V] = false;
@@ -1680,7 +1680,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SUBA_D: //90
-		postbyte=MemRead8( (dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16 = A_REG - postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,A_REG);
@@ -1691,7 +1691,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case CMPA_D: //91
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp8= A_REG-postbyte;
 		cc[C]= temp8 > A_REG;
 		cc[V]= OTEST8(cc[C],postbyte,temp8,A_REG);
@@ -1701,7 +1701,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SBCA_D: //92
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=A_REG-postbyte-cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,A_REG);
@@ -1712,7 +1712,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SUBD_D: //93
-		temp16=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		temp16=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp32=D_REG-temp16;
 		cc[C]=(temp32 & 0x10000)>>16;
 		cc[V]= OTEST16(cc[C],temp32,temp16,D_REG);
@@ -1723,7 +1723,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ANDA_D: //94
-		A_REG = A_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG = A_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(A_REG);
 		cc[Z]= ZTEST(A_REG);
 		cc[V]= false;
@@ -1731,7 +1731,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case BITA_D: //95
-		temp8 = A_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		temp8 = A_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(temp8);
 		cc[Z]= ZTEST(temp8);
 		cc[V]= false;
@@ -1739,7 +1739,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDA_D: //96
-		A_REG= MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG= MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(A_REG);
 		cc[N]= NTEST8(A_REG);
 		cc[V]= false;
@@ -1755,7 +1755,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case EORA_D: //98
-		A_REG= A_REG ^ MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG= A_REG ^ MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(A_REG);
 		cc[Z]= ZTEST(A_REG);
 		cc[V]= false;
@@ -1763,7 +1763,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADCA_D: //99
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16= A_REG + postbyte + cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,A_REG);
@@ -1775,7 +1775,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ORA_D: //9A
-		A_REG = A_REG | MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG = A_REG | MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(A_REG);
 		cc[Z]= ZTEST(A_REG);
 		cc[V]= false;
@@ -1783,7 +1783,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADDA_D: //9B
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=A_REG+postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[H]= ((A_REG ^ postbyte ^ temp16) & 0x10)>>4;
@@ -1795,7 +1795,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case CMPX_D: //9C
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= x.Reg - postword ;
 		cc[C]= temp16 > x.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,X_REG);
@@ -1814,7 +1814,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDX_D: //9E
-		x.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		x.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(x.Reg);
 		cc[N]= NTEST16(x.Reg);
 		cc[V]= false;
@@ -2274,7 +2274,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SUBB_D: //D0
-		postbyte=MemRead8( (dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16 = B_REG - postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,B_REG);
@@ -2285,7 +2285,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case CMPB_D: //D1
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp8= B_REG-postbyte;
 		cc[C]= temp8 > B_REG;
 		cc[V]= OTEST8(cc[C],postbyte,temp8,B_REG);
@@ -2295,7 +2295,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SBCB_D: //D2
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=B_REG-postbyte-cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,B_REG);
@@ -2306,7 +2306,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADDD_D: //D3
-		temp16=MemRead16( (dp.Reg |MemRead8(pc.Reg++)));
+		temp16=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp32= D_REG+ temp16;
 		cc[C]=(temp32 & 0x10000)>>16;
 		cc[V]= OTEST16(cc[C],temp32,temp16,D_REG);
@@ -2317,7 +2317,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ANDB_D: //D4
-		B_REG = B_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		B_REG = B_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]=NTEST8(B_REG);
 		cc[Z] = ZTEST(B_REG);
 		cc[V] = false;
@@ -2325,7 +2325,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case BITB_D: //D5
-		temp8 = B_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		temp8 = B_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(temp8);
 		cc[Z] = ZTEST(temp8);
 		cc[V] = false;
@@ -2333,7 +2333,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDB_D: //D6
-		B_REG=MemRead8( (dp.Reg |MemRead8(pc.Reg++)));
+		B_REG=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z] = ZTEST(B_REG);
 		cc[N]= NTEST8(B_REG);
 		cc[V] = false;
@@ -2349,7 +2349,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case EORB_D: //D8
-		B_REG = B_REG ^ MemRead8((dp.Reg | MemRead8(pc.Reg++)));
+		B_REG = B_REG ^ MemRead8(dp.Reg | MemRead8(pc.Reg++));
 		cc[N]= NTEST8(B_REG);
 		cc[Z] = ZTEST(B_REG);
 		cc[V] = false;
@@ -2357,7 +2357,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADCB_D: //D9
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16= B_REG + postbyte + cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,B_REG);
@@ -2369,7 +2369,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ORB_D: //DA
-		B_REG = B_REG | MemRead8((dp.Reg | MemRead8(pc.Reg++)));
+		B_REG = B_REG | MemRead8(dp.Reg | MemRead8(pc.Reg++));
 		cc[N]= NTEST8(B_REG);
 		cc[Z] = ZTEST(B_REG);
 		cc[V] = false;
@@ -2377,7 +2377,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADDB_D: //DB
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=B_REG+postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[H]= ((B_REG ^ postbyte ^ temp16) & 0x10)>>4;
@@ -2389,7 +2389,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDD_D: //DC
-		D_REG=MemRead16((dp.Reg | MemRead8(pc.Reg++)));
+		D_REG=MemRead16(dp.Reg | MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(D_REG);
 		cc[N]= NTEST16(D_REG);
 		cc[V]= false;
@@ -2405,7 +2405,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDU_D: //DE
-		u.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		u.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(u.Reg);
 		cc[N]= NTEST16(u.Reg);
 		cc[V]= false;
@@ -2952,7 +2952,7 @@ void P2_Opcode(void)
 		break;
 
 	case CMPD_D: //1093
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= D_REG - postword ;
 		cc[C]= temp16 > D_REG;
 		cc[V]= OTEST16(cc[C],postword,temp16,D_REG);
@@ -2962,7 +2962,7 @@ void P2_Opcode(void)
 		break;
 
 	case CMPY_D:	//109C
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= y.Reg - postword ;
 		cc[C]= temp16 > y.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,y.Reg);
@@ -2972,7 +2972,7 @@ void P2_Opcode(void)
 		break;
 
 	case LDY_D: //109E
-		y.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		y.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(y.Reg);
 		cc[N]= NTEST16(y.Reg);
 		cc[V]= false;
@@ -3073,7 +3073,7 @@ void P2_Opcode(void)
 		break;
 
 	case LDS_D: //10DE
-		s.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		s.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(s.Reg);
 		cc[N]= NTEST16(s.Reg);
 		cc[V] = false;
@@ -3181,7 +3181,7 @@ void P3_Opcode(void)
 		break;
 
 	case CMPU_D: //1193
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= u.Reg - postword ;
 		cc[C]= temp16 > u.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,U_REG);
@@ -3191,7 +3191,7 @@ void P3_Opcode(void)
 		break;
 
 	case CMPS_D: //119C
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= s.Reg - postword ;
 		cc[C]= temp16 > s.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,S_REG);

--- a/mc6821.cpp
+++ b/mc6821.cpp
@@ -267,7 +267,7 @@ void pia1_write(unsigned char data,unsigned char port)
 	case 0: // cpu write FF20
 		if (dda)
 		{
-            vccJoystickStartTandy(regb[port],data);
+            vccJoystickStartTandy(data);
             regb[port]=data;
 			CaptureBit((regb[0]&2)>>1);
 			if (GetMuxState() == 0)

--- a/mc6821.h
+++ b/mc6821.h
@@ -29,7 +29,6 @@ void ClosePrintFile(void);
 void SetSerialParams(unsigned char);
 void SetMonState(BOOL);
 unsigned char VDG_Mode(void);
-void kb_tap(unsigned int,unsigned int,unsigned int);
 void irq_hs(int);
 void irq_fs(int);
 void AssertCart(void);

--- a/memdump.cpp
+++ b/memdump.cpp
@@ -84,7 +84,7 @@ void SetDumpPath(const char * dumpfile)
 void MemDump(void)
 {
 	int fd = OpenDumpFile();
-	unsigned char * ptr = Get_mem_pointer();
+	const unsigned char * ptr = Get_mem_pointer();
 	int siz = GetMemSize();
 	blockdump(fd,ptr,siz);
     _close(fd);
@@ -94,12 +94,12 @@ void MemDump(void)
 void CpuDump(void)
 {
 	std::array<int,8> regs = GetMmuRegs();
-	unsigned char * pmem = Get_mem_pointer();
+	const unsigned char * pmem = Get_mem_pointer();
 	int blk;
 
 	int fd = OpenDumpFile();
 	for (blk=0; blk<8; blk++) {
-		unsigned char * ptr = pmem + regs[blk] * 0x2000;
+		const unsigned char * ptr = pmem + regs[blk] * 0x2000;
 		int siz = 0x2000;
 		blockdump(fd,ptr,siz);
 	}

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -17,11 +17,11 @@ Copyright 2015 by Joseph Forgione
 */
 // This is an expansion module for the Vcc Emulator. It simulated the functions of the TRS-80 Multi-Pak Interface
 
-#include <windows.h>
+#include <Windows.h>
 #include <iostream>
 #include "stdio.h"
 #include "resource.h"
-#include <commctrl.h>
+#include <CommCtrl.h>
 #include "mpi.h"
 #include "../fileops.h"
 #include "../DialogOps.h"
@@ -403,7 +403,7 @@ LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*l
 		}
 		UpdateSlotSelect(SwitchSlot);
 		return TRUE;
-		break;
+
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
 		case IDC_SELECT1:
@@ -513,7 +513,6 @@ unsigned char MountModule(unsigned char Slot,const char *ModuleName)
 	{
 	case 0: //File doesn't exist
 		return 0;
-	break;
 
 	case 2: //ROM image
 		UnloadModule(Slot);

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -106,7 +106,7 @@ LRESULT CALLBACK MpiConfigDlg(HWND,UINT,WPARAM,LPARAM);
 
 unsigned char MountModule(unsigned char,const char *);
 void UnloadModule(unsigned char);
-void UpdateCartDLL(unsigned char,char *);
+void UpdateCartDLL(unsigned char slot);
 void LoadConfig(void);
 void WriteConfig(void);
 void ReadModuleParms(unsigned char,char *);
@@ -290,7 +290,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void PakMemWrite8(unsigned char Data,unsigned short Address)
+	__declspec(dllexport) void PakMemWrite8(unsigned char /*Data*/,unsigned short /*Address*/)
 	{
 
 		return;
@@ -382,7 +382,7 @@ void CenterDialog(HWND hDlg)
 	SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
-LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 
 	switch (message) {
@@ -480,7 +480,7 @@ void UpdateSlotContent(int Slot)
 		return;
 	}
 
-	UpdateCartDLL(Slot,ModulePaths[Slot]);
+	UpdateCartDLL(Slot);
 	SendDlgItemMessage(hConfDlg,EDITBOXS[Slot],WM_SETTEXT,0,(LPARAM)SlotLabel[Slot]);
 	if ((strcmp(ModuleNames[Slot],"Empty") != 0) || hinstLib[Slot])
 		SendDlgItemMessage(hConfDlg,INSBOXS[Slot],WM_SETTEXT,0,(LPARAM)"X");
@@ -628,7 +628,7 @@ void UnloadModule(unsigned char Slot)
 	return;
 }
 
-void UpdateCartDLL(unsigned char Slot,char *DllPath)
+void UpdateCartDLL(unsigned char Slot)
 {
 	if ((strcmp(ModuleNames[Slot],"Empty") != 0) || hinstLib[Slot]) {
 		UnloadModule(Slot);

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -355,7 +355,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -520,13 +520,13 @@ unsigned char MountModule(unsigned char Slot,const char *ModuleName)
 		ExtRomPointers[Slot]=(unsigned char *)malloc(0x40000);
 		if (ExtRomPointers[Slot]==nullptr)
 		{
-			MessageBox(0,"Rom pointer is NULL","Error",0);
+			MessageBox(nullptr,"Rom pointer is NULL","Error",0);
 			return 0; //Can Allocate RAM
 		}
 		rom_handle=fopen(MountName,"rb");
 		if (rom_handle==nullptr)
 		{
-			MessageBox(0,"File handle is NULL","Error",0);
+			MessageBox(nullptr,"File handle is NULL","Error",0);
 			return 0;
 		}
 		while ((feof(rom_handle)==0) & (index<0x40000))
@@ -573,7 +573,7 @@ unsigned char MountModule(unsigned char Slot,const char *ModuleName)
 		if (GetModuleNameCalls[Slot] == nullptr)
 		{
 			UnloadModule(Slot);
-			MessageBox(0,"Not a valid Module","Ok",0);
+			MessageBox(nullptr,"Not a valid Module","Ok",0);
 			return 0; //Error Not a Vcc Module
 		}
 		GetModuleNameCalls[Slot](ModuleNames[Slot],CatNumber[Slot],DynamicMenuCallbackCalls[Slot]); //Need to add address of local Dynamic menu callback function!
@@ -791,7 +791,7 @@ void BuildDynaMenu(void)
 {
 	// DynamicMenuCallback() resides in VCC pakinterface. Make sure we have it's address
 	if (DynamicMenuCallback == nullptr) {
-		MessageBox(0,"MPI internal menu error","Ok",0);
+		MessageBox(nullptr,"MPI internal menu error","Ok",0);
 		return;
 	}
 

--- a/mpi/mpi.h
+++ b/mpi/mpi.h
@@ -21,8 +21,8 @@ This file is part of VCC (Virtual Color Computer).
 #include "../MachineDefs.h"
 
 //Misc
-#define MAX_LOADSTRING 100
-#define QUERY 255
+constexpr auto MAX_LOADSTRING = 100u;
+constexpr auto QUERY = 255u;
 
 // FIXME: These need to be turned into an enum and the signature of functions
 // that use them updated. These are also duplicated everywhere and need to be
@@ -31,6 +31,8 @@ This file is part of VCC (Virtual Color Computer).
 #define SLAVE 1
 #define STANDALONE 2
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 typedef void (*GETNAME)(char *,char *,DYNAMICMENUCALLBACK); 
 typedef void (*CONFIGIT)(unsigned char); 

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -47,7 +47,7 @@ BOOL WINAPI DllMain(
 
 extern "C" 
 {          
-	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,DYNAMICMENUCALLBACK Temp)
+	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,DYNAMICMENUCALLBACK /*Temp*/)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);		
@@ -78,7 +78,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char PackPortRead(unsigned char Port)
+	__declspec(dllexport) unsigned char PackPortRead(unsigned char /*Port*/)
 	{
 		return 0;
 	}

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -19,7 +19,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <stdio.h>
 #include "defines.h"
 #include "resource.h" 
-#include "..\fileops.h"
+#include "../fileops.h"
 
 // FIXME: These typedefs are duplicated across more if not all projects and
 // need to be consolidated in one place.

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -29,7 +29,7 @@ typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 static HINSTANCE g_hinstDLL=nullptr;
 static unsigned char LeftChannel=0,RightChannel=0;
 static void (*PakSetCart)(unsigned char)=nullptr;
-unsigned char LoadExtRom(char *);
+unsigned char LoadExtRom(const char *);
 static unsigned char Rom[8192];
 BOOL WINAPI DllMain(
     HINSTANCE hinstDLL,  // handle to DLL module
@@ -135,7 +135,7 @@ extern "C"
 
 
 
-unsigned char LoadExtRom(char *FilePath)	//Returns 1 on if loaded
+unsigned char LoadExtRom(const char *FilePath)	//Returns 1 on if loaded
 {
 
 	FILE *rom_handle = nullptr;

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -21,6 +21,8 @@ This file is part of VCC (Virtual Color Computer).
 #include "resource.h" 
 #include "..\fileops.h"
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*SETCART)(unsigned char);
 typedef void (*SETCARTPOINTER)(SETCART);
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -15,7 +15,7 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <windows.h>
+#include <Windows.h>
 #include <stdio.h>
 #include "defines.h"
 #include "resource.h" 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -393,7 +393,7 @@ int InsertModule (char *ModulePath)
 Load a ROM pack
 return total bytes loaded, or 0 on failure
 */
-int load_ext_rom(const char filename[MAX_PATH])
+int load_ext_rom(const char *filename)
 {
 	constexpr size_t PAK_MAX_MEM = 0x40000;
 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -90,7 +90,7 @@ typedef void (*SETCARTPOINTER)(SETCART);
 typedef void (*SETINTERUPTCALLPOINTER) (PAKINTERRUPT);
 typedef unsigned short (*MODULEAUDIOSAMPLE)(void);
 typedef void (*MODULERESET)(void);
-typedef void (*SETINIPATH)(char *);
+typedef void (*SETINIPATH)(const char *);
 
 static void (*GetModuleName)(char *,char *,DYNAMICMENUCALLBACK)=nullptr;
 static void (*ConfigModule)(unsigned char)=nullptr;
@@ -104,7 +104,7 @@ static unsigned char (*PakMemRead8)(unsigned short)=nullptr;
 static void (*ModuleStatus)(char *)=nullptr;
 static unsigned short (*ModuleAudioSample)(void)=nullptr;
 static void (*ModuleReset) (void)=nullptr;
-static void (*SetIniPath) (char *)=nullptr;
+static void (*SetIniPath) (const char *)=nullptr;
 static void (*PakSetCart)(SETCART)=nullptr;
 static char PakPath[MAX_PATH];
 
@@ -239,7 +239,7 @@ int LoadCart(void)
 }
 
 // Insert Module returns 0 on success
-int InsertModule (char *ModulePath)
+int InsertModule (const char *ModulePath)
 {
 	char CatNumber[MAX_LOADSTRING]="";
 	char Temp[MAX_LOADSTRING]="";

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -72,6 +72,8 @@ static unsigned int BankedCartOffset=0;
 static char DllPath[256]="";
 static unsigned short ModualParms=0;
 static HINSTANCE hinstLib = nullptr;
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 typedef void (*GETNAME)(char *,char *,DYNAMICMENUCALLBACK);
 typedef void (*CONFIGIT)(unsigned char);

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -29,7 +29,7 @@ unsigned short PackAudioSample(void);
 void ResetBus(void);
 int load_ext_rom(const char *);
 void GetCurrentModule(char *);
-int InsertModule (char *);
+int InsertModule (const char *);
 void UpdateBusPointer(void);
 void UnloadDll(void);
 void UnloadPack(void);

--- a/sdc/cloud9.cpp
+++ b/sdc/cloud9.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 *																		*
 ************************************************************************/
 
-#include <windows.h>
+#include <Windows.h>
 #include "cloud9.h"
 
 static 	SYSTEMTIME now;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -817,7 +817,7 @@ void UpdateFlashItem(int index)
 void SelectCardBox(void)
 {
     // Prompt user for path
-    BROWSEINFO bi = { 0 };
+    BROWSEINFO bi = { nullptr };
     bi.hwndOwner = GetActiveWindow();
     bi.lpszTitle = "Set the SD card path";
     bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NONEWFOLDERBUTTON;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -134,12 +134,12 @@
 #include <cstdio>
 #include <cerrno>
 #include <cstring>
-#include <windows.h>
+#include <Windows.h>
 #include <windowsx.h>
-#include <shlwapi.h>
+#include <Shlwapi.h>
 #pragma warning(push)
 #pragma warning(disable:4091)
-#include <shlobj.h>
+#include <ShlObj.h>
 #pragma warning(pop)
 #include <stdio.h>
 #include <ctype.h>

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -208,7 +208,7 @@ bool MountNext(int);
 void OpenNew(int,const char *,int);
 void CloseDrive(int);
 void OpenFound(int,int);
-void LoadReply(void *, int);
+void LoadReply(const void *, int);
 void BlockReceive(unsigned char);
 char * LastErrorTxt(void);
 void FlashControl(unsigned char);
@@ -434,7 +434,7 @@ extern "C"
     }
 
     // Set ini file path and Initialize SDC
-    __declspec(dllexport) void SetIniPath (char *IniFilePath)
+    __declspec(dllexport) void SetIniPath (const char *IniFilePath)
     {
         strncpy(IniFile,IniFilePath,MAX_PATH);
         return;
@@ -1410,7 +1410,7 @@ void GetDirectoryLeaf(void)
 
     // If at least one leaf find the last one
     if (n > 0) {
-        char *p = strrchr(CurDir,'/');
+		const char *p = strrchr(CurDir,'/');
         if (p == nullptr) {
             p = CurDir;
         } else {
@@ -1779,7 +1779,7 @@ void SDCControl(void)
 //----------------------------------------------------------------------
 // Load reply. Count is bytes, 512 max.
 //----------------------------------------------------------------------
-void LoadReply(void *data, int count)
+void LoadReply(const void *data, int count)
 {
     if ((count < 2) | (count > 512)) {
         _DLOG("LoadReply bad count %d\n",count);
@@ -1870,9 +1870,9 @@ bool LoadFoundFile(struct FileRecord * rec)
     }
 
     // File type
-    char * pdot = strrchr(dFound.cFileName,'.');
+	const char * pdot = strrchr(dFound.cFileName,'.');
     if (pdot) {
-        char * ptyp = pdot + 1;
+		const char * ptyp = pdot + 1;
         for (int cnt = 0; cnt<3; cnt++) {
            if (*ptyp == '\0') break;
            rec->type[cnt] = *ptyp++;
@@ -1880,7 +1880,7 @@ bool LoadFoundFile(struct FileRecord * rec)
     }
 
     // File name
-    char * pnam = dFound.cFileName;
+	const char * pnam = dFound.cFileName;
     for (int cnt = 0; cnt < 8; cnt++) {
         if (*pnam == '\0') break;
         if (pdot && (pnam == pdot)) break;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -824,7 +824,7 @@ void SelectCardBox(void)
 
     // Start from user home diretory
     SHGetSpecialFolderLocation
-        (nullptr,CSIDL_PROFILE,(LPITEMIDLIST *) &bi.pidlRoot);
+        (nullptr,CSIDL_PROFILE, const_cast<LPITEMIDLIST*>(& bi.pidlRoot));
 
     LPITEMIDLIST pidl = SHBrowseForFolder(&bi);
     if (pidl != nullptr) {

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -159,6 +159,8 @@
 // Functions
 //======================================================================
 
+// FIXME: These typedefs are duplicated across more if not all projects and
+// need to be consolidated in one place.
 typedef void (*ASSERTINTERUPT) (unsigned char,unsigned char);
 typedef void (*DYNAMICMENUCALLBACK)( const char *,int, int);
 typedef unsigned char (*MEMREAD8)(unsigned short);

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -155,7 +155,7 @@ void UpdateScreen8 (SystemState *US8State)
 	char Pix=0,Bit=0,Sphase=0;
 	static char Carry1=0,Carry2=0;
 	static char Pcolor=0;
-	unsigned char *buffer=US8State->RamBuffer;
+	const unsigned char *buffer=US8State->RamBuffer;
 	Carry1=1;
 	Pcolor=0;
 	
@@ -6335,7 +6335,7 @@ case 192+63: //Bpp=3 Sr=15
 
 
 // BEGIN of 24 Bit render loop *****************************************************************************************
-void UpdateScreen24 (SystemState *USState24)
+void UpdateScreen24 (SystemState */*USState24*/)
 {
 
 	return;
@@ -6356,7 +6356,7 @@ void UpdateScreen32(SystemState *USState32)
 	unsigned char Character = 0, Attributes = 0;
 	unsigned int TextPallete[2] = { 0,0 };
 	unsigned short * WideBuffer = (unsigned short *)USState32->RamBuffer;
-	unsigned char *buffer = USState32->RamBuffer;
+	const unsigned char *buffer = USState32->RamBuffer;
 	unsigned short WidePixel = 0;
 	//	unsigned short lColor=0;
 	//	unsigned short Yindex[4]={316,308,300,292};
@@ -6368,10 +6368,10 @@ void UpdateScreen32(SystemState *USState32)
 	long Xpitch = USState32->SurfacePitch;
 	Carry1 = 1;
 	Pcolor = 0;
-	static string curr_gmode = "";
-	static string last_gmode = "";
+	static std::string curr_gmode = "";
+	static std::string last_gmode = "";
 	if (curr_gmode != last_gmode) {
-		string tmpout = "Graphics mode switched to " + curr_gmode +"\n";
+		std::string tmpout = "Graphics mode switched to " + curr_gmode +"\n";
 		OutputDebugString(tmpout.c_str());
 		last_gmode = curr_gmode;
 	}
@@ -8277,180 +8277,183 @@ case 192+2:	//Bpp=0 Sr=2
 	if (!pmode4MonType && BoarderColor32 == 0xFFFFFF && GetPaletteType() == PALETTE_NTSC)
 	{
 		// byte pointer to ram
-		unsigned char* cocoRam = (unsigned char*)WideBuffer;
+		const unsigned char* cocoRam = (unsigned char*)WideBuffer;
 		// destination screen (less 2 pixels for bleed)
 		size_t surfaceDest = (((y + VertCenter) * 2) * Xpitch) + HorzCenter - 2;
 		// source coco screens
-		unsigned char* cocoSrc = cocoRam + (VidMask & (Start + (unsigned char)Hoffset));
+		const unsigned char* cocoSrc = cocoRam + (VidMask & (Start + (unsigned char)Hoffset));
 		RenderPMODE4NTSC(szSurface32, surfaceDest, Xpitch, cocoSrc, USState32->ScanLines);
 	}
 	else
-	for (HorzBeam=0;HorzBeam<BytesperRow;HorzBeam+=2) //1bbp Stretch=2
 	{
-		WidePixel=WideBuffer[(VidMask & ( Start+(unsigned char)(Hoffset+HorzBeam) ))>>1];
-//************************************************************************************
-		if (!pmode4MonType && BoarderColor32 == 0xFFFFFF)
-		{ //Pcolor
-			for (Bit=7;Bit>=0;Bit--)
-			{
-				Pix=(1 & (WidePixel>>Bit) );
-				Sphase= (Carry2<<2)|(Carry1<<1)|Pix;
-				switch(Sphase)
+		for (HorzBeam = 0; HorzBeam < BytesperRow; HorzBeam += 2) //1bbp Stretch=2
+		{
+			WidePixel = WideBuffer[(VidMask & (Start + (unsigned char)(Hoffset + HorzBeam))) >> 1];
+			//************************************************************************************
+			if (!pmode4MonType && BoarderColor32 == 0xFFFFFF)
+			{ //Pcolor
+				for (Bit = 7; Bit >= 0; Bit--)
 				{
-				case 0:
-				case 4:
-				case 6:
-					Pcolor=0;
-					break;
-				case 1:
-				case 5:
-					Pcolor=(Bit &1)+1;
-					break;
-				case 2:
-				//	Pcolor=(!(Bit &1))+1; Use last color
-					break;
-				case 3:
-					Pcolor=3;
-					szSurface32[YStride-1]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch-1]=Afacts32[ColorInvert][3];
-					szSurface32[YStride]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][3];
-					break;
-				case 7:
-					Pcolor=3;
-					break;
-				} //END Switch
+					Pix = (1 & (WidePixel >> Bit));
+					Sphase = (Carry2 << 2) | (Carry1 << 1) | Pix;
+					switch (Sphase)
+					{
+					case 0:
+					case 4:
+					case 6:
+						Pcolor = 0;
+						break;
+					case 1:
+					case 5:
+						Pcolor = (Bit & 1) + 1;
+						break;
+					case 2:
+						//	Pcolor=(!(Bit &1))+1; Use last color
+						break;
+					case 3:
+						Pcolor = 3;
+						szSurface32[YStride - 1] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch - 1] = Afacts32[ColorInvert][3];
+						szSurface32[YStride] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][3];
+						break;
+					case 7:
+						Pcolor = 3;
+						break;
+					} //END Switch
 
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				Carry2=Carry1;
-				Carry1=Pix;
-			}
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					Carry2 = Carry1;
+					Carry1 = Pix;
+				}
 
-			for (Bit=15;Bit>=8;Bit--)
-			{
-				Pix=(1 & (WidePixel>>Bit) );
-				Sphase= (Carry2<<2)|(Carry1<<1)|Pix;
-				switch(Sphase)
+				for (Bit = 15; Bit >= 8; Bit--)
 				{
-				case 0:
-				case 4:
-				case 6:
-					Pcolor=0;
-					break;
-				case 1:
-				case 5:
-					Pcolor=(Bit &1)+1;
-					break;
-				case 2:
-				//	Pcolor=(!(Bit &1))+1; Use last color
-					break;
-				case 3:
-					Pcolor=3;
-					szSurface32[YStride-1]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch-1]=Afacts32[ColorInvert][3];
-					szSurface32[YStride]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][3];
-					break;
-				case 7:
-					Pcolor=3;
-					break;
-				} //END Switch
+					Pix = (1 & (WidePixel >> Bit));
+					Sphase = (Carry2 << 2) | (Carry1 << 1) | Pix;
+					switch (Sphase)
+					{
+					case 0:
+					case 4:
+					case 6:
+						Pcolor = 0;
+						break;
+					case 1:
+					case 5:
+						Pcolor = (Bit & 1) + 1;
+						break;
+					case 2:
+						//	Pcolor=(!(Bit &1))+1; Use last color
+						break;
+					case 3:
+						Pcolor = 3;
+						szSurface32[YStride - 1] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch - 1] = Afacts32[ColorInvert][3];
+						szSurface32[YStride] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][3];
+						break;
+					case 7:
+						Pcolor = 3;
+						break;
+					} //END Switch
 
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				Carry2=Carry1;
-				Carry1=Pix;
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					Carry2 = Carry1;
+					Carry1 = Pix;
+				}
+
 			}
-
-		}
 			else
 			{
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-			if (!USState32->ScanLines)
-			{
-				YStride-=32;
-				YStride+=Xpitch;
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-				YStride-=Xpitch;
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+				if (!USState32->ScanLines)
+				{
+					YStride -= 32;
+					YStride += Xpitch;
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+					YStride -= Xpitch;
+				}
 			}
-		}
 
-}
+		}
+	}
+	
 	break;
 
 case 192+3: //Bpp=0 Sr=3 1BPP Stretch=4 PMODE 0
@@ -9529,7 +9532,7 @@ void DrawTopBoarder16(SystemState *DTState)
 	return;
 }
 
-void DrawTopBoarder24(SystemState *DTState)
+void DrawTopBoarder24(SystemState */*DTState*/)
 {
 
 	return;
@@ -9580,7 +9583,7 @@ void DrawBottomBoarder16(SystemState *DTState)
 	return;
 }
 
-void DrawBottomBoarder24(SystemState *DTState)
+void DrawBottomBoarder24(SystemState */*DTState*/)
 {
 	return;
 }

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -35,8 +35,6 @@ using Surface32 = VCC::VideoArray<unsigned int, 640 * 480>;
 void SetupDisplay(void); //This routine gets called every time a software video register get updated.
 void MakeRGBPalette (void);
 void MakeCMPpalette(void);
-bool  DDFailedCheck(HRESULT hr, char *szMessage);
-char *DDErrorString(HRESULT hr);
 void RenderPMODE4NTSC(Surface32 surface32, size_t surfaceDest, int XpitchDest, const unsigned char* cocoSrc, char scanLines);
 
 //extern STRConfig CurrentConfig;

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -9716,7 +9716,7 @@ void SetGimeBoarderColor(unsigned char data)
 	return;
 }
 
-void SetBoarderChange (unsigned char data)
+void SetBoarderChange ()
 {
 	if (BoarderChange >0)
 		BoarderChange--;

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -53,7 +53,7 @@ void GimeInit(void);
 void GimeReset(void);
 void SetVideoBank(unsigned char);
 unsigned char SetMonitorType(unsigned char );
-void SetBoarderChange (unsigned char);
+void SetBoarderChange ();
 int GetBytesPerRow(void);
 unsigned char GetHorizontalBorderSize();
 unsigned short GetDisplayedPixelsPerLine();

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -66,6 +66,8 @@ static unsigned char Lpf[4]={192,199,225,225}; // 2 is really undefined but I go
 static unsigned char VcenterTable[4] = { 25,19,8,8 };
 static unsigned char TopOffScreenTable[4] = { 11,14,11,11 };
 static unsigned char BottomOffScreenTable[4] = { 5,1,5,5 };
+
+// FIXME: These should be a scoped enumeration
 #define MRGB	1
 #define MCMP	0
 

--- a/tcc1014mmu.cpp
+++ b/tcc1014mmu.cpp
@@ -49,7 +49,7 @@ static unsigned int VidMask[4]={0x1FFFF,0x7FFFF,0x1FFFFF,0x7FFFFF};
 static unsigned char CurrentRamConfig=1;
 static unsigned short MmuPrefix=0;
 static unsigned int RamSize=0;
-atomic_bool mem_initializing;
+std::atomic_bool mem_initializing;
 
 void UpdateMmuArray(void);
 
@@ -276,10 +276,14 @@ void MemWrite8(unsigned char data,unsigned short address)
 		return;
 	}
 	if (RamVectors)	//Address must be $FE00 - $FEFF
-		memory[(0x2000*VectorMask[CurrentRamConfig])|(address & 0x1FFF)]=data;
-	else
-	if (MapType | (MmuRegisters[MmuState][address>>13] <VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address>>13] > VectorMask[CurrentRamConfig]))
-		MemPages[MmuRegisters[MmuState][address>>13]][address & 0x1FFF]=data;
+	{
+		memory[(0x2000 * VectorMask[CurrentRamConfig]) | (address & 0x1FFF)] = data;
+	}
+	else if (MapType | (MmuRegisters[MmuState][address >> 13] < VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address >> 13] > VectorMask[CurrentRamConfig]))
+	{
+		MemPages[MmuRegisters[MmuState][address >> 13]][address & 0x1FFF] = data;
+	}
+
 	return;
 }
 
@@ -325,10 +329,16 @@ void __fastcall fMemWrite8(unsigned char data,unsigned short address)
 		return;
 	}
 	if (RamVectors)	//Address must be $FE00 - $FEFF
-		memory[(0x2000*VectorMask[CurrentRamConfig])|(address & 0x1FFF)]=data;
+	{
+		memory[(0x2000 * VectorMask[CurrentRamConfig]) | (address & 0x1FFF)] = data;
+	}
 	else
-	if (MapType | (MmuRegisters[MmuState][address>>13] <VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address>>13] > VectorMask[CurrentRamConfig]))
-		MemPages[MmuRegisters[MmuState][address>>13]][address & 0x1FFF]=data;
+	{
+		if (MapType | (MmuRegisters[MmuState][address >> 13] < VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address >> 13] > VectorMask[CurrentRamConfig]))
+		{
+			MemPages[MmuRegisters[MmuState][address >> 13]][address & 0x1FFF] = data;
+		}
+	}
 	return;
 }
 

--- a/tcc1014mmu.h
+++ b/tcc1014mmu.h
@@ -44,18 +44,17 @@ void GetMMUPage(size_t page, std::array<unsigned char, 8192>& outBuffer);
 void MemWrite8(unsigned char,unsigned short );
 void MemWrite16(unsigned short,unsigned short );
 
-unsigned short MemRead16(short unsigned int);
-unsigned char MemRead8(short unsigned int);
-unsigned char SafeMemRead8(short unsigned int);
+unsigned short MemRead16(unsigned short);
+unsigned char MemRead8(unsigned short);
+unsigned char SafeMemRead8(unsigned short);
 unsigned char * MmuInit(unsigned char);
 unsigned char *	Getint_rom_pointer(void);
-unsigned char * Getext_rom_pointer(void);
 unsigned short GetMem(unsigned long);
 void SetMem(unsigned long, unsigned short);
 bool MemCheckWrite(unsigned short address);
 
 void __fastcall fMemWrite8(unsigned char,unsigned short );
-unsigned char __fastcall fMemRead8(short unsigned int);
+unsigned char __fastcall fMemRead8(unsigned short);
 
 void SetMapType(unsigned char);
 void LoadRom(void);
@@ -67,7 +66,6 @@ void SetVectors(unsigned char);
 void MmuReset(void);
 void SetDistoRamBank(unsigned char);
 void SetMmuPrefix(unsigned char);
-void SetCartMMU (unsigned char);
 unsigned char * Get_mem_pointer(void);
 
 // FIXME: These need to be turned into an enum and the signature of functions

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -172,12 +172,12 @@ unsigned char GimeRead(unsigned char port)
 		data=LastIrq;
 		LastIrq=0;
 		CPUDeAssertInterupt(IS_GIME, INT_IRQ);
-		return(data);
+		return data;
 	case 0x93:
 		data=LastFirq;
 		LastFirq=0;
 		CPUDeAssertInterupt(IS_GIME, INT_FIRQ);
-		return(data);
+		return data;
 	default:
 		if (port >= 0xA0) {
 			data = GimeRegisters[port];

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -36,9 +36,9 @@ static unsigned char EnhancedFIRQFlag=0,EnhancedIRQFlag=0;
 static int InteruptTimer=0;
 void SetInit0(unsigned char);
 void SetInit1(unsigned char);
-void SetGimeIRQStearing(unsigned char);
+void SetGimeIRQStearing();
 void SetGimeFIRQStearing(unsigned char);
-void SetTimerMSB(unsigned char);
+void SetTimerMSB();
 void SetTimerLSB(unsigned char);
 unsigned char GetInit0(unsigned char port);
 static unsigned char IRQStearing[8]={0,0,0,0,0,0,0,0};
@@ -72,7 +72,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x92:
-		SetGimeIRQStearing(data);
+		SetGimeIRQStearing();
 		break;
 
 	case 0x93:
@@ -80,7 +80,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x94:
-		SetTimerMSB(data);
+		SetTimerMSB();
 		break;
 
 	case 0x95:
@@ -213,7 +213,7 @@ unsigned char GetInit0(unsigned char port)
 	return data;
 }
 
-void SetGimeIRQStearing(unsigned char data) //92
+void SetGimeIRQStearing() //92
 {
 	// FIXME: GimeIRQStearing for CART (bit 0)
 
@@ -266,7 +266,7 @@ void SetGimeFIRQStearing(unsigned char data) //93
 	return;
 }
 
-void SetTimerMSB(unsigned char data) //94
+void SetTimerMSB() //94
 {
 	unsigned short Temp;
 	Temp=((GimeRegisters[0x94] <<8)+ GimeRegisters[0x95]) & 4095;

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -37,10 +37,10 @@ static int InteruptTimer=0;
 void SetInit0(unsigned char);
 void SetInit1(unsigned char);
 void SetGimeIRQStearing();
-void SetGimeFIRQStearing(unsigned char);
+void SetGimeFIRQStearing();
 void SetTimerMSB();
-void SetTimerLSB(unsigned char);
-unsigned char GetInit0(unsigned char port);
+void SetTimerLSB();
+unsigned char GetInit0();
 static unsigned char IRQStearing[8]={0,0,0,0,0,0,0,0};
 static unsigned char FIRQStearing[8]={0,0,0,0,0,0,0,0};
 static unsigned char LastIrq = 0, LastFirq = 0;
@@ -76,7 +76,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x93:
-		SetGimeFIRQStearing(data);
+		SetGimeFIRQStearing();
 		break;
 
 	case 0x94:
@@ -84,7 +84,7 @@ void GimeWrite(unsigned char port,unsigned char data)
 		break;
 
 	case 0x95:
-		SetTimerLSB(data);
+		SetTimerLSB();
 		break;
 
 	case 0x96:
@@ -207,7 +207,7 @@ void SetInit1(unsigned char data)
 	return;
 }
 
-unsigned char GetInit0(unsigned char port)
+unsigned char GetInit0()
 {
 	unsigned char data=0;
 	return data;
@@ -239,7 +239,7 @@ void SetGimeIRQStearing() //92
 	return;
 }
 
-void SetGimeFIRQStearing(unsigned char data) //93
+void SetGimeFIRQStearing() //93
 {
 	// FIXME: GimeFIRQStearing for CART (bit 0)
 
@@ -274,7 +274,7 @@ void SetTimerMSB() //94
 	return;	
 }
 
-void SetTimerLSB(unsigned char data) //95
+void SetTimerLSB() //95
 {
 	unsigned short Temp;
 	Temp=((GimeRegisters[0x94] <<8)+ GimeRegisters[0x95]) & 4095;

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -368,7 +368,7 @@ unsigned char sam_read(unsigned char port) //SAM don't talk much :)
 
 	return 0;
 }
-void sam_write(unsigned char data ,unsigned char port)
+void sam_write(unsigned char port)
 {
 	unsigned char mask=0;
 	unsigned char reg=0;

--- a/tcc1014registers.h
+++ b/tcc1014registers.h
@@ -28,7 +28,7 @@ void GimeAssertVertInterupt(void);
 void GimeAssertTimerInterupt(void);
 void GimeAssertCartInterupt(void);
 unsigned char sam_read(unsigned char);
-void sam_write(unsigned char,unsigned char);
+void sam_write(unsigned char);
 void mc6883_reset();
 unsigned char VDG_Offset(void);
 unsigned char VDG_Modes(void);

--- a/xDebug.h
+++ b/xDebug.h
@@ -19,7 +19,7 @@ extern "C"
 {
 #endif
 	
-	void		_xDbgTrace(const void * pFile, const int iLine, const void * pFormat, ...);
+	void		_xDbgTrace(const char* pFile, const int iLine, const char* pFormat, ...);
 	
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is dependant on Part 3

More general cleanup

- Add deleted copy constructor and copy assignment operator to `CriticalSection`.
- Add correct annotations to WinMain.
- Add initialization of member variables.
- Remove superfluous casts.
- Remove redundant parenthesis.
- Remove redundant type from declaration and change to `auto`.
- Change `NULL` to `nullptr`.
- Make variables pointer-to-const.
- Make parameters pointer-to-const.
- Make parameters and variables `const`.
- Replace use of `insert` with `emplace` and `emplace_back`. Remove iterator variables.
- Default the ctor of SN76489Device
- Add braces
- Update IndexingModes to use transparent compare.
- Remove `using std::namespace`.
- Remove unused variables
- Format `if`/`else` chains and add braces so their levels and flow are clear (i.e. properly indented).
