### PR TITLE
General code cleanup

### DIFF
--- a/Audio.cpp
+++ b/Audio.cpp
@@ -157,7 +157,7 @@ int SoundInit (HWND main_window_handle,const _GUID * Guid,unsigned int Rate)
 
 void FlushAudioBuffer(unsigned int *Abuffer,unsigned int Lenth)
 {
-	unsigned char *Abuffer2=(unsigned char *)Abuffer;
+	const unsigned char *Abuffer2=(unsigned char *)Abuffer;
 
 	if (!InitPassed || AudioPause || !Abuffer)
 		return;

--- a/CommandLine.cpp
+++ b/CommandLine.cpp
@@ -102,9 +102,9 @@ static char *NxtTokenPtr;
 // CmdString:  The third arg to WinMain()
 //-------------------------------------------------------------------
 
-int GetCmdLineArgs(char *CmdString) 
+int GetCmdLineArgs(const char *CmdString) 
 {
-    char *token;      // token pointer (to item in command string)
+	const char *token;      // token pointer (to item in command string)
     int  argnum = 0;  // non-option argument number
     int  len;         // len of a chr string
 
@@ -219,7 +219,7 @@ char * ParseCmdString(const char *CmdString, const char *ValueRequired)
     static char option[256];  // Used to append value to option
     int quoted;
     char *token;
-    char *value;
+	const char *value;
 
     // Initial call sets command string. Subsequent calls expect a NULL
     if (CmdString) {                   

--- a/CommandLine.h
+++ b/CommandLine.h
@@ -34,7 +34,7 @@ struct CmdLineArguments {
 extern struct CmdLineArguments CmdArg;
 
 // Get Settings from Command line string 
-int  GetCmdLineArgs(char * lpCmdLine);
+int  GetCmdLineArgs(const char * lpCmdLine);
 
 // Errors returned
 // FIXME: These need to be turned into a scoped enum and the signature of functions

--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -485,7 +485,7 @@ namespace VCC { namespace Debugger
 		MemWrite8(memWrite.value, memWrite.addr);
 	}
 
-	bool Debugger::Halt_Enabled()
+	bool Debugger::Halt_Enabled() const
 	{
 		return Halt_Enabled_TF;
 	}
@@ -495,7 +495,7 @@ namespace VCC { namespace Debugger
 		Halt_Enabled_TF = flag;
 	}
 
-	bool Debugger::Break_Enabled()
+	bool Debugger::Break_Enabled() const
 	{
 		return Break_Enabled_TF;
 	}

--- a/Debugger.h
+++ b/Debugger.h
@@ -111,9 +111,9 @@ namespace VCC { namespace Debugger
 		// haltpoints to avoid conflict with the mechanism used by the source
 		// code debugger)  BREAK instruction is page two opcodes 0x113E and the
 		// HALT instruction is opcode 0x15.
-		bool Break_Enabled();
+		bool Break_Enabled() const;
 		void Enable_Break(bool);
-		bool Halt_Enabled();
+		bool Halt_Enabled() const;
 		void Enable_Halt(bool);
 
 	protected:
@@ -146,8 +146,8 @@ namespace VCC { namespace Debugger
 	private:
 
 		mutable CriticalSection			Section_;
-		bool							HasPendingCommand_;
-		ExecutionMode					PendingCommand_;
+		bool							HasPendingCommand_ = false;
+		ExecutionMode					PendingCommand_ = ExecutionMode::Halt;
 		breakpointsbuffer_type			Breakpoints_;
 		bool							BreakpointsChanged_ = false;
 		CPUState						ProcessorState_;

--- a/DebuggerUtils.h
+++ b/DebuggerUtils.h
@@ -38,6 +38,9 @@ namespace VCC
 			DeleteCriticalSection(&Section_);
 		}
 
+		CriticalSection(const CriticalSection&) = delete;
+		CriticalSection& operator=(const CriticalSection&) = delete;
+
 		void Lock()
 		{
 			EnterCriticalSection(&Section_);

--- a/DialogOps.cpp
+++ b/DialogOps.cpp
@@ -24,7 +24,6 @@
 //    along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 //
 //-------------------------------------------------------------------------------------------
-
 #include <Windows.h>
 #include "DialogOps.h"
 
@@ -113,7 +112,8 @@ void FileDialog::getupath(char * PathCopy, int maxsize) const {
 }
 
 // Get a pointer to the selected file path
-char * FileDialog::path() {
+const char *FileDialog::path() const
+{
 	return Path;
 }
 

--- a/DialogOps.h
+++ b/DialogOps.h
@@ -60,7 +60,7 @@ public:
 	void getdir(char * Dir, int maxsize = MAX_PATH) const;
 	void getpath(char * Path, int maxsize = MAX_PATH) const;
 	void getupath(char * Path, int maxsize = MAX_PATH) const;
-	char * path();
+	const char *path() const;
 private:
 	OPENFILENAME ofn;
 	char Path[MAX_PATH] = {};

--- a/DirectDrawInterface.cpp
+++ b/DirectDrawInterface.cpp
@@ -351,7 +351,7 @@ void SetStatusBarText(const char *TextBuffer,const SystemState *STState)
 {
 	if (!STState->FullScreen)
 	{
-		SendMessage(hwndStatusBar,WM_SETTEXT,0,(LPARAM)(LPCSTR)TextBuffer);
+		SendMessage(hwndStatusBar,WM_SETTEXT,0, reinterpret_cast<LPARAM>(TextBuffer));
 		SendMessage(hwndStatusBar,WM_SIZE,0,0);
 	}
 	else

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -707,7 +707,7 @@ bool IsBreakpoint(int realaddr)
 /*******************************************************/
 void FindHaltpoints()
 {
-    std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+    auto it = mHaltpoints.begin();
     while (it != mHaltpoints.end()) {
         int adr = it->first;
         // If decoded with CPU addressing convert haltpoint to CPU address
@@ -884,7 +884,7 @@ void RefreshHPlist()
     if (hBrkpDlg == nullptr) return;
     SendDlgItemMessage(hBrkpDlg,IDC_LIST_BREAKPOINTS,LB_RESETCONTENT,0,0);
     if (mHaltpoints.size() > 0) {
-        std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+		auto it = mHaltpoints.begin();
         while (it != mHaltpoints.end()) {
             int realaddr = it->first;
             Haltpoint hp = it->second;
@@ -918,7 +918,7 @@ void ListHaltpoints()
 /*******************************************************/
 void KillHaltpoints()
 {
-    std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+	auto it = mHaltpoints.begin();
     while (it != mHaltpoints.end()) {
         int realaddr = it->first;
         Haltpoint hp = it->second;
@@ -938,7 +938,7 @@ void KillHaltpoints()
 void ApplyHaltpoints(bool flag)
 {
     // Iterate over all defined haltpoints
-    std::map<int, Haltpoint>::iterator it = mHaltpoints.begin();
+	auto it = mHaltpoints.begin();
     while (it != mHaltpoints.end()) {
         int realaddr = it->first;
         Haltpoint hp = it->second;
@@ -1029,7 +1029,7 @@ void DecodeAddr()
 
     // Convert real address to offset and block for disassemble
     if (RealAdrMode) {
-        blk = (unsigned) adr >> 13;
+        blk = adr >> 13;
         adr = adr & 0x1FFF;
     }
 

--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -170,7 +170,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawBorder(HDC hdc, LPRECT clientRect)
+	void DrawBorder(HDC hdc, LPCRECT clientRect)
 	{
 		RECT rect = *clientRect;
 
@@ -178,7 +178,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		HBRUSH brush = (HBRUSH)GetStockObject(WHITE_BRUSH);
 		FillRect(hdc, &rect, brush);
 
-		HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+		HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
 		SelectObject(hdc, pen);
 
 		// Draw the border.
@@ -210,7 +210,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 
 		std::stringstream ss;
 		ss << samples << " Samples Collected";
-		DrawText(hdc, (LPCSTR)ss.str().c_str(), ss.str().size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+		DrawText(hdc, ss.str().c_str(), ss.str().size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
 		DeleteObject(hFont);
 	}
@@ -231,13 +231,13 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		SelectObject(hdc, hFont);
 
 		std::string s = "Press Enable to start collection";
-		DrawText(hdc, (LPCSTR)s.c_str(), s.size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+		DrawText(hdc, s.c_str(), s.size(), &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
 		DeleteObject(hFont);
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawSamples(HDC hdc, LPRECT clientRect)
+	void DrawSamples(HDC hdc, LPCRECT clientRect)
 	{
 		long samples = EmuState.Debugger.GetTraceSamples();
 
@@ -270,7 +270,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 			CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, FIXED_PITCH, TEXT("Consolas"));
 		SelectObject(hdc, hFont);
 
-		HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+		HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
 		SelectObject(hdc, pen);
 
 		EmuState.Debugger.LockTrace();
@@ -292,18 +292,11 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Running a 6309 CPU?
 		if (Is6309)
 		{
-			std::vector<std::string>::iterator itHeader;
-			std::vector<int>::iterator itColumn;
+			headers.emplace(headers.begin() + 9, "W");
+			columns.emplace(columns.begin() + 9, 30);
 
-			itHeader = headers.begin();
-			itHeader = headers.insert(itHeader + 9, "W");
-			itColumn = columns.begin();
-			itColumn = columns.insert(itColumn + 9, 30);
-
-			itHeader = headers.end();
-			itHeader = headers.insert(itHeader, "MD");
-			itColumn = columns.end();
-			itColumn = columns.insert(itColumn, 30);
+			headers.emplace_back("MD");
+			columns.emplace_back(30);
 		}
 
 		int x = 10;
@@ -622,7 +615,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 //-------------------------------------------------------------------------------
-	void DrawExecutionTrace(HDC hdc, LPRECT clientRect)
+	void DrawExecutionTrace(HDC hdc, LPCRECT clientRect)
 	{
 		// Draw the border.
 		DrawBorder(hdc, clientRect);
@@ -1116,7 +1109,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		//	offset, nlines, count, _trace.size());
 
 		char* pos = line;
-		char* end = pos + lineSize;
+		const char* end = pos + lineSize;
 		DWORD dummy;
 
 		auto Flush = [&]()

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -86,7 +86,7 @@ static float WriteSpeed = 0;
 // Should default to "127.0.0.1" and "65504"
 //------------------------------------------------------
 
-int becker_sethost(char *bufdwaddr, char *bufdwport)
+int becker_sethost(const char *bufdwaddr, const char *bufdwport)
 {
 	strcpy(dwaddress,bufdwaddr);
 	strcpy(dwsport,bufdwport);

--- a/FD502/becker.h
+++ b/FD502/becker.h
@@ -2,7 +2,7 @@
 #define __BECKER_H__
 
 void becker_enable(bool);                        // enable or disable
-int becker_sethost(char *, char *);              // server ip address, port
+int becker_sethost(const char *, const char *);  // server ip address, port
 unsigned char becker_read(unsigned short);       // coco port
 void becker_write(unsigned char,unsigned short); // value, coco port
 void becker_status(char *);                      // becker status for status line

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -68,7 +68,7 @@ LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
 LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
 void LoadConfig(void);
 void SaveConfig(void);
-long CreateDiskHeader(char *,unsigned char,unsigned char,unsigned char);
+long CreateDiskHeader(const char *,unsigned char,unsigned char,unsigned char);
 void Load_Disk(unsigned char);
 void CenterDialog(HWND hDlg);
 
@@ -77,7 +77,7 @@ static HINSTANCE g_hinstDLL;
 static unsigned long RealDisks=0;
 long CreateDisk (unsigned char);
 static char TempFileName[MAX_PATH]="";
-unsigned char LoadExtRom( unsigned char,char *);
+unsigned char LoadExtRom( unsigned char, const char *);
 
 int BeckerEnabled=0;
 char BeckerAddr[MAX_PATH]="";
@@ -164,7 +164,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();
@@ -584,7 +584,7 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
     return FALSE;
 }
 
-long CreateDiskHeader(char *FileName,unsigned char Type,unsigned char Tracks,unsigned char DblSided)
+long CreateDiskHeader(const char *FileName,unsigned char Type,unsigned char Tracks,unsigned char DblSided)
 {
 	HANDLE hr=nullptr;
 	unsigned char Dummy=0;
@@ -745,7 +745,7 @@ void SaveConfig(void)
 	return;
 }
 
-unsigned char LoadExtRom( unsigned char RomType,char *FilePath)	//Returns 1 on if loaded
+unsigned char LoadExtRom( unsigned char RomType,const char *FilePath)	//Returns 1 on if loaded
 {
 
 	FILE *rom_handle=nullptr;

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -51,7 +51,7 @@ unsigned char WriteBytetoSector (unsigned char);
 unsigned char WriteBytetoTrack  (unsigned char);
 unsigned char (*WriteBytetoDisk)(unsigned char)=&WriteBytetoSector;
 
-unsigned char MountDisk(char *,unsigned char);
+unsigned char MountDisk(const char *filename,unsigned char);
 void DispatchCommand(unsigned char);
 void DecodeControlReg(unsigned char);
 void SetType1Flags(unsigned char);
@@ -59,12 +59,12 @@ void SetType2Flags(unsigned char);
 void SetType3Flags(unsigned char);
 
 long ReadSector (unsigned char,unsigned char,unsigned char,unsigned char *);
-long WriteSector(unsigned char,unsigned char,unsigned char,unsigned char *,long);
+long WriteSector(unsigned char,unsigned char,unsigned char,const unsigned char *,long);
 long ReadTrack  (unsigned char,unsigned char,unsigned char,unsigned char *);
-long WriteTrack (unsigned char,unsigned char,unsigned char,unsigned char *);
+long WriteTrack (unsigned char,unsigned char,unsigned char,const unsigned char *);
 
 unsigned short ccitt_crc16(unsigned short crc, const unsigned char *, unsigned short );
-long GetSectorInfo (SectorInfo *,unsigned char *);
+long GetSectorInfo (SectorInfo *,const unsigned char *);
 void CommandDone(void);
 extern unsigned char PhysicalDriveA,PhysicalDriveB;
 bool FormatTrack (HANDLE , BYTE , BYTE,BYTE );
@@ -241,7 +241,7 @@ void DecodeControlReg(unsigned char Tmp)
 	return;
 }
 
-int mount_disk_image(char filename[MAX_PATH],unsigned char drive)
+int mount_disk_image(const char *filename,unsigned char drive)
 {
 	unsigned int Temp=0;
 	Temp=MountDisk(filename,drive);
@@ -273,7 +273,7 @@ void DiskStatus(char *Status)
 	return;
 }
 
-unsigned char MountDisk(char *FileName,unsigned char disk)
+unsigned char MountDisk(const char *FileName,unsigned char disk)
 {
 	unsigned long BytesRead=0;
 	unsigned char HeaderBlock[HEADERBUFFERSIZE]="";
@@ -399,7 +399,7 @@ long ReadSector (unsigned char Side,	//0 or 1
 	DWORD dwRet;
 	FD_SEEK_PARAMS sp;
 	unsigned char Ret=0;
-	unsigned char *pva=nullptr;
+	const unsigned char *pva=nullptr;
 //************************
 
 	if (Drive[CurrentDisk].FileHandle==nullptr)
@@ -473,7 +473,7 @@ long ReadSector (unsigned char Side,	//0 or 1
 long WriteSector (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
 					unsigned char Sector,	//1 to 18 could be 0 to 17
-					unsigned char *WriteBuffer, //)
+				    const unsigned char *WriteBuffer, //)
 					long BytestoWrite)
 {
 	unsigned long BytesWritten=0,Result=0,BytesRead=0;
@@ -484,7 +484,7 @@ long WriteSector (	unsigned char Side,		//0 or 1
 	DWORD dwRet;
 	FD_SEEK_PARAMS sp;
 	unsigned char Ret=0;
-	unsigned char *pva=nullptr;
+	const unsigned char *pva=nullptr;
 	SectorInfo CurrentSector;
 	if ( (Drive[CurrentDisk].FileHandle==nullptr) | ((Side+1) > Drive[CurrentDisk].Sides) )
 		return 0;
@@ -547,7 +547,7 @@ long WriteSector (	unsigned char Side,		//0 or 1
 long WriteTrack (	unsigned char Side,		//0 or 1
 					unsigned char Track,	//0 to 255 "REAL" values are 1 to 80
 					unsigned char /*Dummy*/,	//Sector Value unused
-					unsigned char *WriteBuffer)
+					const unsigned char *WriteBuffer)
 {
 	unsigned char xTrack=0,xSide=0,xSector=0,xLenth=0;
 	unsigned short BufferIndex=0,WriteIndex=0,IdamIndex=0;
@@ -1255,7 +1255,7 @@ unsigned char SetTurboDisk( unsigned char Tmp)
 	return TurboMode;
 }
 
-long GetSectorInfo (SectorInfo *Sector,unsigned char *TempBuffer)
+long GetSectorInfo (SectorInfo *Sector,const unsigned char *TempBuffer)
 {
 	unsigned short Temp1=0,Temp2=0;
 	unsigned char Density=0;

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -20,7 +20,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 unsigned char disk_io_read(unsigned char port);
 void disk_io_write(unsigned char data,unsigned char port);	
-int mount_disk_image(char *,unsigned char );
+int mount_disk_image(const char *,unsigned char );
 void unmount_disk_image(unsigned char drive);
 void DiskStatus(char *);
 void PingFdc(void);

--- a/GMC/GMCCartridge.cpp
+++ b/GMC/GMCCartridge.cpp
@@ -55,7 +55,7 @@ void GMCCartridge::OnMenuItemSelected(unsigned char menuId)
 			"ROM Selected",
 			MB_OK);
 
-		m_Configuration.SetActiveRom(selectedFile.data());
+		m_Configuration.SetActiveRom(selectedFile);
 
 		AssetCartridgeLine(false);
 		AssetCartridgeLine(true);

--- a/GMC/sn76496.cpp
+++ b/GMC/sn76496.cpp
@@ -142,13 +142,6 @@
 #define MAX_OUTPUT 0x7fff
 
 
-SN76489Device::SN76489Device()
-{}
-
-
-
-
-
 void SN76489Device::device_start()
 {
 	for (int i = 0; i < 8; i += 2)

--- a/GMC/sn76496.h
+++ b/GMC/sn76496.h
@@ -10,7 +10,7 @@ public:
 
 	using stream_sample_t = unsigned short;
 
-	SN76489Device();
+	SN76489Device() = default;
 	virtual ~SN76489Device() = default;
 
 	virtual void device_start();

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -241,7 +241,7 @@ extern "C"
 extern "C"
 {
     __declspec(dllexport) void
-    SetIniPath (char *IniFilePath)
+    SetIniPath (const char *IniFilePath)
     {
         strcpy(IniFile,IniFilePath);
         LoadConfig();

--- a/MMUMonitor.cpp
+++ b/MMUMonitor.cpp
@@ -87,7 +87,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	}
 
 	// Draw the Monitor Window
-	void DrawMMUMonitor(HDC hdc, LPRECT clientRect)
+	void DrawMMUMonitor(HDC hdc, LPCRECT clientRect)
 	{
 		RECT rect = *clientRect;
 
@@ -95,8 +95,8 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		HBRUSH brush = (HBRUSH)GetStockObject(WHITE_BRUSH);
 		FillRect(hdc, &rect, brush);
 
-		HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, rgbGray);
-		HPEN thickPen = (HPEN)CreatePen(PS_SOLID, 2, rgbGray);
+		HPEN pen = CreatePen(PS_SOLID, 1, rgbGray);
+		HPEN thickPen = CreatePen(PS_SOLID, 2, rgbGray);
 
 		HFONT hFont = CreateFont(14, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE,
 		                         DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,

--- a/MemoryMap.cpp
+++ b/MemoryMap.cpp
@@ -40,8 +40,8 @@ void FlashDialogWindow();
 void WriteMemory(int,unsigned char);
 void SetBackBuffer(const RECT&);
 void CreateScrollBar(const RECT&);
-void DrawForm(HDC,LPRECT);
-void DrawMemory(HDC,LPRECT);
+void DrawForm(HDC,LPCRECT);
+void DrawMemory(HDC,LPCRECT);
 void SetEditPosition(int,int);
 void LocateMemory();
 void CommitValue();
@@ -77,7 +77,7 @@ AddrMode AddrMode_ = AddrMode::NotSet;
 
 int MemSize = 0;
 int memoryOffset = 0;
-static unsigned char *Rom = nullptr;
+unsigned char *Rom = nullptr;
 bool Editing = false;
 int editAddress = 0;
 
@@ -349,7 +349,7 @@ void CreateScrollBar(const RECT& Rect)
 //------------------------------------------------------------------
 // Draw display form with header and vert guide lines
 //------------------------------------------------------------------
-void DrawForm(HDC hdc,LPRECT clientRect)
+void DrawForm(HDC hdc,LPCRECT clientRect)
 {
 	int top = clientRect->top;
 	int lft = clientRect->left;
@@ -395,7 +395,7 @@ void DrawForm(HDC hdc,LPRECT clientRect)
 //------------------------------------------------------------------
 // Fill memory data on form
 //------------------------------------------------------------------
-void DrawMemory(HDC hdc, LPRECT clientRect)
+void DrawMemory(HDC hdc, LPCRECT clientRect)
 {
 	int top = clientRect->top;
 	int lft = clientRect->left;
@@ -646,7 +646,7 @@ void InitializeDialog(HWND hDlg)
 		SetMemType();
 
 		// Set display pen color
-		HPEN pen = (HPEN) CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+		HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
 		SelectObject(BackBuf.DeviceContext, pen);
 		DeleteObject(pen);
 

--- a/ModuleDefs.h
+++ b/ModuleDefs.h
@@ -37,5 +37,5 @@ typedef void (*DMAMEMPOINTERS) ( MEMREAD8,MEMWRITE8);
 typedef void (*SETINTERUPTCALLPOINTER) (PAKINTERUPT);
 typedef unsigned short (*MODULEAUDIOSAMPLE)(void);
 typedef void (*MODULERESET)(void);
-typedef void (*SETINIPATH)(char *);
+typedef void (*SETINIPATH)(const char *);
 typedef void (*ASSERTINTERUPT)(unsigned char, unsigned char);

--- a/OpCodeTables.h
+++ b/OpCodeTables.h
@@ -916,7 +916,7 @@ namespace VCC { namespace Debugger
 			bool only6309 = false;		// Valid only if running a 6309, in other words, invalid on a 6809
 		};
 
-		const std::map<std::string, IndexModeInfo> IndexingModes = 
+		const std::map<std::string, IndexModeInfo, std::less<>> IndexingModes = 
 		{ 
 			{ "1RR00100", {"1RR00100", ",R",		0,	0,	0,	false } },
 			{ "0RRnnnnn", {"0RRnnnnn", "n,R",		1,	1,	0,	false } },

--- a/OpenGL.cpp
+++ b/OpenGL.cpp
@@ -436,7 +436,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int GetSurface(Pixel** pixels)
+		int GetSurface(Pixel** pixels) const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 			*pixels = this->pixels;
@@ -469,7 +469,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int RenderText(const OpenGLFont* font, float x, float y, float size, const char* text)
+		int RenderText(const OpenGLFont* font, float x, float y, float size, const char* text) const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 
@@ -514,7 +514,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int Present()
+		int Present() const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 			wglMakeCurrent(hDC, hRC);
@@ -528,7 +528,7 @@ namespace VCC
 			return Result(OK);
 		}
 
-		int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end)
+		int LoadFont(const OpenGLFont** outFont, int bitmapRes, const OpenGLFontGlyph* glyphs, int start, int end) const
 		{
 			*outFont = nullptr;
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
@@ -606,7 +606,7 @@ namespace VCC
 		}
 		#endif // USE_DEBUG_LINES
 
-		int RenderBox(float x, float y, float w, float h, Pixel color, bool filled)
+		int RenderBox(float x, float y, float w, float h, Pixel color, bool filled) const
 		{
 			if (!isInitialized) return Result(ERR_NOTINITIALIZED);
 			float x2 = x + w;
@@ -658,7 +658,7 @@ namespace VCC
 	private:
 
 		// returns the box where display should be rendered
-		void GetDisplayArea(Rect* area)
+		void GetDisplayArea(Rect* area) const
 		{
 			area->w = (float)width;
 			area->h = (float)height;
@@ -683,14 +683,14 @@ namespace VCC
 			area->y = (height - area->h) / 2.0f;
 		}
 
-		void GetRenderArea(Rect* area)
+		void GetRenderArea(Rect* area) const
 		{
 			area->x = area->y = 0;
 			area->w = (float)width;
 			area->h = (float)height;
 		}
 
-		void GetSurfaceArea(Rect* area)
+		void GetSurfaceArea(Rect* area) const
 		{
 			area->x = area->y = 0;
 			area->w = (float)SurfaceWidth;

--- a/ProcessorState.cpp
+++ b/ProcessorState.cpp
@@ -60,7 +60,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
         LineTo(hdc, rx, ry + h);
     }
 
-    void DrawProcessorState(HDC hdc, LPRECT clientRect)
+    void DrawProcessorState(HDC hdc, LPCRECT clientRect)
     {
         RECT rect = *clientRect;
         Decoder = std::make_unique<OpDecoder>();
@@ -69,7 +69,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
         HBRUSH brush = (HBRUSH)GetStockObject(WHITE_BRUSH);
         FillRect(hdc, &rect, brush);
 
-        HPEN pen = (HPEN)CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
+        HPEN pen = CreatePen(PS_SOLID, 1, RGB(192, 192, 192));
         SelectObject(hdc, pen);
 
         // Draw the border.

--- a/SourceDebug.cpp
+++ b/SourceDebug.cpp
@@ -81,7 +81,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 
 	bool LoadSource(const char* source)
 	{
-		SendDlgItemMessage(hWndSourceDebug, IDC_EDIT_SOURCE, WM_SETTEXT, 0, (LPARAM)(LPCSTR)source);
+		SendDlgItemMessage(hWndSourceDebug, IDC_EDIT_SOURCE, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(source));
 
 		int nLines = 0;
 		std::string loaded(std::to_string(nLines) + " lines loaded");
@@ -227,7 +227,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	{
 		Debugger::breakpointsbuffer_type breakpoints;
 
-		std::map<int, Breakpoint>::iterator it = mapBreakpoints.begin();
+		auto it = mapBreakpoints.begin();
 		while (it != mapBreakpoints.end())
 		{
 			Breakpoint bp = it->second;

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -35,7 +35,7 @@ static HANDLE hDiskFile[2];
 static unsigned char DiskSelect=0,LbaEnabled=0;
 unsigned long BytesMoved=0;
 unsigned char BusyCounter=BUSYWAIT;
-HANDLE OpenDisk(char *,unsigned char);
+HANDLE OpenDisk(const char *,unsigned char);
 static unsigned short IDBlock[2][256];
 static unsigned char Mounted=0,ScanCount=0;
 static char CurrStatus[32]="IDE:Idle ";
@@ -270,7 +270,7 @@ void ByteSwap (char *String)
 	return;
 }
 
-HANDLE OpenDisk(char *ImageFile,unsigned char DiskNum)
+HANDLE OpenDisk(const char *ImageFile,unsigned char DiskNum)
 {
 	HANDLE hTemp=nullptr;
 	unsigned long FileSize=0;
@@ -333,7 +333,7 @@ void DiskStatus(char *Temp)
 	}
 	return;
 }
-unsigned char MountDisk(char *FileName,unsigned char DiskNumber)
+unsigned char MountDisk(const char *FileName,unsigned char DiskNumber)
 {
 	if (DiskNumber>1)
 		return FALSE;

--- a/SuperIDE/IdeBus.h
+++ b/SuperIDE/IdeBus.h
@@ -33,7 +33,7 @@ void IdeInit();
 void IdeRegWrite(unsigned char,unsigned short);
 unsigned short IdeRegRead(unsigned char);
 void DiskStatus(char *);
-unsigned char MountDisk(char *,unsigned char );
+unsigned char MountDisk(const char *,unsigned char );
 unsigned char DropDisk(unsigned char);
 void QueryDisk(unsigned char,char *);
 //Status 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -180,7 +180,7 @@ extern "C"
 
 extern "C" 
 {
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -100,7 +100,7 @@ LRESULT CALLBACK WndProc( HWND, UINT, WPARAM, LPARAM);
 void SoftReset(void);
 void LoadIniFile(void);
 void SaveConfig(void);
-unsigned __stdcall EmuLoop(void *);
+unsigned __stdcall EmuLoop(HANDLE hEvent);
 unsigned __stdcall CartLoad(void *);
 void (*CPUInit)(void)=nullptr;
 int  (*CPUExec)( int)=nullptr;
@@ -133,10 +133,10 @@ bool IsShiftKeyDown(void);
 
 //static CRITICAL_SECTION  FrameRender;
 /*--------------------------------------------------------------------------*/
-int APIENTRY WinMain(HINSTANCE hInstance,
-                     HINSTANCE hPrevInstance,
-                     LPSTR     lpCmdLine,
-                     int       nCmdShow)
+int APIENTRY WinMain(_In_ HINSTANCE hInstance,
+					  _In_opt_ HINSTANCE hPrevInstance,
+					  _In_ LPSTR    lpCmdLine,
+					  _In_ int       nCmdShow)
 {
 	MSG  Msg;
 
@@ -952,9 +952,8 @@ void SaveConfig(void) {
 	return;
 }
 
-unsigned __stdcall EmuLoop(void *Dummy)
+unsigned __stdcall EmuLoop(HANDLE hEvent)
 {
-	HANDLE hEvent = (HANDLE)Dummy;
 	static float FPS;
 	static unsigned int FrameCounter=0;	
 	CalibrateThrottle();

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -66,7 +66,7 @@ char AciaFileWrPath[MAX_PATH]; // Path for file writes
 
 static unsigned char Rom[8192];
 void (*AssertInt)(unsigned char, unsigned char);
-unsigned char LoadExtRom(char *);
+unsigned char LoadExtRom(const char *);
 
 //------------------------------------------------------------------------
 //  DLL Entry point
@@ -145,7 +145,7 @@ __declspec(dllexport) unsigned char PakMemRead8(unsigned short Address)
 //-----------------------------------------------------------------------
 // Load Rom. Returns 1 if loaded
 //-----------------------------------------------------------------------
-unsigned char LoadExtRom(char *FilePath)
+unsigned char LoadExtRom(const char *FilePath)
 {
     FILE *file;
     int cnt = 0;
@@ -210,7 +210,7 @@ __declspec(dllexport) void ModuleConfig(unsigned char /*MenuID*/)
 // Dll export VCC ini file path and load settings
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void SetIniPath (char *IniFilePath)
+__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 {
     strcpy(IniFile,IniFilePath);
     LoadConfig();
@@ -574,7 +574,7 @@ void com_close() {
 }
 
 // com_write will block until some data is written or error
-int com_write(char * buf, int len) {
+int com_write(const char * buf, int len) {
     switch (AciaComType) {
     case COM_CONSOLE:
         return console_write(buf,len);

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -80,31 +80,31 @@ extern void sc6551_write(unsigned char data, unsigned short port);
 // Comunications hooks
 extern int  com_open();
 extern void com_close();
-extern int  com_write(char*,int);
+extern int  com_write(const char*,int);
 extern int  com_read(char*,int);
 
 // Console
 extern int  console_open();
 extern void console_close();
 extern int  console_read(char*,int);
-extern int  console_write(char*,int);
+extern int  console_write(const char*,int);
 
 // File
 extern int  file_open();
 extern void file_close();
 extern int  file_read(char*,int);
-extern int  file_write(char*,int);
+extern int  file_write(const char*,int);
 
 // Tcpip
 extern int  tcpip_open();
 extern void tcpip_close();
 extern int  tcpip_read(char*,int);
-extern int  tcpip_write( char*,int);
+extern int  tcpip_write(const char*,int);
 
 // WinCom 
 extern int  wincom_open();
 extern void wincom_close();
 extern int  wincom_read(char*,int);
-extern int  wincom_write(char*,int);
+extern int  wincom_write(const char*,int);
 
 #endif

--- a/acia/console.cpp
+++ b/acia/console.cpp
@@ -261,7 +261,7 @@ int  SeqArgsNeeded = 0;
 int  SeqArgsCount = 0;
 char SeqArgs[8];
 
-int console_write(char *buf, int len) {
+int console_write(const char *buf, int len) {
 
     int cnt = 0;
     int chr;

--- a/acia/file.cpp
+++ b/acia/file.cpp
@@ -103,7 +103,7 @@ int file_read(char* buf,int siz)
 }
 
 // Write file.  If text skip LF chars and convert CR to CRLF
-int  file_write(char* buf,int siz)
+int  file_write(const char* buf,int siz)
 {
 	// FIXME: This is needed and should not be commented out. Wrap it conditional
 	// either here or in the debug log functions.

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -205,7 +205,7 @@ DWORD WINAPI sc6551_output_thread(LPVOID /*param*/)
             if (!Ilock.test_and_set()) {
                 StatReg &= ~StatTxE;
                 if (AciaComMode != COM_MODE_READ) {
-                    char * ptr = OutBuf;
+                    const char * ptr = OutBuf;
                     while (Wcnt > 0) {
                         int cnt = com_write(ptr,Wcnt);
                         _LOGF("W %d\n",cnt);

--- a/acia/tcpip.cpp
+++ b/acia/tcpip.cpp
@@ -110,7 +110,7 @@ int tcpip_read(char* buf, int siz)
 }
 
 //Write
-int tcpip_write(char* buf, int siz)
+int tcpip_write(const char* buf, int siz)
 {
     char CRLF[3]="\r\n";
 

--- a/acia/wincom.cpp
+++ b/acia/wincom.cpp
@@ -32,7 +32,7 @@ HANDLE hReadEvent;
 HANDLE hWriteEvent;
 HANDLE hComPort=INVALID_HANDLE_VALUE;
 
-int writeport(char *buf,int siz);
+int writeport(const char *buf,int siz);
 
 static unsigned int BaudRate;
 static unsigned int EnParity;
@@ -119,7 +119,7 @@ int wincom_read(char* buf,int siz)
 //=====================================================
 // Write to com port.  If text mode convert line endings
 //=====================================================
-int  wincom_write(char* buf,int siz)
+int  wincom_write(const char* buf,int siz)
 {
     int cnt = 0;
     if (hComPort == INVALID_HANDLE_VALUE) return -1;
@@ -130,7 +130,8 @@ int  wincom_write(char* buf,int siz)
         // here maximizes write sizes without re-buffering.
         while(cnt < siz) {
             // search for a CR or LF
-            char *ptr, *tbuf, chr;
+			const char* ptr, * tbuf;
+			char chr;
             int tsiz;
             ptr = tbuf = buf + cnt;
             for (tsiz = 0; tsiz < siz-cnt; tsiz++) {
@@ -162,7 +163,7 @@ int  wincom_write(char* buf,int siz)
 //=====================================================
 // Write function for overlapped I/O
 //=====================================================
-int writeport(char *buf,int siz) {
+int writeport(const char *buf,int siz) {
     OVERLAPPED ovl = {0};
     ovl.hEvent = hWriteEvent;
     DWORD cnt;

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -61,10 +61,10 @@ char msg[MAX_PATH];
 static boolean logging = false;
 
 static DYNAMICMENUCALLBACK DynamicMenuCallback = NULL;
-unsigned char LoadExtRom(char *);
+unsigned char LoadExtRom(const char *);
 void SetDWTCPConnectionEnable(unsigned int enable);
-int dw_setaddr(char *bufdwaddr);
-int dw_setport(char *bufdwport);
+int dw_setaddr(const char *bufdwaddr);
+int dw_setport(const char *bufdwport);
 void BuildDynaMenu(void);
 void LoadConfig(void);
 void SaveConfig(void);
@@ -183,7 +183,7 @@ void killDWTCPThread(void)
 
 
 // set our hostname, called from config.c
-int dw_setaddr(char *bufdwaddr)
+int dw_setaddr(const char *bufdwaddr)
 {
         strcpy(dwaddress,bufdwaddr);
         return 0;
@@ -191,7 +191,7 @@ int dw_setaddr(char *bufdwaddr)
 
 
 // set our port, called from config.c
-int dw_setport(char *bufdwport)
+int dw_setport(const char *bufdwport)
 {
         dwsport = (unsigned short)atoi(bufdwport);
 
@@ -559,7 +559,7 @@ extern "C" __declspec(dllexport) void ModuleConfig(unsigned char MenuID)
 		return;
 	}
 
-extern "C" __declspec(dllexport) void SetIniPath (char *IniFilePath)
+extern "C" __declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();
@@ -680,7 +680,7 @@ void SaveConfig(void)
 	return;
 }
 
-unsigned char LoadExtRom( char *FilePath)	//Returns 1 on if loaded
+unsigned char LoadExtRom( const char *FilePath)	//Returns 1 on if loaded
 {
 
 	FILE *rom_handle = NULL;

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -113,7 +113,7 @@ std::string GetClipboardText();
 void HLINE(void);
 void VSYNC(unsigned char level);
 void HSYNC(unsigned char level);
-string CvtStrToSC(string);
+std::string CvtStrToSC(std::string);
 
 using namespace std;
 
@@ -947,7 +947,7 @@ std::string GetClipboardText()
 	if (!OpenClipboard(nullptr)) { MessageBox(nullptr, "Unable to open clipboard.", "Clipboard", 0); return {}; }
 	HANDLE hClip = GetClipboardData(CF_TEXT);
 	if (hClip == nullptr) { CloseClipboard(); MessageBox(nullptr, "No text found in clipboard.", "Clipboard", 0); return {}; }
-	char* tmp = static_cast<char*>(GlobalLock(hClip));
+	const char* tmp = static_cast<char*>(GlobalLock(hClip));
 	if (tmp == nullptr) {
 		CloseClipboard();  MessageBox(nullptr, "NULL Pointer", "Clipboard", 0); return {};
 	}

--- a/config.cpp
+++ b/config.cpp
@@ -80,36 +80,36 @@ LRESULT CALLBACK Paths(HWND, UINT, WPARAM, LPARAM);
 // Structure for some (but not all) Vcc settings
 struct STRConfig
 {
-	unsigned char	CPUMultiplyer;
-	unsigned short	MaxOverclock;
-	unsigned char	FrameSkip;
-	unsigned char	SpeedThrottle;
-	unsigned char	CpuType;
-	unsigned char	HaltOpcEnabled;   // 0x15   halt enabled
-	unsigned char	BreakOpcEnabled;  // 0x113E halt enabled
-	unsigned char	MonitorType;
-	unsigned char   PaletteType;
-	unsigned char	ScanLines;
-	unsigned char	Resize;
-	unsigned char	Aspect;
-	unsigned char	RememberSize;
+	unsigned char	CPUMultiplyer = 0;
+	unsigned short	MaxOverclock = 0;
+	unsigned char	FrameSkip = 0;
+	unsigned char	SpeedThrottle = 0;
+	unsigned char	CpuType = 0;
+	unsigned char	HaltOpcEnabled = 0;   // 0x15   halt enabled
+	unsigned char	BreakOpcEnabled = 0;  // 0x113E halt enabled
+	unsigned char	MonitorType = 0;
+	unsigned char   PaletteType = 0;
+	unsigned char	ScanLines = 0;
+	unsigned char	Resize = 0;
+	unsigned char	Aspect = 0;
+	unsigned char	RememberSize = 0;
 	Rect			WindowRect;
-	unsigned char	RamSize;
-	unsigned char	AutoStart;
-	unsigned char	CartAutoStart;
-	unsigned char	RebootNow;
-	unsigned char	SndOutDev;
-	unsigned char	KeyMap;
-	char			SoundCardName[64];
-	unsigned int	AudioRate;	// 0 = Mute
-	char			ModulePath[MAX_PATH];
-	char			PathtoExe[MAX_PATH];
-	char			FloppyPath[MAX_PATH];
-	char			CassPath[MAX_PATH];
-    unsigned char   ShowMousePointer;
-	unsigned char	UseExtCocoRom;
-	char        	ExtRomFile[MAX_PATH];
-	unsigned char   EnableOverclock;
+	unsigned char	RamSize = 0;
+	unsigned char	AutoStart = 0;
+	unsigned char	CartAutoStart = 0;
+	unsigned char	RebootNow = 0;
+	unsigned char	SndOutDev = 0;
+	unsigned char	KeyMap = 0;
+	char			SoundCardName[64] = { 0 };
+	unsigned int	AudioRate = 0;	// 0 = Mute
+	char			ModulePath[MAX_PATH] = { 0 };
+	char			PathtoExe[MAX_PATH] = { 0 };
+	char			FloppyPath[MAX_PATH] = { 0 };
+	char			CassPath[MAX_PATH] = { 0 };
+    unsigned char   ShowMousePointer = 0;
+	unsigned char	UseExtCocoRom = 0;
+	char        	ExtRomFile[MAX_PATH] = { 0 };
+	unsigned char   EnableOverclock = 0;
 };
 
 static STRConfig CurrentConfig;

--- a/config.h
+++ b/config.h
@@ -18,8 +18,8 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "defines.h"
-#include<iostream>
-using namespace std;
+#include <iostream>
+
 void LoadConfig(SystemState *);
 void InitSound();
 void LoadModule();

--- a/defines.h
+++ b/defines.h
@@ -184,35 +184,35 @@ namespace VCC
 
 struct SystemState
 {
-    HWND			WindowHandle;
-    HWND			ConfigDialog;
+    HWND			WindowHandle = nullptr;
+    HWND			ConfigDialog = nullptr;
 
-    HINSTANCE		WindowInstance;
-    unsigned char	*RamBuffer;
-    unsigned short	*WRamBuffer;
-    std::atomic<unsigned char>	RamSize;
-    double			CPUCurrentSpeed;
-    unsigned char	DoubleSpeedMultiplyer;
-    unsigned char	DoubleSpeedFlag;
-    unsigned char	TurboSpeedFlag;
-    unsigned char	CpuType;
-    unsigned char	FrameSkip;
-    unsigned char	BitDepth;
-    unsigned char	Throttle;
-    unsigned char	*PTRsurface8;
-    unsigned short	*PTRsurface16;
-    unsigned int	*PTRsurface32;
-    long			SurfacePitch;
-    unsigned short	LineCounter;
-    unsigned char	ScanLines;
-    unsigned char	EmulationRunning;
-    unsigned char	ResetPending;
+    HINSTANCE		WindowInstance = nullptr;
+    unsigned char	*RamBuffer = nullptr;
+    unsigned short	*WRamBuffer = nullptr;
+    std::atomic<unsigned char>	RamSize = 0;
+    double			CPUCurrentSpeed = 0.0;
+    unsigned char	DoubleSpeedMultiplyer = 0;
+    unsigned char	DoubleSpeedFlag = 0;
+    unsigned char	TurboSpeedFlag = 0;
+    unsigned char	CpuType = 0;
+    unsigned char	FrameSkip = 0;
+    unsigned char	BitDepth = 0;
+    unsigned char	Throttle = 0;
+    unsigned char	*PTRsurface8 = nullptr;
+    unsigned short	*PTRsurface16 = nullptr;
+    unsigned int	*PTRsurface32 = nullptr;
+    long			SurfacePitch = 0;
+    unsigned short	LineCounter = 0;
+    unsigned char	ScanLines = 0;
+    unsigned char	EmulationRunning = 0;
+    unsigned char	ResetPending = 0;
     VCC::Size		WindowSize;
-    unsigned char	FullScreen;
-    bool        	Exiting;
-    unsigned char	MousePointer;
-    unsigned char	OverclockFlag;
-    char			StatusLine[256];
+    unsigned char	FullScreen = 0;
+    bool        	Exiting = false;
+    unsigned char	MousePointer = 0;
+    unsigned char	OverclockFlag = 0;
+	char			StatusLine[256] = { 0 };
 
 	// Debugger Package	
 	VCC::Debugger::Debugger Debugger;

--- a/hd6309.cpp
+++ b/hd6309.cpp
@@ -252,14 +252,14 @@ void HD6309Init(void)
 	xfreg16[6] = &W_REG;
 	xfreg16[7] = &V_REG;
 
-	ureg8[0]=(unsigned char*)&A_REG;		
-	ureg8[1]=(unsigned char*)&B_REG;		
-	ureg8[2]=(unsigned char*)&ccbits;
-	ureg8[3]=(unsigned char*)&dp.B.msb;
-	ureg8[4]=(unsigned char*)&z.B.msb;
-	ureg8[5]=(unsigned char*)&z.B.lsb;
-	ureg8[6]=(unsigned char*)&E_REG;
-	ureg8[7]=(unsigned char*)&F_REG;
+	ureg8[0] = &A_REG;		
+	ureg8[1] = &B_REG;		
+	ureg8[2] = &ccbits;
+	ureg8[3] = &dp.B.msb;
+	ureg8[4] = &z.B.msb;
+	ureg8[5] = &z.B.lsb;
+	ureg8[6] = &E_REG;
+	ureg8[7] = &F_REG;
 
 	//This handles the disparity between 6309 and 6809 Instruction timing
 	InsCycles[0][M65]=6;	//6-5
@@ -762,8 +762,8 @@ void Addr(void)
 			switch (Source)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
-			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 2:	        source16 = getcc(); break; // CC
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -832,7 +832,7 @@ void Adcr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -899,8 +899,8 @@ void Subr(void)
 			switch (Source)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
-			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 2:	        source16 = getcc(); break; // CC
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -968,8 +968,8 @@ void Sbcr(void)
 			switch (Source)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
-			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 2:	        source16 = getcc(); break; // CC
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1014,9 +1014,9 @@ void Andr(void)
 		temp8 = dest8 & source8;
 		switch (Dest)
 		{
-			case 2: 				setcc((unsigned char)temp8); break;
+			case 2: 				setcc(temp8); break;
 			case 4: case 5: break; // never assign to zero reg
-			default: 				*ureg8[Dest] = (unsigned char)temp8; break;
+			default: 				*ureg8[Dest] = temp8; break;
 		}
 		cc[N] = temp8 >> 7;
 		cc[Z] = ZTEST(temp8);
@@ -1036,7 +1036,7 @@ void Andr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1080,9 +1080,9 @@ void Orr(void)
 		temp8 = dest8 | source8;
 		switch (Dest)
 		{
-			case 2: 				setcc((unsigned char)temp8); break;
+			case 2: 				setcc(temp8); break;
 			case 4: case 5: break; // never assign to zero reg
-			default: 				*ureg8[Dest] = (unsigned char)temp8; break;
+			default: 				*ureg8[Dest] = temp8; break;
 		}
 		cc[N] = temp8 >> 7;
 		cc[Z] = ZTEST(temp8);
@@ -1102,7 +1102,7 @@ void Orr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1146,9 +1146,9 @@ void Eorr(void)
 		temp8 = dest8 ^ source8;
 		switch (Dest)
 		{
-			case 2: 				setcc((unsigned char)temp8); break;
+			case 2: 				setcc(temp8); break;
 			case 4: case 5: break; // never assign to zero reg
-			default: 				*ureg8[Dest] = (unsigned char)temp8; break;
+			default: 				*ureg8[Dest] = temp8; break;
 		}
 		cc[N] = temp8 >> 7;
 		cc[Z] = ZTEST(temp8);
@@ -1168,7 +1168,7 @@ void Eorr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}
@@ -1231,7 +1231,7 @@ void Cmpr(void)
 			{
 			case 0: case 1: source16 = D_REG; break; // A & B Reg
 			case 2:	        source16 = (unsigned short)getcc(); break; // CC
-			case 3:	        source16 = (unsigned short)dp.Reg; break; // DP
+			case 3:	        source16 = dp.Reg; break; // DP
 			case 4: case 5: source16 = 0; break; // Zero Reg
 			case 6: case 7: source16 = W_REG; break; // E & F Reg
 			}

--- a/keyboard.cpp
+++ b/keyboard.cpp
@@ -322,56 +322,38 @@ int keyTransCompare(const void * e1, const void * e2)
 	// elem1 - elem2
 
 	// empty listing push to end
-	if (   entry1->ScanCode1 == 0
-		&& entry1->ScanCode2 == 0
-		&& entry2->ScanCode1 != 0
-		)
+	if (entry1->ScanCode1 == 0 && entry1->ScanCode2 == 0 && entry2->ScanCode1 != 0)
 	{
 		return 1;
 	}
-	else
-	if (   entry2->ScanCode1 == 0
-		&& entry2->ScanCode2 == 0
-		&& entry1->ScanCode1 != 0
-		)
+	else if (entry2->ScanCode1 == 0 && entry2->ScanCode2 == 0 && entry1->ScanCode1 != 0)
 	{
 		return -1;
 	}
-	else
 	// push shift/alt/control by themselves to the end
-	if (   entry1->ScanCode2 == 0
-		&& (   entry1->ScanCode1 == DIK_LSHIFT
-		    || entry1->ScanCode1 == DIK_LMENU
-		    || entry1->ScanCode1 == DIK_LCONTROL
-		   )
-		)
+	else if (
+		entry1->ScanCode2 == 0
+		&& (entry1->ScanCode1 == DIK_LSHIFT
+			|| entry1->ScanCode1 == DIK_LMENU
+			|| entry1->ScanCode1 == DIK_LCONTROL))
 	{
 		result = 1;
 	}
-	else
 	// push shift/alt/control by themselves to the end
-	if (   entry2->ScanCode2 == 0
-		&& (   entry2->ScanCode1 == DIK_LSHIFT
-		    || entry2->ScanCode1 == DIK_LMENU
-		    || entry2->ScanCode1 == DIK_LCONTROL
-			)
-		)
+	else if (entry2->ScanCode2 == 0
+		&& (entry2->ScanCode1 == DIK_LSHIFT
+			|| entry2->ScanCode1 == DIK_LMENU
+		    || entry2->ScanCode1 == DIK_LCONTROL))
 	{
 		result = -1;
 	}
-	else
 	// move double key combos in front of single ones
-	if (   entry1->ScanCode2 == 0
-		&& entry2->ScanCode2 != 0
-		)
+	else if (entry1->ScanCode2 == 0 && entry2->ScanCode2 != 0)
 	{
 		result = 1;
 	}
-	else
 	// move double key combos in front of single ones
-	if (   entry2->ScanCode2 == 0
-		&& entry1->ScanCode2 != 0
-		)
+	else if (entry2->ScanCode2 == 0 && entry1->ScanCode2 != 0)
 	{
 		result = -1;
 	}
@@ -414,7 +396,7 @@ void vccKeyboardBuildRuntimeTable(keyboardlayout_e keyBoardLayout)
 {
 	int Index1 = 0;
 	int Index2 = 0;
-	keytranslationentry_t *		keyLayoutTable = nullptr;
+	const keytranslationentry_t *		keyLayoutTable = nullptr;
 	keytranslationentry_t		keyTransEntry;
 
 	assert(keyBoardLayout >= 0 && keyBoardLayout < kKBLayoutCount);

--- a/keyboardEdit.cpp
+++ b/keyboardEdit.cpp
@@ -99,7 +99,7 @@ void  DoKeyDown(WPARAM,LPARAM);
 void  ShowMapError(int, const char *);
 void  SetDialogFocus(HWND);
 int   GetKeymapLine (char*, keytranslationentry_t *, int);
-char *GenKeymapLine(keytranslationentry_t *);
+const char *GenKeymapLine(const keytranslationentry_t *);
 
 // Lookup functions for keyname tables
 static struct CoCoKey * cctable_rowcol_lookup(unsigned char, unsigned char);
@@ -162,9 +162,9 @@ int LoadCustomKeyMap(const char* keymapfile)
 //-----------------------------------------------------
 int GetKeymapLine ( char* line, keytranslationentry_t * trans, int lnum)
 {
-    char *pStr;
-    static struct PCScanCode * pPCScanCode; 
-    static struct CoCoKey * pCoCoKey;
+	const char *pStr;
+    static struct PCScanCode * pPCScanCode; // FIXME: Why is this static?
+    static struct CoCoKey * pCoCoKey;		// FIXME: Why is this static?
 
     // pc scancode -> ScanCode1
     pStr = strtok(line, " \t\n\r");
@@ -259,7 +259,7 @@ int CloneStandardKeymap(int keymap)
 {
     int i = 0;
     keytranslationentry_t * dst = keyTranslationsCustom;
-    keytranslationentry_t * src;
+	const keytranslationentry_t * src;
     switch (keymap) {
     case kKBLayoutCoCo:
         src = keyTranslationsCoCo;
@@ -286,7 +286,7 @@ int CloneStandardKeymap(int keymap)
 //-----------------------------------------------------
 int SaveCustomKeyMap(const char* keymapfile) 
 {
-    keytranslationentry_t * pTran;
+	const keytranslationentry_t * pTran;
 	pTran = keyTranslationsCustom;
 
     FILE *omap;
@@ -355,11 +355,11 @@ int SaveCustomKeyMap(const char* keymapfile)
 //------------------------------------------------------
 // Convert translation record for keymap file
 //-----------------------------------------------------
-char * GenKeymapLine( keytranslationentry_t * pTran )
+const char * GenKeymapLine( const keytranslationentry_t * pTran )
 {
 	static char txt[64];
-	static struct PCScanCode * pSC; 
-    static struct CoCoKey * pCC; 
+	static struct PCScanCode * pSC;	// FIXME: Why is this static?
+    static struct CoCoKey * pCC;	// FIXME: Why is this static?
 	int CCmod = 0;
 	int PCmod = 0;
 
@@ -591,7 +591,7 @@ BOOL CALLBACK KeyMapProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         case IDCANCEL:
             if (KeyMapChanged) { 
                 LoadCustomKeyMap(GetKeyMapFilePath());
-                vccKeyboardBuildRuntimeTable((keyboardlayout_e) kKBLayoutCustom);
+                vccKeyboardBuildRuntimeTable(kKBLayoutCustom);
              }
             return EndDialog(hWnd,wParam);
         default:
@@ -662,7 +662,7 @@ BOOL SetCustomKeymap() {
 
 	int ModCol;
 	int ModRow;
-	static struct CoCoKey *p;
+	static struct CoCoKey *p;	// FIXME: Why is this static?
 
 	if (pKeyTran == nullptr) {
 
@@ -735,7 +735,7 @@ BOOL SetCustomKeymap() {
 
     // Update runtime table
 	if (GetKeyboardLayout() == kKBLayoutCustom)
-			vccKeyboardBuildRuntimeTable((keyboardlayout_e) kKBLayoutCustom);
+			vccKeyboardBuildRuntimeTable(kKBLayoutCustom);
 
 	// Disable set button
 	EnableWindow(GetDlgItem(hKeyMapDlg,IDC_SET_CUST_KEYMAP),FALSE);
@@ -835,7 +835,7 @@ void ShowCoCoKey()
 {
 	char str[64];
 	const char * keytxt = "";
-	struct CoCoKey *p;
+	const struct CoCoKey *p;
 
 	// set coco keyboard buttons 
 	if (CC_KeySelected != CoCoKeySet) {
@@ -945,7 +945,7 @@ void ShowPCkey()
 {
 	char str[64];
 	const char * keytxt = "";
-    struct PCScanCode * entry;
+    const struct PCScanCode * entry;
 	if (PC_KeySelected>0) { 
 		entry = scantable_scancode_lookup(PC_KeySelected);
 		if (entry == nullptr) {
@@ -965,7 +965,7 @@ void ShowPCkey()
 //-----------------------------------------------------
 void SetCoCokey()
 {
-    static struct CoCoKey * pCoCoKey;
+    static struct CoCoKey * pCoCoKey;	// FIXME: Why is this static?
 
 	// Clear selected coco keys
     CC_KeySelected = 0;

--- a/mc6809.cpp
+++ b/mc6809.cpp
@@ -532,7 +532,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case TST_D: //D
-		temp8=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		temp8=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(temp8);
 		cc[N]= NTEST8(temp8);
 		cc[V] = false;
@@ -1680,7 +1680,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SUBA_D: //90
-		postbyte=MemRead8( (dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16 = A_REG - postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,A_REG);
@@ -1691,7 +1691,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case CMPA_D: //91
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp8= A_REG-postbyte;
 		cc[C]= temp8 > A_REG;
 		cc[V]= OTEST8(cc[C],postbyte,temp8,A_REG);
@@ -1701,7 +1701,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SBCA_D: //92
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=A_REG-postbyte-cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,A_REG);
@@ -1712,7 +1712,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SUBD_D: //93
-		temp16=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		temp16=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp32=D_REG-temp16;
 		cc[C]=(temp32 & 0x10000)>>16;
 		cc[V]= OTEST16(cc[C],temp32,temp16,D_REG);
@@ -1723,7 +1723,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ANDA_D: //94
-		A_REG = A_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG = A_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(A_REG);
 		cc[Z]= ZTEST(A_REG);
 		cc[V]= false;
@@ -1731,7 +1731,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case BITA_D: //95
-		temp8 = A_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		temp8 = A_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(temp8);
 		cc[Z]= ZTEST(temp8);
 		cc[V]= false;
@@ -1739,7 +1739,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDA_D: //96
-		A_REG= MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG= MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(A_REG);
 		cc[N]= NTEST8(A_REG);
 		cc[V]= false;
@@ -1755,7 +1755,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case EORA_D: //98
-		A_REG= A_REG ^ MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG= A_REG ^ MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(A_REG);
 		cc[Z]= ZTEST(A_REG);
 		cc[V]= false;
@@ -1763,7 +1763,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADCA_D: //99
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16= A_REG + postbyte + cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,A_REG);
@@ -1775,7 +1775,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ORA_D: //9A
-		A_REG = A_REG | MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		A_REG = A_REG | MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(A_REG);
 		cc[Z]= ZTEST(A_REG);
 		cc[V]= false;
@@ -1783,7 +1783,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADDA_D: //9B
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=A_REG+postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[H]= ((A_REG ^ postbyte ^ temp16) & 0x10)>>4;
@@ -1795,7 +1795,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case CMPX_D: //9C
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= x.Reg - postword ;
 		cc[C]= temp16 > x.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,X_REG);
@@ -1814,7 +1814,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDX_D: //9E
-		x.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		x.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(x.Reg);
 		cc[N]= NTEST16(x.Reg);
 		cc[V]= false;
@@ -2274,7 +2274,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SUBB_D: //D0
-		postbyte=MemRead8( (dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16 = B_REG - postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,B_REG);
@@ -2285,7 +2285,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case CMPB_D: //D1
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp8= B_REG-postbyte;
 		cc[C]= temp8 > B_REG;
 		cc[V]= OTEST8(cc[C],postbyte,temp8,B_REG);
@@ -2295,7 +2295,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case SBCB_D: //D2
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=B_REG-postbyte-cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,B_REG);
@@ -2306,7 +2306,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADDD_D: //D3
-		temp16=MemRead16( (dp.Reg |MemRead8(pc.Reg++)));
+		temp16=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp32= D_REG+ temp16;
 		cc[C]=(temp32 & 0x10000)>>16;
 		cc[V]= OTEST16(cc[C],temp32,temp16,D_REG);
@@ -2317,7 +2317,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ANDB_D: //D4
-		B_REG = B_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		B_REG = B_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]=NTEST8(B_REG);
 		cc[Z] = ZTEST(B_REG);
 		cc[V] = false;
@@ -2325,7 +2325,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case BITB_D: //D5
-		temp8 = B_REG & MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		temp8 = B_REG & MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[N]= NTEST8(temp8);
 		cc[Z] = ZTEST(temp8);
 		cc[V] = false;
@@ -2333,7 +2333,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDB_D: //D6
-		B_REG=MemRead8( (dp.Reg |MemRead8(pc.Reg++)));
+		B_REG=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z] = ZTEST(B_REG);
 		cc[N]= NTEST8(B_REG);
 		cc[V] = false;
@@ -2349,7 +2349,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case EORB_D: //D8
-		B_REG = B_REG ^ MemRead8((dp.Reg | MemRead8(pc.Reg++)));
+		B_REG = B_REG ^ MemRead8(dp.Reg | MemRead8(pc.Reg++));
 		cc[N]= NTEST8(B_REG);
 		cc[Z] = ZTEST(B_REG);
 		cc[V] = false;
@@ -2357,7 +2357,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADCB_D: //D9
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16= B_REG + postbyte + cc[C];
 		cc[C]= (temp16 & 0x100)>>8;
 		cc[V]= OTEST8(cc[C],postbyte,temp16,B_REG);
@@ -2369,7 +2369,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ORB_D: //DA
-		B_REG = B_REG | MemRead8((dp.Reg | MemRead8(pc.Reg++)));
+		B_REG = B_REG | MemRead8(dp.Reg | MemRead8(pc.Reg++));
 		cc[N]= NTEST8(B_REG);
 		cc[Z] = ZTEST(B_REG);
 		cc[V] = false;
@@ -2377,7 +2377,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case ADDB_D: //DB
-		postbyte=MemRead8((dp.Reg |MemRead8(pc.Reg++)));
+		postbyte=MemRead8(dp.Reg |MemRead8(pc.Reg++));
 		temp16=B_REG+postbyte;
 		cc[C]=(temp16 & 0x100)>>8;
 		cc[H]= ((B_REG ^ postbyte ^ temp16) & 0x10)>>4;
@@ -2389,7 +2389,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDD_D: //DC
-		D_REG=MemRead16((dp.Reg | MemRead8(pc.Reg++)));
+		D_REG=MemRead16(dp.Reg | MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(D_REG);
 		cc[N]= NTEST16(D_REG);
 		cc[V]= false;
@@ -2405,7 +2405,7 @@ void Do_Opcode(int CycleFor)
 		break;
 
 	case LDU_D: //DE
-		u.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		u.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(u.Reg);
 		cc[N]= NTEST16(u.Reg);
 		cc[V]= false;
@@ -2952,7 +2952,7 @@ void P2_Opcode(void)
 		break;
 
 	case CMPD_D: //1093
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= D_REG - postword ;
 		cc[C]= temp16 > D_REG;
 		cc[V]= OTEST16(cc[C],postword,temp16,D_REG);
@@ -2962,7 +2962,7 @@ void P2_Opcode(void)
 		break;
 
 	case CMPY_D:	//109C
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= y.Reg - postword ;
 		cc[C]= temp16 > y.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,y.Reg);
@@ -2972,7 +2972,7 @@ void P2_Opcode(void)
 		break;
 
 	case LDY_D: //109E
-		y.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		y.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(y.Reg);
 		cc[N]= NTEST16(y.Reg);
 		cc[V]= false;
@@ -3073,7 +3073,7 @@ void P2_Opcode(void)
 		break;
 
 	case LDS_D: //10DE
-		s.Reg=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		s.Reg=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		cc[Z]= ZTEST(s.Reg);
 		cc[N]= NTEST16(s.Reg);
 		cc[V] = false;
@@ -3181,7 +3181,7 @@ void P3_Opcode(void)
 		break;
 
 	case CMPU_D: //1193
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= u.Reg - postword ;
 		cc[C]= temp16 > u.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,U_REG);
@@ -3191,7 +3191,7 @@ void P3_Opcode(void)
 		break;
 
 	case CMPS_D: //119C
-		postword=MemRead16((dp.Reg |MemRead8(pc.Reg++)));
+		postword=MemRead16(dp.Reg |MemRead8(pc.Reg++));
 		temp16= s.Reg - postword ;
 		cc[C]= temp16 > s.Reg;
 		cc[V]= OTEST16(cc[C],postword,temp16,S_REG);

--- a/memdump.cpp
+++ b/memdump.cpp
@@ -84,7 +84,7 @@ void SetDumpPath(const char * dumpfile)
 void MemDump(void)
 {
 	int fd = OpenDumpFile();
-	unsigned char * ptr = Get_mem_pointer();
+	const unsigned char * ptr = Get_mem_pointer();
 	int siz = GetMemSize();
 	blockdump(fd,ptr,siz);
     _close(fd);
@@ -94,12 +94,12 @@ void MemDump(void)
 void CpuDump(void)
 {
 	std::array<int,8> regs = GetMmuRegs();
-	unsigned char * pmem = Get_mem_pointer();
+	const unsigned char * pmem = Get_mem_pointer();
 	int blk;
 
 	int fd = OpenDumpFile();
 	for (blk=0; blk<8; blk++) {
-		unsigned char * ptr = pmem + regs[blk] * 0x2000;
+		const unsigned char * ptr = pmem + regs[blk] * 0x2000;
 		int siz = 0x2000;
 		blockdump(fd,ptr,siz);
 	}

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -95,7 +95,7 @@ static void (*SetCarts[NUMSLOTS])(unsigned char)={SetCartSlot0,SetCartSlot1,SetC
 static DYNAMICMENUCALLBACK DynamicMenuCallbackCalls[NUMSLOTS]={DynamicMenuCallback0,DynamicMenuCallback1,DynamicMenuCallback2,DynamicMenuCallback3};
 static void (*SetCartCalls[NUMSLOTS])(SETCART)={nullptr};
 
-static void (*SetIniPathCalls[NUMSLOTS]) (char *)={nullptr};
+static void (*SetIniPathCalls[NUMSLOTS]) (const char *)={nullptr};
 static DYNAMICMENUCALLBACK DynamicMenuCallback = nullptr;
 //***************************************************************
 static HINSTANCE hinstLib[NUMSLOTS]={nullptr};
@@ -357,7 +357,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void SetIniPath (char *IniFilePath)
+	__declspec(dllexport) void SetIniPath (const char *IniFilePath)
 	{
 		strcpy(IniFile,IniFilePath);
 		LoadConfig();

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -25,7 +25,7 @@ This file is part of VCC (Virtual Color Computer).
 static HINSTANCE g_hinstDLL=nullptr;
 static unsigned char LeftChannel=0,RightChannel=0;
 static void (*PakSetCart)(unsigned char)=nullptr;
-unsigned char LoadExtRom(char *);
+unsigned char LoadExtRom(const char *);
 static unsigned char Rom[8192];
 BOOL WINAPI DllMain(
     HINSTANCE hinstDLL,  // handle to DLL module
@@ -131,7 +131,7 @@ extern "C"
 
 
 
-unsigned char LoadExtRom(char *FilePath)	//Returns 1 on if loaded
+unsigned char LoadExtRom(const char *FilePath)	//Returns 1 on if loaded
 {
 
 	FILE *rom_handle = nullptr;

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -69,7 +69,7 @@ static unsigned char (*PakMemRead8)(unsigned short)=nullptr;
 static void (*ModuleStatus)(char *)=nullptr;
 static unsigned short (*ModuleAudioSample)(void)=nullptr;
 static void (*ModuleReset) (void)=nullptr;
-static void (*SetIniPath) (char *)=nullptr;
+static void (*SetIniPath) (const char *)=nullptr;
 static void (*PakSetCart)(SETCART)=nullptr;
 static char PakPath[MAX_PATH];
 
@@ -191,7 +191,7 @@ int LoadCart(void)
 }
 
 // Insert Module returns 0 on success
-int InsertModule (char *ModulePath)
+int InsertModule (const char *ModulePath)
 {
 	char CatNumber[MAX_LOADSTRING]="";
 	char Temp[MAX_LOADSTRING]="";

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -29,7 +29,7 @@ unsigned short PackAudioSample(void);
 void ResetBus(void);
 int load_ext_rom(const char *);
 void GetCurrentModule(char *);
-int InsertModule (char *);
+int InsertModule (const char *);
 void UpdateBusPointer(void);
 void UnloadDll(void);
 void UnloadPack(void);

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -194,7 +194,7 @@ bool MountNext(int);
 void OpenNew(int,const char *,int);
 void CloseDrive(int);
 void OpenFound(int,int);
-void LoadReply(void *, int);
+void LoadReply(const void *, int);
 void BlockReceive(unsigned char);
 char * LastErrorTxt(void);
 void FlashControl(unsigned char);
@@ -420,7 +420,7 @@ extern "C"
     }
 
     // Set ini file path and Initialize SDC
-    __declspec(dllexport) void SetIniPath (char *IniFilePath)
+    __declspec(dllexport) void SetIniPath (const char *IniFilePath)
     {
         strncpy(IniFile,IniFilePath,MAX_PATH);
         return;
@@ -1396,7 +1396,7 @@ void GetDirectoryLeaf(void)
 
     // If at least one leaf find the last one
     if (n > 0) {
-        char *p = strrchr(CurDir,'/');
+		const char *p = strrchr(CurDir,'/');
         if (p == nullptr) {
             p = CurDir;
         } else {
@@ -1765,7 +1765,7 @@ void SDCControl(void)
 //----------------------------------------------------------------------
 // Load reply. Count is bytes, 512 max.
 //----------------------------------------------------------------------
-void LoadReply(void *data, int count)
+void LoadReply(const void *data, int count)
 {
     if ((count < 2) | (count > 512)) {
         _DLOG("LoadReply bad count %d\n",count);
@@ -1856,9 +1856,9 @@ bool LoadFoundFile(struct FileRecord * rec)
     }
 
     // File type
-    char * pdot = strrchr(dFound.cFileName,'.');
+	const char * pdot = strrchr(dFound.cFileName,'.');
     if (pdot) {
-        char * ptyp = pdot + 1;
+		const char * ptyp = pdot + 1;
         for (int cnt = 0; cnt<3; cnt++) {
            if (*ptyp == '\0') break;
            rec->type[cnt] = *ptyp++;
@@ -1866,7 +1866,7 @@ bool LoadFoundFile(struct FileRecord * rec)
     }
 
     // File name
-    char * pnam = dFound.cFileName;
+	const char * pnam = dFound.cFileName;
     for (int cnt = 0; cnt < 8; cnt++) {
         if (*pnam == '\0') break;
         if (pdot && (pnam == pdot)) break;

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -155,7 +155,7 @@ void UpdateScreen8 (SystemState *US8State)
 	char Pix=0,Bit=0,Sphase=0;
 	static char Carry1=0,Carry2=0;
 	static char Pcolor=0;
-	unsigned char *buffer=US8State->RamBuffer;
+	const unsigned char *buffer=US8State->RamBuffer;
 	Carry1=1;
 	Pcolor=0;
 	
@@ -6335,7 +6335,7 @@ case 192+63: //Bpp=3 Sr=15
 
 
 // BEGIN of 24 Bit render loop *****************************************************************************************
-void UpdateScreen24 (SystemState *USState24)
+void UpdateScreen24 (SystemState */*USState24*/)
 {
 
 	return;
@@ -6356,7 +6356,7 @@ void UpdateScreen32(SystemState *USState32)
 	unsigned char Character = 0, Attributes = 0;
 	unsigned int TextPallete[2] = { 0,0 };
 	unsigned short * WideBuffer = (unsigned short *)USState32->RamBuffer;
-	unsigned char *buffer = USState32->RamBuffer;
+	const unsigned char *buffer = USState32->RamBuffer;
 	unsigned short WidePixel = 0;
 	//	unsigned short lColor=0;
 	//	unsigned short Yindex[4]={316,308,300,292};
@@ -6368,10 +6368,10 @@ void UpdateScreen32(SystemState *USState32)
 	long Xpitch = USState32->SurfacePitch;
 	Carry1 = 1;
 	Pcolor = 0;
-	static string curr_gmode = "";
-	static string last_gmode = "";
+	static std::string curr_gmode = "";
+	static std::string last_gmode = "";
 	if (curr_gmode != last_gmode) {
-		string tmpout = "Graphics mode switched to " + curr_gmode +"\n";
+		std::string tmpout = "Graphics mode switched to " + curr_gmode +"\n";
 		OutputDebugString(tmpout.c_str());
 		last_gmode = curr_gmode;
 	}
@@ -8277,180 +8277,183 @@ case 192+2:	//Bpp=0 Sr=2
 	if (!pmode4MonType && BoarderColor32 == 0xFFFFFF && GetPaletteType() == PALETTE_NTSC)
 	{
 		// byte pointer to ram
-		unsigned char* cocoRam = (unsigned char*)WideBuffer;
+		const unsigned char* cocoRam = (unsigned char*)WideBuffer;
 		// destination screen (less 2 pixels for bleed)
 		size_t surfaceDest = (((y + VertCenter) * 2) * Xpitch) + HorzCenter - 2;
 		// source coco screens
-		unsigned char* cocoSrc = cocoRam + (VidMask & (Start + (unsigned char)Hoffset));
+		const unsigned char* cocoSrc = cocoRam + (VidMask & (Start + (unsigned char)Hoffset));
 		RenderPMODE4NTSC(szSurface32, surfaceDest, Xpitch, cocoSrc, USState32->ScanLines);
 	}
 	else
-	for (HorzBeam=0;HorzBeam<BytesperRow;HorzBeam+=2) //1bbp Stretch=2
 	{
-		WidePixel=WideBuffer[(VidMask & ( Start+(unsigned char)(Hoffset+HorzBeam) ))>>1];
-//************************************************************************************
-		if (!pmode4MonType && BoarderColor32 == 0xFFFFFF)
-		{ //Pcolor
-			for (Bit=7;Bit>=0;Bit--)
-			{
-				Pix=(1 & (WidePixel>>Bit) );
-				Sphase= (Carry2<<2)|(Carry1<<1)|Pix;
-				switch(Sphase)
+		for (HorzBeam = 0; HorzBeam < BytesperRow; HorzBeam += 2) //1bbp Stretch=2
+		{
+			WidePixel = WideBuffer[(VidMask & (Start + (unsigned char)(Hoffset + HorzBeam))) >> 1];
+			//************************************************************************************
+			if (!pmode4MonType && BoarderColor32 == 0xFFFFFF)
+			{ //Pcolor
+				for (Bit = 7; Bit >= 0; Bit--)
 				{
-				case 0:
-				case 4:
-				case 6:
-					Pcolor=0;
-					break;
-				case 1:
-				case 5:
-					Pcolor=(Bit &1)+1;
-					break;
-				case 2:
-				//	Pcolor=(!(Bit &1))+1; Use last color
-					break;
-				case 3:
-					Pcolor=3;
-					szSurface32[YStride-1]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch-1]=Afacts32[ColorInvert][3];
-					szSurface32[YStride]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][3];
-					break;
-				case 7:
-					Pcolor=3;
-					break;
-				} //END Switch
+					Pix = (1 & (WidePixel >> Bit));
+					Sphase = (Carry2 << 2) | (Carry1 << 1) | Pix;
+					switch (Sphase)
+					{
+					case 0:
+					case 4:
+					case 6:
+						Pcolor = 0;
+						break;
+					case 1:
+					case 5:
+						Pcolor = (Bit & 1) + 1;
+						break;
+					case 2:
+						//	Pcolor=(!(Bit &1))+1; Use last color
+						break;
+					case 3:
+						Pcolor = 3;
+						szSurface32[YStride - 1] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch - 1] = Afacts32[ColorInvert][3];
+						szSurface32[YStride] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][3];
+						break;
+					case 7:
+						Pcolor = 3;
+						break;
+					} //END Switch
 
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				Carry2=Carry1;
-				Carry1=Pix;
-			}
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					Carry2 = Carry1;
+					Carry1 = Pix;
+				}
 
-			for (Bit=15;Bit>=8;Bit--)
-			{
-				Pix=(1 & (WidePixel>>Bit) );
-				Sphase= (Carry2<<2)|(Carry1<<1)|Pix;
-				switch(Sphase)
+				for (Bit = 15; Bit >= 8; Bit--)
 				{
-				case 0:
-				case 4:
-				case 6:
-					Pcolor=0;
-					break;
-				case 1:
-				case 5:
-					Pcolor=(Bit &1)+1;
-					break;
-				case 2:
-				//	Pcolor=(!(Bit &1))+1; Use last color
-					break;
-				case 3:
-					Pcolor=3;
-					szSurface32[YStride-1]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch-1]=Afacts32[ColorInvert][3];
-					szSurface32[YStride]=Afacts32[ColorInvert][3];
-					if (!USState32->ScanLines)
-						szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][3];
-					break;
-				case 7:
-					Pcolor=3;
-					break;
-				} //END Switch
+					Pix = (1 & (WidePixel >> Bit));
+					Sphase = (Carry2 << 2) | (Carry1 << 1) | Pix;
+					switch (Sphase)
+					{
+					case 0:
+					case 4:
+					case 6:
+						Pcolor = 0;
+						break;
+					case 1:
+					case 5:
+						Pcolor = (Bit & 1) + 1;
+						break;
+					case 2:
+						//	Pcolor=(!(Bit &1))+1; Use last color
+						break;
+					case 3:
+						Pcolor = 3;
+						szSurface32[YStride - 1] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch - 1] = Afacts32[ColorInvert][3];
+						szSurface32[YStride] = Afacts32[ColorInvert][3];
+						if (!USState32->ScanLines)
+							szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][3];
+						break;
+					case 7:
+						Pcolor = 3;
+						break;
+					} //END Switch
 
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				szSurface32[YStride+=1]=Afacts32[ColorInvert][Pcolor];
-				if (!USState32->ScanLines)
-					szSurface32[YStride+Xpitch]=Afacts32[ColorInvert][Pcolor];
-				Carry2=Carry1;
-				Carry1=Pix;
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					szSurface32[YStride += 1] = Afacts32[ColorInvert][Pcolor];
+					if (!USState32->ScanLines)
+						szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][Pcolor];
+					Carry2 = Carry1;
+					Carry1 = Pix;
+				}
+
 			}
-
-		}
 			else
 			{
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-			szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-			if (!USState32->ScanLines)
-			{
-				YStride-=32;
-				YStride+=Xpitch;
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>7))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>6))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>5))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>4))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>3))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>2))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>1))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & WidePixel)];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>15))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>14))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>13))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>12))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>11))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>10))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>9))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-				szSurface32[YStride+=1]=Pallete32Bit[PalleteIndex+( 1 & (WidePixel>>8))];
-				YStride-=Xpitch;
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+				szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+				if (!USState32->ScanLines)
+				{
+					YStride -= 32;
+					YStride += Xpitch;
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 7))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 6))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 5))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 4))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 3))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 2))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 1))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & WidePixel)];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 15))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 14))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 13))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 12))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 11))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 10))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 9))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+					szSurface32[YStride += 1] = Pallete32Bit[PalleteIndex + (1 & (WidePixel >> 8))];
+					YStride -= Xpitch;
+				}
 			}
-		}
 
-}
+		}
+	}
+	
 	break;
 
 case 192+3: //Bpp=0 Sr=3 1BPP Stretch=4 PMODE 0
@@ -9529,7 +9532,7 @@ void DrawTopBoarder16(SystemState *DTState)
 	return;
 }
 
-void DrawTopBoarder24(SystemState *DTState)
+void DrawTopBoarder24(SystemState */*DTState*/)
 {
 
 	return;
@@ -9580,7 +9583,7 @@ void DrawBottomBoarder16(SystemState *DTState)
 	return;
 }
 
-void DrawBottomBoarder24(SystemState *DTState)
+void DrawBottomBoarder24(SystemState */*DTState*/)
 {
 	return;
 }

--- a/tcc1014mmu.cpp
+++ b/tcc1014mmu.cpp
@@ -49,7 +49,7 @@ static unsigned int VidMask[4]={0x1FFFF,0x7FFFF,0x1FFFFF,0x7FFFFF};
 static unsigned char CurrentRamConfig=1;
 static unsigned short MmuPrefix=0;
 static unsigned int RamSize=0;
-atomic_bool mem_initializing;
+std::atomic_bool mem_initializing;
 
 void UpdateMmuArray(void);
 
@@ -276,10 +276,14 @@ void MemWrite8(unsigned char data,unsigned short address)
 		return;
 	}
 	if (RamVectors)	//Address must be $FE00 - $FEFF
-		memory[(0x2000*VectorMask[CurrentRamConfig])|(address & 0x1FFF)]=data;
-	else
-	if (MapType | (MmuRegisters[MmuState][address>>13] <VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address>>13] > VectorMask[CurrentRamConfig]))
-		MemPages[MmuRegisters[MmuState][address>>13]][address & 0x1FFF]=data;
+	{
+		memory[(0x2000 * VectorMask[CurrentRamConfig]) | (address & 0x1FFF)] = data;
+	}
+	else if (MapType | (MmuRegisters[MmuState][address >> 13] < VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address >> 13] > VectorMask[CurrentRamConfig]))
+	{
+		MemPages[MmuRegisters[MmuState][address >> 13]][address & 0x1FFF] = data;
+	}
+
 	return;
 }
 
@@ -325,10 +329,16 @@ void __fastcall fMemWrite8(unsigned char data,unsigned short address)
 		return;
 	}
 	if (RamVectors)	//Address must be $FE00 - $FEFF
-		memory[(0x2000*VectorMask[CurrentRamConfig])|(address & 0x1FFF)]=data;
+	{
+		memory[(0x2000 * VectorMask[CurrentRamConfig]) | (address & 0x1FFF)] = data;
+	}
 	else
-	if (MapType | (MmuRegisters[MmuState][address>>13] <VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address>>13] > VectorMask[CurrentRamConfig]))
-		MemPages[MmuRegisters[MmuState][address>>13]][address & 0x1FFF]=data;
+	{
+		if (MapType | (MmuRegisters[MmuState][address >> 13] < VectorMaska[CurrentRamConfig]) | (MmuRegisters[MmuState][address >> 13] > VectorMask[CurrentRamConfig]))
+		{
+			MemPages[MmuRegisters[MmuState][address >> 13]][address & 0x1FFF] = data;
+		}
+	}
 	return;
 }
 

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -172,12 +172,12 @@ unsigned char GimeRead(unsigned char port)
 		data=LastIrq;
 		LastIrq=0;
 		CPUDeAssertInterupt(IS_GIME, INT_IRQ);
-		return(data);
+		return data;
 	case 0x93:
 		data=LastFirq;
 		LastFirq=0;
 		CPUDeAssertInterupt(IS_GIME, INT_FIRQ);
-		return(data);
+		return data;
 	default:
 		if (port >= 0xA0) {
 			data = GimeRegisters[port];


### PR DESCRIPTION
- Add deleted copy constructor and copy assignment operator to CriticalSection.
- Add correct annotations to WinMain.
- Add initialization of member variables.
- Remove superfluous casts.
- Remove redundant parenthesis.
- Remove redundant type from declaration and change to `auto`.
- Change `NULL` to `nullptr`.
- Make variables pointer-to-const.
- Make parameters pointer-to-const.
- Make parameters and variables `const`.
- Replace use of `insert` with `emplace` and `emplace_back`. Remove iterator variables.
- Default the ctor of SN76489Device
- Add braces
- Update IndexingModes to use transparent compare.
- Remove `using std::namespace`.
- Remove unused variables
- Format `if`/`else` chains and add braces so their levels and flow are clear (i.e. properly indented).