### PR TITLE
remove void parameter from functions that take no arguments

### DIFF
--- a/Audio.cpp
+++ b/Audio.cpp
@@ -217,7 +217,7 @@ void FlushAudioBuffer(unsigned int *Abuffer,unsigned int Lenth)
 }
 
 
-int GetFreeBlockCount(void) //return 0 on full buffer
+int GetFreeBlockCount() //return 0 on full buffer
  {
 	unsigned long WriteCursor=0,PlayCursor=0;
 	long RetVal=0,MaxSize=0;
@@ -232,7 +232,7 @@ int GetFreeBlockCount(void) //return 0 on full buffer
 
  }
 
- void PurgeAuxBuffer(void)
+ void PurgeAuxBuffer()
  {
 	if ((!InitPassed) | AudioPause)
 		return;
@@ -272,7 +272,7 @@ BOOL CALLBACK DSEnumCallback(LPGUID lpGuid,LPCSTR lpcstrDescription,LPCSTR /*lpc
 	return (CardCount<MAXCARDS);
 }
 
-int SoundDeInit(void)
+int SoundDeInit()
 {
 	if (InitPassed)
 	{
@@ -309,12 +309,12 @@ int SoundInInit (const _GUID * Guid)
 	return 0;
 }
 
-unsigned int GetSoundStatus(void)
+unsigned int GetSoundStatus()
 {
 	return CurrentRate;
 }
 
-void ResetAudio (void)
+void ResetAudio ()
 {
 	SetAudioRate(GetTapeRate());
 	if (InitPassed)

--- a/Cassette.cpp
+++ b/Cassette.cpp
@@ -124,8 +124,8 @@ static unsigned char Mask=0,Byte=0,LastSample=0;
 
 void WavtoCas(const unsigned char *,unsigned int);
 int MountTape( const char *);
-void CloseTapeFile(void);
-void SyncFileBuffer (void);
+void CloseTapeFile();
+void SyncFileBuffer();
 void CastoWav(unsigned char *,unsigned int);
 
 unsigned int GetTapeRate()
@@ -195,7 +195,7 @@ void Motor(unsigned char State)
 	return;
 }
 
-unsigned int GetTapeCounter(void)
+unsigned int GetTapeCounter()
 {
 	return TapeOffset;
 }
@@ -436,7 +436,7 @@ int MountTape( const char *FileName)	//Return 1 on sucess 0 on fail
 	return 1;
 }
 
-void CloseTapeFile(void)
+void CloseTapeFile()
 {
 	if (TapeHandle==nullptr)
 		return;
@@ -447,7 +447,7 @@ void CloseTapeFile(void)
 	TotalSize=0;
 }
 
-unsigned int LoadTape(void)
+unsigned int LoadTape()
 {
 	FileDialog dlg;
 	char IniFilePath[MAX_PATH];
@@ -479,7 +479,7 @@ void GetTapeName(char *Name)
 	return;
 }
 
-void SyncFileBuffer (void)
+void SyncFileBuffer ()
 {
 	if (!TapeWritten) return;
 	char Buffer[64]="";

--- a/Cassette.h
+++ b/Cassette.h
@@ -30,8 +30,8 @@ constexpr auto CAS_TAPEREADAHEAD = 1000u; // decoded batch size
 constexpr auto CAS_SILENCE = 128u;
 constexpr auto CAS_TAPEAUDIORATE = 44100u;
 
-unsigned int GetTapeCounter(void);
-unsigned int LoadTape(void);
+unsigned int GetTapeCounter();
+unsigned int LoadTape();
 void SetTapeCounter(unsigned int, bool force = false);
 void SetTapeMode(unsigned char);
 void Motor(unsigned char);

--- a/FD502/becker.cpp
+++ b/FD502/becker.cpp
@@ -47,8 +47,8 @@ constexpr SOCKET SOCKET_FATAL = (SOCKET)-2;
 void dw_open();
 void dw_close();
 SOCKET dw_open(const char *, const char *);
-unsigned char dw_status(void);
-unsigned char dw_read(void);
+unsigned char dw_status();
+unsigned char dw_read();
 int dw_write(char);
 unsigned __stdcall dw_thread(void *);
 
@@ -240,7 +240,7 @@ int dw_write( char dwdata)
 	return 0;
 }
 
-void dw_close(void)
+void dw_close()
 {
 	// close socket to cause io thread to die
 	_DLOG("dw_close\n");

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -66,8 +66,8 @@ static unsigned char TempSelectRom=0;
 static unsigned char ClockEnabled=1;
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
 LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
-void LoadConfig(void);
-void SaveConfig(void);
+void LoadConfig();
+void SaveConfig();
 long CreateDiskHeader(const char *,unsigned char,unsigned char,unsigned char);
 void Load_Disk(unsigned char);
 void CenterDialog(HWND hDlg);
@@ -216,7 +216,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void HeartBeat(void)
+	__declspec(dllexport) void HeartBeat()
 	{
 		PingFdc();
 		return;
@@ -442,7 +442,7 @@ unsigned char SetChip(unsigned char Tmp)
 	return SelectRom;
 }
 
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
 	char TempMsg[64]="";
 	char TempBuf[MAX_PATH]="";
@@ -655,7 +655,7 @@ long CreateDiskHeader(const char *FileName,unsigned char Type,unsigned char Trac
 	return 0;
 }
 
-void LoadConfig(void)  // Called on SetIniPath
+void LoadConfig()  // Called on SetIniPath
 {
 	char ModName[MAX_LOADSTRING]="";
 	unsigned char Index=0;
@@ -715,7 +715,7 @@ void LoadConfig(void)  // Called on SetIniPath
 	return;
 }
 
-void SaveConfig(void)
+void SaveConfig()
 {
 	unsigned char Index=0;
 	char ModName[MAX_LOADSTRING]="";

--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -22,7 +22,7 @@ This file is part of VCC (Virtual Color Computer).
 #define COMBINE_BECKER
 
 extern "C" void (*AssertInt)(unsigned char,unsigned char);
-void BuildDynaMenu(void);
+void BuildDynaMenu();
 
 // FIXME: These need to be turned into a scoped enum and the signature of functions
 // that use them updated.

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -65,7 +65,7 @@ long WriteTrack (unsigned char,unsigned char,unsigned char,const unsigned char *
 
 unsigned short ccitt_crc16(unsigned short crc, const unsigned char *, unsigned short );
 long GetSectorInfo (SectorInfo *,const unsigned char *);
-void CommandDone(void);
+void CommandDone();
 extern unsigned char PhysicalDriveA,PhysicalDriveB;
 bool FormatTrack (HANDLE , BYTE , BYTE,BYTE );
 bool CmdFormat (HANDLE , PFD_FORMAT_PARAMS , ULONG );
@@ -677,7 +677,7 @@ long ReadTrack (	unsigned char Side,		//0 or 1
 }
 
 //This gets called at the end of every scan line so the controller has acurate timing.
-void PingFdc(void)
+void PingFdc()
 {
 	static char wobble=0;
 	if (MotorOn==0)
@@ -1295,7 +1295,7 @@ long GetSectorInfo (SectorInfo *Sector,const unsigned char *TempBuffer)
 
 }
 
-void CommandDone(void)
+void CommandDone()
 {
 	if (InteruptEnable)
 		AssertInt(INT_NMI,IS_NMI);
@@ -1419,7 +1419,7 @@ bool CmdFormat (HANDLE h_, PFD_FORMAT_PARAMS pfp_, ULONG ulSize_)
     return !!DeviceIoControl(h_, IOCTL_FDCMD_FORMAT_TRACK, pfp_, ulSize_, nullptr, 0, &dwRet, nullptr);
 }
 
-unsigned short InitController (void)
+unsigned short InitController ()
 {
 	long RawDriverVersion=0;
 	RawDriverVersion=GetDriverVersion ();

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -23,11 +23,11 @@ void disk_io_write(unsigned char data,unsigned char port);
 int mount_disk_image(const char *,unsigned char );
 void unmount_disk_image(unsigned char drive);
 void DiskStatus(char *);
-void PingFdc(void);
+void PingFdc();
 unsigned char SetTurboDisk( unsigned char);
 //unsigned char UseKeyboardLeds(unsigned char);
 DWORD GetDriverVersion ();
-unsigned short InitController (void);
+unsigned short InitController ();
 //unsigned long UseRawDisk(unsigned char,unsigned char);
 // Commands for the wd1793 disk controller $FF48
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -52,12 +52,12 @@ private:
 	friend void ModuleStatus(char *statusBuffer);
 	friend void ModuleConfig(unsigned char menuId);
 	friend void SetIniPath(const char *iniFilePath);
-	friend void ModuleReset(void);
+	friend void ModuleReset();
 	friend void SetCart(SETCART Pointer);
 	friend unsigned char PakMemRead8(unsigned short address);
 	friend void PackPortWrite(unsigned char port, unsigned char data);
 	friend unsigned char PackPortRead(unsigned char port);
-	friend unsigned short ModuleAudioSample(void);
+	friend unsigned short ModuleAudioSample();
 
 private:
 

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -138,7 +138,7 @@ void UnmountHD(int drive)
 }
 
 // Clear drive select on reset
-void VhdReset(void) {
+void VhdReset() {
     MemWrite(0,0xFF86);
 }
 

--- a/HardDisk/cc3vhd.h
+++ b/HardDisk/cc3vhd.h
@@ -26,7 +26,7 @@ int MountHD(const char*, int);
 unsigned char IdeRead(unsigned char);
 void IdeWrite (unsigned char, unsigned char);
 void DiskStatus(char *);
-void VhdReset(void);
+void VhdReset();
 
 constexpr auto DRIVESIZE = 512u; // Mb
 constexpr auto MAX_SECTOR = DRIVESIZE * 1024 * 1024;

--- a/HardDisk/cloud9.cpp
+++ b/HardDisk/cloud9.cpp
@@ -37,7 +37,7 @@ static unsigned __int64 CurrentBit=0;
 static unsigned char FormatBit=0; //1 = 12Hour Mode
 static unsigned char CookieRecived=0;
 static unsigned char WriteEnabled=0;
-void SetTime(void);
+void SetTime();
 unsigned char ReadTime(unsigned short port)
 {
 	unsigned char ret_val=0;
@@ -128,7 +128,7 @@ unsigned char ReadTime(unsigned short port)
 }
 
 
-void SetTime(void)
+void SetTime()
 {
 	now.wMilliseconds= (unsigned short)(InBuffer & 15);
 	InBuffer>>=4;

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -48,9 +48,9 @@ LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
 
 ///void Load_Disk(unsigned char);
 void LoadHardDisk(int drive);
-void LoadConfig(void);
-void SaveConfig(void);
-void BuildDynaMenu(void);
+void LoadConfig();
+void SaveConfig();
+void BuildDynaMenu();
 int CreateDisk(HWND,int);
 void CenterDialog(HWND hDlg);
 
@@ -304,7 +304,7 @@ void LoadHardDisk(int drive)
 }
 
 // Get configuration items from ini file
-void LoadConfig(void)
+void LoadConfig()
 {
     char ModName[MAX_LOADSTRING]="";
     HANDLE hr;
@@ -350,7 +350,7 @@ void LoadConfig(void)
 }
 
 // Save config saves the hard disk path and vhd file names
-void SaveConfig(void)
+void SaveConfig()
 {
     char ModName[MAX_LOADSTRING]="";
     LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
@@ -369,7 +369,7 @@ void SaveConfig(void)
 }
 
 // Generate menu for mounting the drives
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
     char TempMsg[512]="";
     char TempBuf[MAX_PATH]="";

--- a/MachineDefs.h
+++ b/MachineDefs.h
@@ -78,9 +78,9 @@ constexpr uint8_t Bit(uint8_t n) { return 1 << n; }
 // make mask of nth bit 0-7
 constexpr uint8_t BitMask(uint8_t n) { return ~Bit(n); }
 
-extern void (*CPUInit)(void);
+extern void (*CPUInit)();
 extern int  (*CPUExec)(int);
-extern void (*CPUReset)(void);
+extern void (*CPUReset)();
 extern void (*CPUAssertInterupt)(InterruptSource, Interrupt);
 extern void (*CPUDeAssertInterupt)(InterruptSource, Interrupt);
 extern void (*CPUForcePC)(unsigned short);

--- a/Ramdisk/memboard.cpp
+++ b/Ramdisk/memboard.cpp
@@ -30,7 +30,7 @@ union
 
 static unsigned char *RamBuffer=nullptr;
 
-bool InitMemBoard(void)
+bool InitMemBoard()
 {
 	IndexAddress.Address=0;
 
@@ -65,7 +65,7 @@ bool WriteArray(unsigned char Data)
 	return false;
 }
 
-unsigned char ReadArray(void)
+unsigned char ReadArray()
 {
 	return(RamBuffer[IndexAddress.Address]);
 }

--- a/Ramdisk/memboard.h
+++ b/Ramdisk/memboard.h
@@ -21,9 +21,9 @@ This file is part of VCC (Virtual Color Computer).
 #define RAMSIZE 1024*512
 
 
-bool InitMemBoard(void);
+bool InitMemBoard();
 bool WritePort(unsigned char,unsigned char);
 bool WriteArray(unsigned char);
-unsigned char ReadArray(void);
+unsigned char ReadArray();
 
 #endif

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -28,7 +28,7 @@ static unsigned char XferBuffer[512]="";
 static unsigned int BufferIndex=0;
 static unsigned int BufferLenth=0;
 static unsigned char CurrentCommand=0;
-void ExecuteCommand(void);
+void ExecuteCommand();
 void ByteSwap (char *);
 static IDEINTERFACE Registers;
 static HANDLE hDiskFile[2];
@@ -178,7 +178,7 @@ unsigned short IdeRegRead(unsigned char Reg)
 	return RetVal;
 }
 
-void ExecuteCommand(void)
+void ExecuteCommand()
 {
 	CurrentCommand=Registers.Command;
 	char Temp=0;

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -34,7 +34,7 @@ static char IniFile[MAX_PATH]  { 0 };
 static char SuperIDEPath[MAX_PATH];
 static DYNAMICMENUCALLBACK DynamicMenuCallback = nullptr;
 static unsigned char BaseAddress=0x50;
-void BuildDynaMenu(void);
+void BuildDynaMenu();
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM );
 void Select_Disk(unsigned char);
 void SaveConfig();
@@ -189,7 +189,7 @@ extern "C"
 	}
 }
 
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
 	char TempMsg[512]="";
 	char TempBuf[MAX_PATH]="";
@@ -294,7 +294,7 @@ void Select_Disk(unsigned char Disk)
 	return;
 }
 
-void SaveConfig(void)
+void SaveConfig()
 {
 	char ModName[MAX_LOADSTRING]="";
 	LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
@@ -312,7 +312,7 @@ void SaveConfig(void)
 	return;
 }
 
-void LoadConfig(void)
+void LoadConfig()
 {
 	char ModName[MAX_LOADSTRING]="";
 

--- a/SuperIDE/cloud9.cpp
+++ b/SuperIDE/cloud9.cpp
@@ -38,7 +38,7 @@ static unsigned __int64 CurrentBit=0;
 static unsigned char FormatBit=0; //1 = 12Hour Mode
 static unsigned char CookieRecived=0;
 static unsigned char WriteEnabled=0;
-void SetTime(void);
+void SetTime();
 unsigned char ReadTime(unsigned short port)
 {
 	unsigned char ret_val=0;
@@ -129,7 +129,7 @@ unsigned char ReadTime(unsigned short port)
 }
 
 
-void SetTime(void)
+void SetTime()
 {
 	now.wMilliseconds= (unsigned short)(InBuffer & 15);
 	InBuffer>>=4;

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -97,25 +97,25 @@ BOOL CALLBACK About(HWND, UINT, WPARAM, LPARAM);
 BOOL CALLBACK FunctionKeys(HWND, UINT, WPARAM, LPARAM);
 LRESULT CALLBACK WndProc( HWND, UINT, WPARAM, LPARAM);
 
-void SoftReset(void);
-void LoadIniFile(void);
-void SaveConfig(void);
+void SoftReset();
+void LoadIniFile();
+void SaveConfig();
 unsigned __stdcall EmuLoop(HANDLE hEvent);
 unsigned __stdcall CartLoad(void *);
-void (*CPUInit)(void)=nullptr;
+void (*CPUInit)()=nullptr;
 int  (*CPUExec)( int)=nullptr;
-void (*CPUReset)(void)=nullptr;
+void (*CPUReset)()=nullptr;
 void (*CPUSetBreakpoints)(const std::vector<unsigned short>&) = nullptr;
 void (*CPUSetTraceTriggers)(const std::vector<unsigned short>&) = nullptr;
 VCC::CPUState (*CPUGetState)() = nullptr;
 void (*CPUAssertInterupt)(InterruptSource, Interrupt)=nullptr;
 void (*CPUDeAssertInterupt)(InterruptSource, Interrupt)=nullptr;
 void (*CPUForcePC)(unsigned short)=nullptr;
-void FullScreenToggle(void);
+void FullScreenToggle();
 void save_key_down(unsigned char kb_char, unsigned char OEMscan);
-void raise_saved_keys(void);
+void raise_saved_keys();
 void FunctionHelpBox(HWND);
-void SetupClock(void);
+void SetupClock();
 HMENU GetConfMenu();
 
 // Globals
@@ -129,7 +129,7 @@ static char g_szAppName[MAX_LOADSTRING] = "";
 bool BinaryRunning;
 static unsigned char FlagEmuStop=TH_RUNNING;
 
-bool IsShiftKeyDown(void);
+bool IsShiftKeyDown();
 
 //static CRITICAL_SECTION  FrameRender;
 /*--------------------------------------------------------------------------*/
@@ -729,7 +729,7 @@ unsigned char SetCPUMultiplyer(unsigned char Multiplyer)
 	return(EmuState.DoubleSpeedMultiplyer);
 }
 
-void SetupClock(void)
+void SetupClock()
 {
 	int mult = (EmuState.OverclockFlag) ? EmuState.DoubleSpeedMultiplyer : 2;
 	SetClockSpeed(1);
@@ -796,7 +796,7 @@ void DoHardReset(SystemState* const HRState)
 	return;
 }
 
-void SoftReset(void)
+void SoftReset()
 {
 	mc6883_reset();
 	PiaReset();
@@ -886,7 +886,7 @@ unsigned char SetCpuType( unsigned char Tmp)
 	return(EmuState.CpuType);
 }
 
-void DoReboot(void)
+void DoReboot()
 {
 	EmuState.ResetPending=2;
 	return;
@@ -900,7 +900,7 @@ unsigned char SetAutoStart(unsigned char Tmp)
 }
 
 // LoadIniFile allows user to browse for an ini file and reloads the config from it.
-void LoadIniFile(void)
+void LoadIniFile()
 {
 	FileDialog dlg;
 	dlg.setFilter("INI\0*.ini\0\0");
@@ -925,7 +925,7 @@ void LoadIniFile(void)
 }
 
 // SaveConfig copies the current ini file to a choosen ini file.
-void SaveConfig(void) {
+void SaveConfig() {
 
 	FileDialog dlg;
 	dlg.setFilter("INI\0*.ini\0\0");
@@ -1058,7 +1058,7 @@ unsigned __stdcall EmuLoop(HANDLE hEvent)
 	return 0;
 }
 
-void LoadPack(void)
+void LoadPack()
 {
 	unsigned threadID;
 	if (DialogOpen)
@@ -1076,7 +1076,7 @@ unsigned __stdcall CartLoad(void* /*Dummy*/)
 	return 0;
 }
 
-void FullScreenToggle(void)
+void FullScreenToggle()
 {
 	PauseAudio(true);
 	if (!CreateDDWindow(&EmuState))

--- a/Vcc.h
+++ b/Vcc.h
@@ -32,9 +32,9 @@ unsigned char SetSpeedThrottle(unsigned char);
 unsigned char SetFrameSkip(unsigned char);
 unsigned char SetCpuType( unsigned char);
 unsigned char SetAutoStart(unsigned char);
-void SetPaletteType(void);
-void DoReboot(void);
+void SetPaletteType();
+void DoReboot();
 void DoHardReset(SystemState *);
-void LoadPack (void);
+void LoadPack ();
 
 #endif

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -31,11 +31,11 @@
 // Local Functions
 //------------------------------------------------------------------------
 
-void BuildDynaMenu(void);
+void BuildDynaMenu();
 
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
-void LoadConfig(void);
-void SaveConfig(void);
+void LoadConfig();
+void SaveConfig();
 void CenterDialog(HWND);
 
 //------------------------------------------------------------------------
@@ -128,7 +128,7 @@ PackPortRead(unsigned char Port)
 // Dll export module reset
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void ModuleReset(void)
+__declspec(dllexport) void ModuleReset()
 {
     sc6551_close();
     return;
@@ -168,7 +168,7 @@ unsigned char LoadExtRom(const char *FilePath)
 // Dll export Heartbeat (HSYNC)
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void HeartBeat(void)
+__declspec(dllexport) void HeartBeat()
 {
     sc6551_heartbeat();
     return;
@@ -221,7 +221,7 @@ __declspec(dllexport) void SetIniPath (const char *IniFilePath)
 //-----------------------------------------------------------------------
 //  Add config option to Cartridge menu
 //----------------------------------------------------------------------
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
     DynamicMenuCallback("",MID_BEGIN,MIT_Head);
     DynamicMenuCallback("",MID_ENTRY,MIT_Seperator);
@@ -232,7 +232,7 @@ void BuildDynaMenu(void)
 //-----------------------------------------------------------------------
 //  Load saved config from ini file
 //----------------------------------------------------------------------
-void LoadConfig(void)
+void LoadConfig()
 {
     AciaComType=GetPrivateProfileInt("Acia","AciaComType",
                                      COM_CONSOLE,IniFile);
@@ -276,7 +276,7 @@ void LoadConfig(void)
 //-----------------------------------------------------------------------
 //  Save config to ini file
 //----------------------------------------------------------------------
-void SaveConfig(void)
+void SaveConfig()
 {
     char txt[16];
     sprintf(txt,"%d",AciaBasePort);

--- a/audio.h
+++ b/audio.h
@@ -19,13 +19,13 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 int SoundInit (HWND,const _GUID *,unsigned int);
-int SoundDeInit(void);
+int SoundDeInit();
 void FlushAudioBuffer ( unsigned int *,unsigned int);
-void ResetAudio (void);
+void ResetAudio ();
 unsigned char PauseAudio(unsigned char Pause);
-int GetFreeBlockCount(void);
-void PurgeAuxBuffer(void);
-unsigned int GetSoundStatus(void);
+int GetFreeBlockCount();
+void PurgeAuxBuffer();
+unsigned int GetSoundStatus();
 struct SndCardList
 {
 	char CardName[64];

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -66,9 +66,9 @@ unsigned char LoadExtRom(const char *);
 void SetDWTCPConnectionEnable(unsigned int enable);
 int dw_setaddr(const char *bufdwaddr);
 int dw_setport(const char *bufdwport);
-void BuildDynaMenu(void);
-void LoadConfig(void);
-void SaveConfig(void);
+void BuildDynaMenu();
+void LoadConfig();
+void SaveConfig();
 
 
 // dll entry hook
@@ -165,7 +165,7 @@ int dw_write( char dwdata)
 }
 
 
-void killDWTCPThread(void)
+void killDWTCPThread()
 {
 
         // close socket to cause io thread to die
@@ -469,7 +469,7 @@ extern "C" __declspec(dllexport) unsigned char PackPortRead(unsigned char Port)
 		return 0;
 	}
 /*
-	__declspec(dllexport) unsigned char ModuleReset(void)
+	__declspec(dllexport) unsigned char ModuleReset()
 	{
 		if (PakSetCart!=NULL)
 			PakSetCart(1);
@@ -491,7 +491,7 @@ extern "C" __declspec(dllexport) unsigned char PakMemRead8(unsigned short Addres
 	
 	}
 
-extern "C" __declspec(dllexport) void HeartBeat(void)
+extern "C" __declspec(dllexport) void HeartBeat()
 	{
 		// flush write buffer in the future..?
 		return;
@@ -543,7 +543,7 @@ extern "C" __declspec(dllexport) void ModuleStatus(char *DWStatus)
 	}
 
 
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
 	DynamicMenuCallback( "",MID_BEGIN,MIT_Head);
 	DynamicMenuCallback( "",MID_ENTRY,MIT_Seperator);
@@ -641,7 +641,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 
 
 
-void LoadConfig(void)
+void LoadConfig()
 {
 	char ModName[MAX_LOADSTRING]="";
 	char saddr[MAX_LOADSTRING]="";
@@ -671,7 +671,7 @@ void LoadConfig(void)
 	return;
 }
 
-void SaveConfig(void)
+void SaveConfig()
 {
 	char ModName[MAX_LOADSTRING]="";
 	LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);

--- a/becker/becker.h
+++ b/becker/becker.h
@@ -10,7 +10,7 @@
 // functions
 void MemWrite(unsigned char,unsigned short );
 unsigned char MemRead(unsigned short );
-void BuildDynaMenu(void);
+void BuildDynaMenu();
 
 extern const unsigned char Rom[8192];
 

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -101,16 +101,16 @@ static int AudioFreeBlockCount;
 
 static int clipcycle = 1, cyclewait=2000;
 bool codepaste, PasteWithNew = false; 
-void AudioOut(void);
-void CassOut(void);
-void CassIn(void);
-void (*AudioEvent)(void)=AudioOut;
-void SetMasterTickCounter(void);
+void AudioOut();
+void CassOut();
+void CassIn();
+void (*AudioEvent)()=AudioOut;
+void SetMasterTickCounter();
 void (*DrawTopBoarder[4]) (SystemState *)={DrawTopBoarder8,DrawTopBoarder16,DrawTopBoarder24,DrawTopBoarder32};
 void (*DrawBottomBoarder[4]) (SystemState *)={DrawBottomBoarder8,DrawBottomBoarder16,DrawBottomBoarder24,DrawBottomBoarder32};
 void (*UpdateScreen[4]) (SystemState *)={UpdateScreen8,UpdateScreen16,UpdateScreen24,UpdateScreen32};
 std::string GetClipboardText();
-void HLINE(void);
+void HLINE();
 void VSYNC(unsigned char level);
 void HSYNC(unsigned char level);
 std::string CvtStrToSC(std::string);
@@ -389,7 +389,7 @@ DisplayDetails GetDisplayDetails(const int clientWidth, const int clientHeight)
 	return details;
 }
 
-_inline void HLINE(void)
+_inline void HLINE()
 {
 	UpdateAudio();
 
@@ -570,7 +570,7 @@ void SetTimerClockRate (unsigned char Tmp)	//1= 279.265nS (1/ColorBurst)
 	return;
 }
 
-void SetMasterTickCounter(void)
+void SetMasterTickCounter()
 {
 	// Rate = { 63613.2315, 279.265 };
 	double Rate[2]={NANOSECOND/(TARGETFRAMERATE*LINESPERSCREEN),NANOSECOND/COLORBURST};
@@ -584,7 +584,7 @@ void SetMasterTickCounter(void)
 	return;
 }
 
-void MiscReset(void)
+void MiscReset()
 {
 	HorzInteruptEnabled=0;
 	VertInteruptEnabled=0;
@@ -626,14 +626,14 @@ unsigned int SetAudioRate (unsigned int Rate)
 	return 0;
 }
 
-void AudioOut(void)
+void AudioOut()
 {
 
 	AudioBuffer[AudioIndex++]=GetDACSample();
 	return;
 }
 
-void CassOut(void)
+void CassOut()
 {
 	if (LastMotorState && CassIndex < sizeof(CassBuffer)/sizeof(*CassBuffer))
 		CassBuffer[CassIndex++]=GetCasSample();
@@ -667,7 +667,7 @@ uint8_t CassInBitStream()
 	return nextHalfBit >> 1;
 }
 
-void CassIn(void)
+void CassIn()
 {
 	// fade ramp state
 	static unsigned int fadeTo = 0;

--- a/coco3.h
+++ b/coco3.h
@@ -41,7 +41,7 @@ float RenderFrame (SystemState *);
 void SetTimerInteruptState(unsigned char);
 void SetTimerClockRate (unsigned char);	
 void SetInteruptTimer(unsigned int);
-void MiscReset(void);
+void MiscReset();
 void PasteBASICWithNew();
 void PasteBASIC();
 void PasteText();

--- a/config.cpp
+++ b/config.cpp
@@ -59,7 +59,7 @@ using namespace VCC;
 /********************************************/
 
 int SelectFile(char *);
-void RefreshJoystickStatus(void);
+void RefreshJoystickStatus();
 unsigned char TranslateDisp2Scan(int);
 unsigned char TranslateScan2Disp(int);
 void buildTransDisp2ScanTable();
@@ -222,7 +222,7 @@ void InitSound()
 /***********************************************************/
 /*        Save Configuration Settings to ini file          */
 /***********************************************************/
-unsigned char WriteIniFile(void)
+unsigned char WriteIniFile()
 {
 	Rect winRect = GetCurWindowSize();
 	CurrentConfig.Resize = 1;      // How to restore default window size?
@@ -297,7 +297,7 @@ unsigned char WriteIniFile(void)
 /***********************************************************/
 /*        Load Configuration Settings from ini file        */
 /***********************************************************/
-unsigned char ReadIniFile(void)
+unsigned char ReadIniFile()
 {
 	unsigned char Index=0;
 
@@ -440,7 +440,7 @@ void SetKeyMapFilePath(const char *Path)
 /*****************************************************/
 /*  Apply Current VCC settings. Also Called by Vcc.c */
 /*****************************************************/
-void UpdateConfig (void)
+void UpdateConfig ()
 {
 	SetPaletteType();
 	SetResize(CurrentConfig.Resize);
@@ -1470,7 +1470,7 @@ void buildTransDisp2ScanTable()
 	_TranslateDisp2Scan[51] = DIK_LSHIFT;
 }
 
-void RefreshJoystickStatus(void)
+void RefreshJoystickStatus()
 {
 	unsigned char Index=0;
 	bool Temp=false;

--- a/config.h
+++ b/config.h
@@ -23,10 +23,10 @@ This file is part of VCC (Virtual Color Computer).
 void LoadConfig(SystemState *);
 void InitSound();
 void LoadModule();
-unsigned char WriteIniFile(void);
-unsigned char ReadIniFile(void);
+unsigned char WriteIniFile();
+unsigned char ReadIniFile();
 void GetIniFilePath( char *);
-void UpdateConfig (void);
+void UpdateConfig ();
 void UpdateSoundBar(const unsigned int *,unsigned int);
 void UpdateTapeCounter(unsigned int,unsigned char,bool force = false);
 int GetKeyboardLayout();

--- a/hd6309.cpp
+++ b/hd6309.cpp
@@ -200,26 +200,26 @@ BOOL DoingTFM = false;
 
 //Fuction Prototypes---------------------------------------
 static unsigned short CalculateEA(unsigned char);
-void InvalidInsHandler(void);
-void DivbyZero(void);
-void ErrorVector(void);
+void InvalidInsHandler();
+void DivbyZero();
+void ErrorVector();
 void setcc (unsigned char);
-unsigned char getcc(void);
+unsigned char getcc();
 void setmd (unsigned char);
-unsigned char getmd(void);
-static void cpu_firq(void);
-static void cpu_irq(void);
-static void cpu_nmi(void);
+unsigned char getmd();
+static void cpu_firq();
+static void cpu_irq();
+static void cpu_nmi();
 unsigned char GetSorceReg(unsigned char);
-void Page_2(void);
-void Page_3(void);
+void Page_2();
+void Page_3();
 void MemWrite32(unsigned int, unsigned short);
 unsigned int MemRead32(unsigned short);
 //END Fuction Prototypes-----------------------------------
 
 #include "CpuCommon.h"
 
-void HD6309Reset(void)
+void HD6309Reset()
 {
 	char index;
 	for(index=0;index<=6;index++)		//Set all register to 0 except V
@@ -240,7 +240,7 @@ void HD6309Reset(void)
 	return;
 }
 
-void HD6309Init(void)
+void HD6309Init()
 {	//Call this first or RESET will core!
 	// reg pointers for TFR and EXG and LEA ops
 	xfreg16[0] = &D_REG;
@@ -350,7 +350,7 @@ void HD6309SetTraceTriggers(const std::vector<unsigned short>& triggers)
 	CPUTraceTriggers = triggers;
 }
 
-void Neg_D(void)
+void Neg_D()
 { //0
 	temp16 = DPADDRESS(PC_REG++);
 	postbyte = MemRead8(temp16);
@@ -363,7 +363,7 @@ void Neg_D(void)
 	CycleCounter += NatEmuCycles65;
 }
 
-void Oim_D(void)
+void Oim_D()
 {//1 6309
 	postbyte=MemRead8(PC_REG++);
 	temp16 = DPADDRESS(PC_REG++);
@@ -375,7 +375,7 @@ void Oim_D(void)
 	CycleCounter+=6;
 }
 
-void Aim_D(void)
+void Aim_D()
 {//2 Phase 2 6309
 	postbyte=MemRead8(PC_REG++);
 	temp16 = DPADDRESS(PC_REG++);
@@ -387,7 +387,7 @@ void Aim_D(void)
 	CycleCounter+=6;
 }
 
-void Com_D(void)
+void Com_D()
 { //03
 	temp16 = DPADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -400,7 +400,7 @@ void Com_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Lsr_D(void)
+void Lsr_D()
 { //04 S2
 	temp16 = DPADDRESS(PC_REG++);
 	temp8 = MemRead8(temp16);
@@ -412,7 +412,7 @@ void Lsr_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Eim_D(void)
+void Eim_D()
 { //05 6309 Untested
 	postbyte=MemRead8(PC_REG++);
 	temp16 = DPADDRESS(PC_REG++);
@@ -424,7 +424,7 @@ void Eim_D(void)
 	CycleCounter+=6;
 }
 
-void Ror_D(void)
+void Ror_D()
 { //06 S2
 	temp16 = DPADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -437,7 +437,7 @@ void Ror_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Asr_D(void)
+void Asr_D()
 { //7
 	temp16 = DPADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -449,7 +449,7 @@ void Asr_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Asl_D(void)
+void Asl_D()
 { //8 
 	temp16 = DPADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -462,7 +462,7 @@ void Asl_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Rol_D(void)
+void Rol_D()
 {	//9
 	temp16 = DPADDRESS(PC_REG++);
 	temp8 = MemRead8(temp16);
@@ -476,7 +476,7 @@ void Rol_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Dec_D(void)
+void Dec_D()
 { //A
 	temp16 = DPADDRESS(PC_REG++);
 	temp8 = MemRead8(temp16)-1;
@@ -487,7 +487,7 @@ void Dec_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Tim_D(void)
+void Tim_D()
 {	//B 6309 Untested wcreate
 	postbyte=MemRead8(PC_REG++);
 	temp8=MemRead8(DPADDRESS(PC_REG++));
@@ -498,7 +498,7 @@ void Tim_D(void)
 	CycleCounter+=6;
 }
 
-void Inc_D(void)
+void Inc_D()
 { //C
 	temp16=(DPADDRESS(PC_REG++));
 	temp8 = MemRead8(temp16)+1;
@@ -509,7 +509,7 @@ void Inc_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Tst_D(void)
+void Tst_D()
 { //D
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(temp8);
@@ -518,13 +518,13 @@ void Tst_D(void)
 	CycleCounter+=NatEmuCycles64;
 }
 
-void Jmp_D(void)
+void Jmp_D()
 {	//E
 	PC_REG = dp.Reg | MemRead8(PC_REG);
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Clr_D(void)
+void Clr_D()
 {	//F
 	MemWrite8(0,DPADDRESS(PC_REG++));
 	cc[Z] = 1;
@@ -534,7 +534,7 @@ void Clr_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void LBeq_R(void)
+void LBeq_R()
 { //1027
 	if (cc[Z])
 	{
@@ -546,13 +546,13 @@ void LBeq_R(void)
 	CycleCounter+=5;
 }
 
-void LBrn_R(void)
+void LBrn_R()
 { //1021
 	PC_REG+=2;
 	CycleCounter+=5;
 }
 
-void LBhi_R(void)
+void LBhi_R()
 { //1022
 	if  (!(cc[C] | cc[Z]))
 	{
@@ -564,7 +564,7 @@ void LBhi_R(void)
 	CycleCounter+=5;
 }
 
-void LBls_R(void)
+void LBls_R()
 { //1023
 	if (cc[C] | cc[Z])
 	{
@@ -576,7 +576,7 @@ void LBls_R(void)
 	CycleCounter+=5;
 }
 
-void LBhs_R(void)
+void LBhs_R()
 { //1024
 	if (!cc[C])
 	{
@@ -588,7 +588,7 @@ void LBhs_R(void)
 	CycleCounter+=6;
 }
 
-void LBcs_R(void)
+void LBcs_R()
 { //1025
 	if (cc[C])
 	{
@@ -600,7 +600,7 @@ void LBcs_R(void)
 	CycleCounter+=5;
 }
 
-void LBne_R(void)
+void LBne_R()
 { //1026
 	if (!cc[Z])
 	{
@@ -612,7 +612,7 @@ void LBne_R(void)
 	CycleCounter+=5;
 }
 
-void LBvc_R(void)
+void LBvc_R()
 { //1028
 	if ( !cc[V])
 	{
@@ -624,7 +624,7 @@ void LBvc_R(void)
 	CycleCounter+=5;
 }
 
-void LBvs_R(void)
+void LBvs_R()
 { //1029
 	if ( cc[V])
 	{
@@ -636,7 +636,7 @@ void LBvs_R(void)
 	CycleCounter+=5;
 }
 
-void LBpl_R(void)
+void LBpl_R()
 { //102A
 if (!cc[N])
 	{
@@ -648,7 +648,7 @@ if (!cc[N])
 	CycleCounter+=5;
 }
 
-void LBmi_R(void)
+void LBmi_R()
 { //102B
 if ( cc[N])
 	{
@@ -660,7 +660,7 @@ if ( cc[N])
 	CycleCounter+=5;
 }
 
-void LBge_R(void)
+void LBge_R()
 { //102C
 	if (! (cc[N] ^ cc[V]))
 	{
@@ -672,7 +672,7 @@ void LBge_R(void)
 	CycleCounter+=5;
 }
 
-void LBlt_R(void)
+void LBlt_R()
 { //102D
 	if ( cc[V] ^ cc[N])
 	{
@@ -684,7 +684,7 @@ void LBlt_R(void)
 	CycleCounter+=5;
 }
 
-void LBgt_R(void)
+void LBgt_R()
 { //102E
 	if ( !( cc[Z] | (cc[N]^cc[V] ) ))
 	{
@@ -696,7 +696,7 @@ void LBgt_R(void)
 	CycleCounter+=5;
 }
 
-void LBle_R(void)
+void LBle_R()
 {	//102F
 	if ( cc[Z] | (cc[N]^cc[V]) )
 	{
@@ -708,7 +708,7 @@ void LBle_R(void)
 	CycleCounter+=5;
 }
 
-void Addr(void)
+void Addr()
 { //1030 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -779,7 +779,7 @@ void Addr(void)
 	CycleCounter += 4;
 }
 
-void Adcr(void)
+void Adcr()
 { //1031 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -847,7 +847,7 @@ void Adcr(void)
 	CycleCounter += 4;
 }
 
-void Subr(void)
+void Subr()
 { //1032 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -916,7 +916,7 @@ void Subr(void)
 	CycleCounter += 4;
 }
 
-void Sbcr(void)
+void Sbcr()
 { //1033 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -985,7 +985,7 @@ void Sbcr(void)
 	CycleCounter += 4;
 }
 
-void Andr(void)
+void Andr()
 { //1034 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -1051,7 +1051,7 @@ void Andr(void)
 	CycleCounter += 4;
 }
 
-void Orr(void)
+void Orr()
 { //1035 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -1117,7 +1117,7 @@ void Orr(void)
 	CycleCounter += 4;
 }
 
-void Eorr(void)
+void Eorr()
 { //1036 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -1183,7 +1183,7 @@ void Eorr(void)
 	CycleCounter += 4;
 }
 
-void Cmpr(void)
+void Cmpr()
 { //1037 6309 - WallyZ 2019
 	unsigned char dest8, source8;
 	unsigned short dest16, source16;
@@ -1246,35 +1246,35 @@ void Cmpr(void)
 	CycleCounter += 4;
 }
 
-void Pshsw(void)
+void Pshsw()
 { //1038 DONE 6309
 	MemWrite8((F_REG),--S_REG);
 	MemWrite8((E_REG),--S_REG);
 	CycleCounter+=6;
 }
 
-void Pulsw(void)
+void Pulsw()
 {	//1039 6309 Untested wcreate
 	E_REG=MemRead8( S_REG++);
 	F_REG=MemRead8( S_REG++);
 	CycleCounter+=6;
 }
 
-void Pshuw(void)
+void Pshuw()
 { //103A 6309 Untested
 	MemWrite8((F_REG),--U_REG);
 	MemWrite8((E_REG),--U_REG);
 	CycleCounter+=6;
 }
 
-void Puluw(void)
+void Puluw()
 { //103B 6309 Untested
 	E_REG=MemRead8( U_REG++);
 	F_REG=MemRead8( U_REG++);
 	CycleCounter+=6;
 }
 
-void Swi2_I(void)
+void Swi2_I()
 { //103F
 	cc[E]=1;
 	MemWrite8( pc.B.lsb,--S_REG);
@@ -1299,7 +1299,7 @@ void Swi2_I(void)
 	CycleCounter+=20;
 }
 
-void Negd_I(void)
+void Negd_I()
 { //1040 Phase 5 6309
 	D_REG = 0-D_REG;
 	cc[C] = temp16>0;
@@ -1309,7 +1309,7 @@ void Negd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Comd_I(void)
+void Comd_I()
 { //1043 6309
 	D_REG = 0xFFFF- D_REG;
 	cc[Z] = ZTEST(D_REG);
@@ -1319,7 +1319,7 @@ void Comd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Lsrd_I(void)
+void Lsrd_I()
 { //1044 6309
 	cc[C] = D_REG & 1;
 	D_REG = D_REG>>1;
@@ -1328,7 +1328,7 @@ void Lsrd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Rord_I(void)
+void Rord_I()
 { //1046 6309 Untested
 	postword=cc[C]<<15;
 	cc[C] = D_REG & 1;
@@ -1338,7 +1338,7 @@ void Rord_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Asrd_I(void)
+void Asrd_I()
 { //1047 6309 Untested TESTED NITRO MULTIVUE
 	cc[C] = D_REG & 1;
 	D_REG = (D_REG & 0x8000) | (D_REG >> 1);
@@ -1347,7 +1347,7 @@ void Asrd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Asld_I(void)
+void Asld_I()
 { //1048 6309
 	cc[C] = D_REG >>15;
 	cc[V] =  cc[C] ^((D_REG & 0x4000)>>14);
@@ -1357,7 +1357,7 @@ void Asld_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Rold_I(void)
+void Rold_I()
 { //1049 6309 Untested
 	postword=cc[C];
 	cc[C] = D_REG >>15;
@@ -1368,7 +1368,7 @@ void Rold_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Decd_I(void)
+void Decd_I()
 { //104A 6309
 	D_REG--;
 	cc[Z] = ZTEST(D_REG);
@@ -1377,7 +1377,7 @@ void Decd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Incd_I(void)
+void Incd_I()
 { //104C 6309
 	D_REG++;
 	cc[Z] = ZTEST(D_REG);
@@ -1386,7 +1386,7 @@ void Incd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Tstd_I(void)
+void Tstd_I()
 { //104D 6309
 	cc[Z] = ZTEST(D_REG);
 	cc[N] = NTEST16(D_REG);
@@ -1394,7 +1394,7 @@ void Tstd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Clrd_I(void)
+void Clrd_I()
 { //104F 6309
 	D_REG= 0;
 	cc[C] = 0;
@@ -1404,7 +1404,7 @@ void Clrd_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Comw_I(void)
+void Comw_I()
 { //1053 6309 Untested
 	W_REG= 0xFFFF- W_REG;
 	cc[Z] = ZTEST(W_REG);
@@ -1414,7 +1414,7 @@ void Comw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Lsrw_I(void)
+void Lsrw_I()
 { //1054 6309 Untested
 	cc[C] = W_REG & 1;
 	W_REG= W_REG>>1;
@@ -1423,7 +1423,7 @@ void Lsrw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Rorw_I(void)
+void Rorw_I()
 { //1056 6309 Untested
 	postword=cc[C]<<15;
 	cc[C] = W_REG & 1;
@@ -1433,7 +1433,7 @@ void Rorw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Rolw_I(void)
+void Rolw_I()
 { //1059 6309
 	postword=cc[C];
 	cc[C] = W_REG >>15;
@@ -1444,7 +1444,7 @@ void Rolw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Decw_I(void)
+void Decw_I()
 { //105A 6309
 	W_REG--;
 	cc[Z] = ZTEST(W_REG);
@@ -1453,7 +1453,7 @@ void Decw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Incw_I(void)
+void Incw_I()
 { //105C 6309
 	W_REG++;
 	cc[Z] = ZTEST(W_REG);
@@ -1462,7 +1462,7 @@ void Incw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Tstw_I(void)
+void Tstw_I()
 { //105D Untested 6309 wcreate
 	cc[Z] = ZTEST(W_REG);
 	cc[N] = NTEST16(W_REG);
@@ -1470,7 +1470,7 @@ void Tstw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Clrw_I(void)
+void Clrw_I()
 { //105F 6309
 	W_REG = 0;
 	cc[C] = 0;
@@ -1480,7 +1480,7 @@ void Clrw_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Subw_M(void)
+void Subw_M()
 { //1080 6309 CHECK
 	postword=IMMADDRESS(PC_REG);
 	temp16= W_REG-postword;
@@ -1493,7 +1493,7 @@ void Subw_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpw_M(void)
+void Cmpw_M()
 { //1081 6309 CHECK
 	postword=IMMADDRESS(PC_REG);
 	temp16= W_REG-postword;
@@ -1505,7 +1505,7 @@ void Cmpw_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Sbcd_M(void)
+void Sbcd_M()
 { //1082 6309
 	postword=IMMADDRESS(PC_REG);
 	temp32=D_REG-postword-cc[C];
@@ -1518,7 +1518,7 @@ void Sbcd_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpd_M(void)
+void Cmpd_M()
 { //1083
 	postword=IMMADDRESS(PC_REG);
 	temp16 = D_REG-postword;
@@ -1530,7 +1530,7 @@ void Cmpd_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Andd_M(void)
+void Andd_M()
 { //1084 6309
 	D_REG &= IMMADDRESS(PC_REG);
 	cc[N] = NTEST16(D_REG);
@@ -1540,7 +1540,7 @@ void Andd_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Bitd_M(void)
+void Bitd_M()
 { //1085 6309 Untested
 	temp16= D_REG & IMMADDRESS(PC_REG);
 	cc[N] = NTEST16(temp16);
@@ -1550,7 +1550,7 @@ void Bitd_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ldw_M(void)
+void Ldw_M()
 { //1086 6309
 	W_REG=IMMADDRESS(PC_REG);
 	cc[Z] = ZTEST(W_REG);
@@ -1560,7 +1560,7 @@ void Ldw_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Eord_M(void)
+void Eord_M()
 { //1088 6309 Untested
 	D_REG ^= IMMADDRESS(PC_REG);
 	cc[N] = NTEST16(D_REG);
@@ -1570,7 +1570,7 @@ void Eord_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Adcd_M(void)
+void Adcd_M()
 { //1089 6309
 	postword=IMMADDRESS(PC_REG);
 	temp32= D_REG + postword + cc[C];
@@ -1584,7 +1584,7 @@ void Adcd_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ord_M(void)
+void Ord_M()
 { //108A 6309 Untested
 	D_REG |= IMMADDRESS(PC_REG);
 	cc[N] = NTEST16(D_REG);
@@ -1594,7 +1594,7 @@ void Ord_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Addw_M(void)
+void Addw_M()
 { //108B Phase 5 6309
 	temp16=IMMADDRESS(PC_REG);
 	temp32= W_REG+ temp16;
@@ -1607,7 +1607,7 @@ void Addw_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpy_M(void)
+void Cmpy_M()
 { //108C
 	postword=IMMADDRESS(PC_REG);
 	temp16 = Y_REG-postword;
@@ -1619,7 +1619,7 @@ void Cmpy_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 	
-void Ldy_M(void)
+void Ldy_M()
 { //108E
 	Y_REG = IMMADDRESS(PC_REG);
 	cc[Z] = ZTEST(Y_REG);
@@ -1629,7 +1629,7 @@ void Ldy_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Subw_D(void)
+void Subw_D()
 { //1090 Untested 6309
 	temp16= MemRead16(DPADDRESS(PC_REG++));
 	temp32= W_REG-temp16;
@@ -1641,7 +1641,7 @@ void Subw_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Cmpw_D(void)
+void Cmpw_D()
 { //1091 6309 Untested
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp16= W_REG - postword ;
@@ -1652,7 +1652,7 @@ void Cmpw_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Sbcd_D(void)
+void Sbcd_D()
 { //1092 6309
 	postword= MemRead16(DPADDRESS(PC_REG++));
 	temp32=D_REG-postword-cc[C];
@@ -1664,7 +1664,7 @@ void Sbcd_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Cmpd_D(void)
+void Cmpd_D()
 { //1093
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp16= D_REG - postword ;
@@ -1675,7 +1675,7 @@ void Cmpd_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Andd_D(void)
+void Andd_D()
 { //1094 6309 Untested
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	D_REG&=postword;
@@ -1685,7 +1685,7 @@ void Andd_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Bitd_D(void)
+void Bitd_D()
 { //1095 6309 Untested
 	temp16= D_REG & MemRead16(DPADDRESS(PC_REG++));
 	cc[N] = NTEST16(temp16);
@@ -1694,7 +1694,7 @@ void Bitd_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Ldw_D(void)
+void Ldw_D()
 { //1096 6309
 	W_REG = MemRead16(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(W_REG);
@@ -1703,7 +1703,7 @@ void Ldw_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Stw_D(void)
+void Stw_D()
 { //1097 6309
 	MemWrite16(W_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(W_REG);
@@ -1712,7 +1712,7 @@ void Stw_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Eord_D(void)
+void Eord_D()
 { //1098 6309 Untested
 	D_REG^=MemRead16(DPADDRESS(PC_REG++));
 	cc[N] = NTEST16(D_REG);
@@ -1721,7 +1721,7 @@ void Eord_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Adcd_D(void)
+void Adcd_D()
 { //1099 6309
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp32= D_REG + postword + cc[C];
@@ -1734,7 +1734,7 @@ void Adcd_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Ord_D(void)
+void Ord_D()
 { //109A 6309 Untested
 	D_REG|=MemRead16(DPADDRESS(PC_REG++));
 	cc[N] = NTEST16(D_REG);
@@ -1743,7 +1743,7 @@ void Ord_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Addw_D(void)
+void Addw_D()
 { //109B 6309
 	temp16=MemRead16( DPADDRESS(PC_REG++));
 	temp32= W_REG+ temp16;
@@ -1755,7 +1755,7 @@ void Addw_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Cmpy_D(void)
+void Cmpy_D()
 {	//109C
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp16= Y_REG - postword ;
@@ -1766,7 +1766,7 @@ void Cmpy_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Ldy_D(void)
+void Ldy_D()
 { //109E
 	Y_REG=MemRead16(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Y_REG);	
@@ -1775,7 +1775,7 @@ void Ldy_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 	
-void Sty_D(void)
+void Sty_D()
 { //109F
 	MemWrite16(Y_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Y_REG);
@@ -1784,7 +1784,7 @@ void Sty_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Subw_X(void)
+void Subw_X()
 { //10A0 6309 MODDED
 	temp16=MemRead16(INDADDRESS(PC_REG++));
 	temp32=W_REG-temp16;
@@ -1796,7 +1796,7 @@ void Subw_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Cmpw_X(void)
+void Cmpw_X()
 { //10A1 6309
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp16= W_REG - postword ;
@@ -1807,7 +1807,7 @@ void Cmpw_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Sbcd_X(void)
+void Sbcd_X()
 { //10A2 6309
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp32=D_REG-postword-cc[C];
@@ -1819,7 +1819,7 @@ void Sbcd_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Cmpd_X(void)
+void Cmpd_X()
 { //10A3
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp16= D_REG - postword ;
@@ -1830,7 +1830,7 @@ void Cmpd_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Andd_X(void)
+void Andd_X()
 { //10A4 6309
 	D_REG&=MemRead16(INDADDRESS(PC_REG++));
 	cc[N] = NTEST16(D_REG);
@@ -1839,7 +1839,7 @@ void Andd_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Bitd_X(void)
+void Bitd_X()
 { //10A5 6309 Untested
 	temp16= D_REG & MemRead16(INDADDRESS(PC_REG++));
 	cc[N] = NTEST16(temp16);
@@ -1848,7 +1848,7 @@ void Bitd_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ldw_X(void)
+void Ldw_X()
 { //10A6 6309
 	W_REG=MemRead16(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(W_REG);
@@ -1857,7 +1857,7 @@ void Ldw_X(void)
 	CycleCounter+=6;
 }
 
-void Stw_X(void)
+void Stw_X()
 { //10A7 6309
 	MemWrite16(W_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(W_REG);
@@ -1866,7 +1866,7 @@ void Stw_X(void)
 	CycleCounter+=6;
 }
 
-void Eord_X(void)
+void Eord_X()
 { //10A8 6309 Untested TESTED NITRO 
 	D_REG ^= MemRead16(INDADDRESS(PC_REG++));
 	cc[N] = NTEST16(D_REG);
@@ -1875,7 +1875,7 @@ void Eord_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Adcd_X(void)
+void Adcd_X()
 { //10A9 6309 untested
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp32 = D_REG + postword + cc[C];
@@ -1888,7 +1888,7 @@ void Adcd_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ord_X(void)
+void Ord_X()
 { //10AA 6309 Untested wcreate
 	D_REG |= MemRead16(INDADDRESS(PC_REG++));
 	cc[N] = NTEST16(D_REG);
@@ -1897,7 +1897,7 @@ void Ord_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Addw_X(void)
+void Addw_X()
 { //10AB 6309 Untested TESTED NITRO CHECK no Half carry?
 	temp16=MemRead16(INDADDRESS(PC_REG++));
 	temp32= W_REG+ temp16;
@@ -1909,7 +1909,7 @@ void Addw_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Cmpy_X(void)
+void Cmpy_X()
 { //10AC
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp16= Y_REG - postword ;
@@ -1920,7 +1920,7 @@ void Cmpy_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ldy_X(void)
+void Ldy_X()
 { //10AE
 	Y_REG=MemRead16(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Y_REG);
@@ -1929,7 +1929,7 @@ void Ldy_X(void)
 	CycleCounter+=6;
 	}
 
-void Sty_X(void)
+void Sty_X()
 { //10AF
 	MemWrite16(Y_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Y_REG);
@@ -1938,7 +1938,7 @@ void Sty_X(void)
 	CycleCounter+=6;
 }
 
-void Subw_E(void)
+void Subw_E()
 { //10B0 6309 Untested
 	temp16=MemRead16(IMMADDRESS(PC_REG));
 	temp32=W_REG-temp16;
@@ -1951,7 +1951,7 @@ void Subw_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Cmpw_E(void)
+void Cmpw_E()
 { //10B1 6309 Untested
 	postword=MemRead16(IMMADDRESS(PC_REG));
 	temp16 = W_REG-postword;
@@ -1963,7 +1963,7 @@ void Cmpw_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Sbcd_E(void)
+void Sbcd_E()
 { //10B2 6309 Untested
 	temp16=MemRead16(IMMADDRESS(PC_REG));
 	temp32=D_REG-temp16-cc[C];
@@ -1976,7 +1976,7 @@ void Sbcd_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Cmpd_E(void)
+void Cmpd_E()
 { //10B3
 	postword=MemRead16(IMMADDRESS(PC_REG));
 	temp16 = D_REG-postword;
@@ -1988,7 +1988,7 @@ void Cmpd_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Andd_E(void)
+void Andd_E()
 { //10B4 6309 Untested
 	D_REG &= MemRead16(IMMADDRESS(PC_REG));
 	cc[N] = NTEST16(D_REG);
@@ -1998,7 +1998,7 @@ void Andd_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Bitd_E(void)
+void Bitd_E()
 { //10B5 6309 Untested CHECK NITRO
 	temp16= D_REG & MemRead16(IMMADDRESS(PC_REG));
 	cc[N] = NTEST16(temp16);
@@ -2008,7 +2008,7 @@ void Bitd_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Ldw_E(void)
+void Ldw_E()
 { //10B6 6309
 	W_REG=MemRead16(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(W_REG);
@@ -2018,7 +2018,7 @@ void Ldw_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Stw_E(void)
+void Stw_E()
 { //10B7 6309
 	MemWrite16(W_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(W_REG);
@@ -2028,7 +2028,7 @@ void Stw_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Eord_E(void)
+void Eord_E()
 { //10B8 6309 Untested
 	D_REG ^= MemRead16(IMMADDRESS(PC_REG));
 	cc[N] = NTEST16(D_REG);
@@ -2038,7 +2038,7 @@ void Eord_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Adcd_E(void)
+void Adcd_E()
 { //10B9 6309 untested
 	postword = MemRead16(IMMADDRESS(PC_REG));
 	temp32 = D_REG + postword + cc[C];
@@ -2052,7 +2052,7 @@ void Adcd_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Ord_E(void)
+void Ord_E()
 { //10BA 6309 Untested
 	D_REG |= MemRead16(IMMADDRESS(PC_REG));
 	cc[N] = NTEST16(D_REG);
@@ -2062,7 +2062,7 @@ void Ord_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Addw_E(void)
+void Addw_E()
 { //10BB 6309 Untested
 	temp16=MemRead16(IMMADDRESS(PC_REG));
 	temp32= W_REG+ temp16;
@@ -2075,7 +2075,7 @@ void Addw_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Cmpy_E(void)
+void Cmpy_E()
 { //10BC
 	postword=MemRead16(IMMADDRESS(PC_REG));
 	temp16 = Y_REG-postword;
@@ -2087,7 +2087,7 @@ void Cmpy_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Ldy_E(void)
+void Ldy_E()
 { //10BE
 	Y_REG=MemRead16(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(Y_REG);
@@ -2097,7 +2097,7 @@ void Ldy_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Sty_E(void)
+void Sty_E()
 { //10BF
 	MemWrite16(Y_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(Y_REG);
@@ -2107,7 +2107,7 @@ void Sty_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Lds_I(void)
+void Lds_I()
 {  //10CE
 	S_REG=IMMADDRESS(PC_REG);
 	cc[Z] = ZTEST(S_REG);
@@ -2117,7 +2117,7 @@ void Lds_I(void)
 	CycleCounter+=4;
 }
 
-void Ldq_D(void)
+void Ldq_D()
 { //10DC 6309
 	Q_REG=MemRead32(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Q_REG);
@@ -2126,7 +2126,7 @@ void Ldq_D(void)
 	CycleCounter+=NatEmuCycles87;
 }
 
-void Stq_D(void)
+void Stq_D()
 { //10DD 6309
 	MemWrite32(Q_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Q_REG);
@@ -2135,7 +2135,7 @@ void Stq_D(void)
 	CycleCounter+=NatEmuCycles87;
 }
 
-void Lds_D(void)
+void Lds_D()
 { //10DE
 	S_REG=MemRead16(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(S_REG);
@@ -2144,7 +2144,7 @@ void Lds_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Sts_D(void)
+void Sts_D()
 { //10DF 6309
 	MemWrite16(S_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(S_REG);
@@ -2153,7 +2153,7 @@ void Sts_D(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Ldq_X(void)
+void Ldq_X()
 { //10EC 6309
 	Q_REG=MemRead32(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Q_REG);
@@ -2162,7 +2162,7 @@ void Ldq_X(void)
 	CycleCounter+=8;
 }
 
-void Stq_X(void)
+void Stq_X()
 { //10ED 6309 DONE
 	MemWrite32(Q_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(Q_REG);
@@ -2172,7 +2172,7 @@ void Stq_X(void)
 }
 
 
-void Lds_X(void)
+void Lds_X()
 { //10EE
 	S_REG=MemRead16(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(S_REG);
@@ -2181,7 +2181,7 @@ void Lds_X(void)
 	CycleCounter+=6;
 }
 
-void Sts_X(void)
+void Sts_X()
 { //10EF 6309
 	MemWrite16(S_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(S_REG);
@@ -2190,7 +2190,7 @@ void Sts_X(void)
 	CycleCounter+=6;
 }
 
-void Ldq_E(void)
+void Ldq_E()
 { //10FC 6309
 	Q_REG=MemRead32(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(Q_REG);
@@ -2200,7 +2200,7 @@ void Ldq_E(void)
 	CycleCounter+=NatEmuCycles98;
 }
 
-void Stq_E(void)
+void Stq_E()
 { //10FD 6309
 	MemWrite32(Q_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(Q_REG);
@@ -2210,7 +2210,7 @@ void Stq_E(void)
 	CycleCounter+=NatEmuCycles98;
 }
 
-void Lds_E(void)
+void Lds_E()
 { //10FE
 	S_REG=MemRead16(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(S_REG);
@@ -2220,7 +2220,7 @@ void Lds_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Sts_E(void)
+void Sts_E()
 { //10FF 6309
 	MemWrite16(S_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(S_REG);
@@ -2230,7 +2230,7 @@ void Sts_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Band(void)
+void Band()
 { //1130 6309 untested
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2261,7 +2261,7 @@ void Band(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Biand(void)
+void Biand()
 { //1131 6309
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2292,7 +2292,7 @@ void Biand(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Bor(void)
+void Bor()
 { //1132 6309
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2323,7 +2323,7 @@ void Bor(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Bior(void)
+void Bior()
 { //1133 6309
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2354,7 +2354,7 @@ void Bior(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Beor(void)
+void Beor()
 { //1134 6309
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2384,7 +2384,7 @@ void Beor(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Bieor(void)
+void Bieor()
 { //1135 6309
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2414,7 +2414,7 @@ void Bieor(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ldbt(void)
+void Ldbt()
 { //1136 6309
 	postbyte = MemRead8(PC_REG++);
 	temp8 = MemRead8(DPADDRESS(PC_REG++));
@@ -2457,7 +2457,7 @@ void Ldbt(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Stbt(void)
+void Stbt()
 { //1137 6309
 	postbyte = MemRead8(PC_REG++);
 	temp16 = DPADDRESS(PC_REG++);
@@ -2495,7 +2495,7 @@ void Stbt(void)
 	CycleCounter+=NatEmuCycles87;
 }
 
-void Tfm1(void)
+void Tfm1()
 { //1138 TFM R+,R+ 6309
 	if (W_REG == 0)
 	{
@@ -2525,7 +2525,7 @@ void Tfm1(void)
 	PC_REG -= 2;
 }
 
-void Tfm2(void)
+void Tfm2()
 { //1139 TFM R-,R- Phase 3 6309
 	if (W_REG == 0)
 	{
@@ -2556,7 +2556,7 @@ void Tfm2(void)
 	PC_REG-=2;
 }
 
-void Tfm3(void)
+void Tfm3()
 { //113A 6309 TFM R+,R 6309
 	if (W_REG == 0)
 	{
@@ -2586,7 +2586,7 @@ void Tfm3(void)
 	CycleCounter += 3;
 }
 
-void Tfm4(void)
+void Tfm4()
 { //113B TFM R,R+ 6309 
 	if (W_REG == 0)
 	{
@@ -2615,7 +2615,7 @@ void Tfm4(void)
 	CycleCounter+=3;
 }
 
-void Bitmd_M(void)
+void Bitmd_M()
 { //113C  6309
 	postbyte = MemRead8(PC_REG++) & 0xC0;
 	temp8 = getmd() & postbyte;
@@ -2625,14 +2625,14 @@ void Bitmd_M(void)
 	CycleCounter+=4;
 }
 
-void Ldmd_M(void)
+void Ldmd_M()
 { //113D DONE 6309
 	mdbits= MemRead8(PC_REG++)&0x03;
 	setmd(mdbits);
 	CycleCounter+=5;
 }
 
-void Swi3_I(void)
+void Swi3_I()
 { //113F
 	cc[E]=1;
 	MemWrite8( pc.B.lsb,--S_REG);
@@ -2657,7 +2657,7 @@ void Swi3_I(void)
 	CycleCounter+=20;
 }
 
-void Come_I(void)
+void Come_I()
 { //1143 6309 Untested
 	E_REG = 0xFF- E_REG;
 	cc[Z] = ZTEST(E_REG);
@@ -2667,7 +2667,7 @@ void Come_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Dece_I(void)
+void Dece_I()
 { //114A 6309
 	E_REG--;
 	cc[Z] = ZTEST(E_REG);
@@ -2676,7 +2676,7 @@ void Dece_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Ince_I(void)
+void Ince_I()
 { //114C 6309
 	E_REG++;
 	cc[Z] = ZTEST(E_REG);
@@ -2685,7 +2685,7 @@ void Ince_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Tste_I(void)
+void Tste_I()
 { //114D 6309 Untested TESTED NITRO
 	cc[Z] = ZTEST(E_REG);
 	cc[N] = NTEST8(E_REG);
@@ -2693,7 +2693,7 @@ void Tste_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Clre_I(void)
+void Clre_I()
 { //114F 6309
 	E_REG= 0;
 	cc[C] = 0;
@@ -2703,7 +2703,7 @@ void Clre_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Comf_I(void)
+void Comf_I()
 { //1153 6309 Untested
 	F_REG= 0xFF- F_REG;
 	cc[Z] = ZTEST(F_REG);
@@ -2713,7 +2713,7 @@ void Comf_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Decf_I(void)
+void Decf_I()
 { //115A 6309
 	F_REG--;
 	cc[Z] = ZTEST(F_REG);
@@ -2722,7 +2722,7 @@ void Decf_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Incf_I(void)
+void Incf_I()
 { //115C 6309 Untested
 	F_REG++;
 	cc[Z] = ZTEST(F_REG);
@@ -2731,7 +2731,7 @@ void Incf_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Tstf_I(void)
+void Tstf_I()
 { //115D 6309
 	cc[Z] = ZTEST(F_REG);
 	cc[N] = NTEST8(F_REG);
@@ -2739,7 +2739,7 @@ void Tstf_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Clrf_I(void)
+void Clrf_I()
 { //115F 6309 Untested wcreate
 	F_REG= 0;
 	cc[C] = 0;
@@ -2749,7 +2749,7 @@ void Clrf_I(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Sube_M(void)
+void Sube_M()
 { //1180 6309 Untested
 	postbyte=MemRead8(PC_REG++);
 	temp16 = E_REG - postbyte;
@@ -2761,7 +2761,7 @@ void Sube_M(void)
 	CycleCounter+=3;
 }
 
-void Cmpe_M(void)
+void Cmpe_M()
 { //1181 6309
 	postbyte=MemRead8(PC_REG++);
 	temp8= E_REG-postbyte;
@@ -2772,7 +2772,7 @@ void Cmpe_M(void)
 	CycleCounter+=3;
 }
 
-void Cmpu_M(void)
+void Cmpu_M()
 { //1183
 	postword=IMMADDRESS(PC_REG);
 	temp16 = U_REG-postword;
@@ -2784,7 +2784,7 @@ void Cmpu_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Lde_M(void)
+void Lde_M()
 { //1186 6309
 	E_REG= MemRead8(PC_REG++);
 	cc[Z] = ZTEST(E_REG);
@@ -2793,7 +2793,7 @@ void Lde_M(void)
 	CycleCounter+=3;
 }
 
-void Adde_M(void)
+void Adde_M()
 { //118B 6309
 	postbyte=MemRead8(PC_REG++);
 	temp16=E_REG+postbyte;
@@ -2806,7 +2806,7 @@ void Adde_M(void)
 	CycleCounter+=3;
 }
 
-void Cmps_M(void)
+void Cmps_M()
 { //118C
 	postword=IMMADDRESS(PC_REG);
 	temp16 = S_REG-postword;
@@ -2818,7 +2818,7 @@ void Cmps_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Divd_M(void)
+void Divd_M()
 { //118D 6309
 	postbyte = MemRead8(PC_REG++);
 
@@ -2860,7 +2860,7 @@ void Divd_M(void)
 	CycleCounter+=25;
 }
 
-void Divq_M(void)
+void Divq_M()
 { //118E 6309
 	postword = MemRead16(PC_REG);
 	PC_REG+=2;
@@ -2902,7 +2902,7 @@ void Divq_M(void)
 	CycleCounter+=34;
 }
 
-void Muld_M(void)
+void Muld_M()
 { //118F Phase 5 6309
 	Q_REG =  (signed short)D_REG * (signed short)IMMADDRESS(PC_REG);
 	cc[C] = 0; 
@@ -2913,7 +2913,7 @@ void Muld_M(void)
 	CycleCounter+=28;
 }
 
-void Sube_D(void)
+void Sube_D()
 { //1190 6309 Untested HERE
 	postbyte=MemRead8( DPADDRESS(PC_REG++));
 	temp16 = E_REG - postbyte;
@@ -2925,7 +2925,7 @@ void Sube_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpe_D(void)
+void Cmpe_D()
 { //1191 6309 Untested
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp8= E_REG-postbyte;
@@ -2936,7 +2936,7 @@ void Cmpe_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpu_D(void)
+void Cmpu_D()
 { //1193
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp16= U_REG - postword ;
@@ -2947,7 +2947,7 @@ void Cmpu_D(void)
 	CycleCounter+=NatEmuCycles75;
 	}
 
-void Lde_D(void)
+void Lde_D()
 { //1196 6309
 	E_REG= MemRead8(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(E_REG);
@@ -2956,7 +2956,7 @@ void Lde_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ste_D(void)
+void Ste_D()
 { //1197 Phase 5 6309
 	MemWrite8( E_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(E_REG);
@@ -2965,7 +2965,7 @@ void Ste_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Adde_D(void)
+void Adde_D()
 { //119B 6309 Untested
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16=E_REG+postbyte;
@@ -2978,7 +2978,7 @@ void Adde_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmps_D(void)
+void Cmps_D()
 { //119C
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp16= S_REG - postword ;
@@ -2989,7 +2989,7 @@ void Cmps_D(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Divd_D(void)
+void Divd_D()
 { //119D 6309 02292008
 	postbyte = MemRead8(DPADDRESS(PC_REG++));
 
@@ -3031,7 +3031,7 @@ void Divd_D(void)
 	CycleCounter+=27;
 }
 
-void Divq_D(void)
+void Divq_D()
 { //119E 6309
 	postword = MemRead16(DPADDRESS(PC_REG++));
 
@@ -3072,7 +3072,7 @@ void Divq_D(void)
   CycleCounter+=NatEmuCycles3635;
 }
 
-void Muld_D(void)
+void Muld_D()
 { //119F 6309 02292008
 	Q_REG = (signed short)D_REG * (signed short)MemRead16(DPADDRESS(PC_REG++));
 	cc[C] = 0;
@@ -3082,7 +3082,7 @@ void Muld_D(void)
 	CycleCounter+=NatEmuCycles3029;
 }
 
-void Sube_X(void)
+void Sube_X()
 { //11A0 6309 Untested
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16 = E_REG - postbyte;
@@ -3094,7 +3094,7 @@ void Sube_X(void)
 	CycleCounter+=5;
 }
 
-void Cmpe_X(void)
+void Cmpe_X()
 { //11A1 6309
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp8= E_REG-postbyte;
@@ -3105,7 +3105,7 @@ void Cmpe_X(void)
 	CycleCounter+=5;
 }
 
-void Cmpu_X(void)
+void Cmpu_X()
 { //11A3
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp16= U_REG - postword ;
@@ -3116,7 +3116,7 @@ void Cmpu_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Lde_X(void)
+void Lde_X()
 { //11A6 6309
 	E_REG= MemRead8(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(E_REG);
@@ -3125,7 +3125,7 @@ void Lde_X(void)
 	CycleCounter+=5;
 }
 
-void Ste_X(void)
+void Ste_X()
 { //11A7 6309
 	MemWrite8(E_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(E_REG);
@@ -3134,7 +3134,7 @@ void Ste_X(void)
 	CycleCounter+=5;
 }
 
-void Adde_X(void)
+void Adde_X()
 { //11AB 6309 Untested
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16=E_REG+postbyte;
@@ -3147,7 +3147,7 @@ void Adde_X(void)
 	CycleCounter+=5;
 }
 
-void Cmps_X(void)
+void Cmps_X()
 {  //11AC
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp16= S_REG - postword ;
@@ -3158,7 +3158,7 @@ void Cmps_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Divd_X(void)
+void Divd_X()
 { //11AD wcreate  6309
 	postbyte = MemRead8(INDADDRESS(PC_REG++));
 
@@ -3200,7 +3200,7 @@ void Divd_X(void)
   CycleCounter += 27;
 }
 
-void Divq_X(void)
+void Divq_X()
 { //11AE Phase 5 6309 CHECK
 	postword = MemRead16(INDADDRESS(PC_REG++));
 
@@ -3241,7 +3241,7 @@ void Divq_X(void)
   CycleCounter += NatEmuCycles3635;
 }
 
-void Muld_X(void)
+void Muld_X()
 { //11AF 6309 CHECK
 	Q_REG=  (signed short)D_REG * (signed short)MemRead16(INDADDRESS(PC_REG++));
 	cc[C] = 0;
@@ -3251,7 +3251,7 @@ void Muld_X(void)
 	CycleCounter+=30;
 }
 
-void Sube_E(void)
+void Sube_E()
 { //11B0 6309 Untested
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16 = E_REG - postbyte;
@@ -3264,7 +3264,7 @@ void Sube_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Cmpe_E(void)
+void Cmpe_E()
 { //11B1 6309 Untested
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp8= E_REG-postbyte;
@@ -3276,7 +3276,7 @@ void Cmpe_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Cmpu_E(void)
+void Cmpu_E()
 { //11B3
 	postword=MemRead16(IMMADDRESS(PC_REG));
 	temp16 = U_REG-postword;
@@ -3288,7 +3288,7 @@ void Cmpu_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Lde_E(void)
+void Lde_E()
 { //11B6 6309
 	E_REG= MemRead8(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(E_REG);
@@ -3298,7 +3298,7 @@ void Lde_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Ste_E(void)
+void Ste_E()
 { //11B7 6309
 	MemWrite8(E_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(E_REG);
@@ -3308,7 +3308,7 @@ void Ste_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Adde_E(void)
+void Adde_E()
 { //11BB 6309 Untested
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16=E_REG+postbyte;
@@ -3322,7 +3322,7 @@ void Adde_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Cmps_E(void)
+void Cmps_E()
 { //11BC
 	postword=MemRead16(IMMADDRESS(PC_REG));
 	temp16 = S_REG-postword;
@@ -3334,7 +3334,7 @@ void Cmps_E(void)
 	CycleCounter+=NatEmuCycles86;
 }
 
-void Divd_E(void)
+void Divd_E()
 { //11BD 6309 02292008 Untested
 	postbyte = MemRead8(IMMADDRESS(PC_REG));
 	PC_REG+=2;
@@ -3377,7 +3377,7 @@ void Divd_E(void)
   CycleCounter += 25;
 }
 
-void Divq_E(void)
+void Divq_E()
 { //11BE Phase 5 6309 CHECK
 	postword = MemRead16(IMMADDRESS(PC_REG));
 	PC_REG+=2;
@@ -3419,7 +3419,7 @@ void Divq_E(void)
   CycleCounter += NatEmuCycles3635;
 }
 
-void Muld_E(void)
+void Muld_E()
 { //11BF 6309
 	Q_REG=  (signed short)D_REG * (signed short)MemRead16(IMMADDRESS(PC_REG));
 	PC_REG+=2;
@@ -3430,7 +3430,7 @@ void Muld_E(void)
 	CycleCounter+=NatEmuCycles3130;
 }
 
-void Subf_M(void)
+void Subf_M()
 { //11C0 6309 Untested
 	postbyte=MemRead8(PC_REG++);
 	temp16 = F_REG - postbyte;
@@ -3442,7 +3442,7 @@ void Subf_M(void)
 	CycleCounter+=3;
 }
 
-void Cmpf_M(void)
+void Cmpf_M()
 { //11C1 6309
 	postbyte=MemRead8(PC_REG++);
 	temp8= F_REG-postbyte;
@@ -3453,7 +3453,7 @@ void Cmpf_M(void)
 	CycleCounter+=3;
 }
 
-void Ldf_M(void)
+void Ldf_M()
 { //11C6 6309
 	F_REG= MemRead8(PC_REG++);
 	cc[Z] = ZTEST(F_REG);
@@ -3462,7 +3462,7 @@ void Ldf_M(void)
 	CycleCounter+=3;
 }
 
-void Addf_M(void)
+void Addf_M()
 { //11CB 6309 Untested
 	postbyte=MemRead8(PC_REG++);
 	temp16=F_REG+postbyte;
@@ -3475,7 +3475,7 @@ void Addf_M(void)
 	CycleCounter+=3;
 }
 
-void Subf_D(void)
+void Subf_D()
 { //11D0 6309 Untested
 	postbyte=MemRead8( DPADDRESS(PC_REG++));
 	temp16 = F_REG - postbyte;
@@ -3487,7 +3487,7 @@ void Subf_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpf_D(void)
+void Cmpf_D()
 { //11D1 6309 Untested
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp8= F_REG-postbyte;
@@ -3498,7 +3498,7 @@ void Cmpf_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ldf_D(void)
+void Ldf_D()
 { //11D6 6309 Untested wcreate
 	F_REG= MemRead8(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(F_REG);
@@ -3507,7 +3507,7 @@ void Ldf_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Stf_D(void)
+void Stf_D()
 { //11D7 Phase 5 6309
 	MemWrite8(F_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(F_REG);
@@ -3516,7 +3516,7 @@ void Stf_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Addf_D(void)
+void Addf_D()
 { //11DB 6309 Untested
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16=F_REG+postbyte;
@@ -3529,7 +3529,7 @@ void Addf_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Subf_X(void)
+void Subf_X()
 { //11E0 6309 Untested
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16 = F_REG - postbyte;
@@ -3541,7 +3541,7 @@ void Subf_X(void)
 	CycleCounter+=5;
 }
 
-void Cmpf_X(void)
+void Cmpf_X()
 { //11E1 6309 Untested
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp8= F_REG-postbyte;
@@ -3552,7 +3552,7 @@ void Cmpf_X(void)
 	CycleCounter+=5;
 }
 
-void Ldf_X(void)
+void Ldf_X()
 { //11E6 6309
 	F_REG=MemRead8(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(F_REG);
@@ -3561,7 +3561,7 @@ void Ldf_X(void)
 	CycleCounter+=5;
 }
 
-void Stf_X(void)
+void Stf_X()
 { //11E7 Phase 5 6309
 	MemWrite8(F_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(F_REG);
@@ -3570,7 +3570,7 @@ void Stf_X(void)
 	CycleCounter+=5;
 }
 
-void Addf_X(void)
+void Addf_X()
 { //11EB 6309 Untested
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16=F_REG+postbyte;
@@ -3583,7 +3583,7 @@ void Addf_X(void)
 	CycleCounter+=5;
 }
 
-void Subf_E(void)
+void Subf_E()
 { //11F0 6309 Untested
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16 = F_REG - postbyte;
@@ -3596,7 +3596,7 @@ void Subf_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Cmpf_E(void)
+void Cmpf_E()
 { //11F1 6309 Untested
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp8= F_REG-postbyte;
@@ -3608,7 +3608,7 @@ void Cmpf_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Ldf_E(void)
+void Ldf_E()
 { //11F6 6309
 	F_REG= MemRead8(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(F_REG);
@@ -3618,7 +3618,7 @@ void Ldf_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Stf_E(void)
+void Stf_E()
 { //11F7 Phase 5 6309
 	MemWrite8(F_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(F_REG);
@@ -3628,7 +3628,7 @@ void Stf_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Addf_E(void)
+void Addf_E()
 { //11FB 6309 Untested
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16=F_REG+postbyte;
@@ -3642,18 +3642,18 @@ void Addf_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Nop_I(void)
+void Nop_I()
 {	//12
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Sync_I(void)
+void Sync_I()
 { //13
 	CycleCounter=gCycleFor;
 	SyncWaiting=1;
 }
 
-void Sexw_I(void)
+void Sexw_I()
 { //14 6309 CHECK
 	if (W_REG & 32768)
 		D_REG=0xFFFF;
@@ -3664,7 +3664,7 @@ void Sexw_I(void)
 	CycleCounter+=4;
 }
 
-void Lbra_R(void)
+void Lbra_R()
 { //16
 	*spostword=IMMADDRESS(PC_REG);
 	PC_REG+=2;
@@ -3672,7 +3672,7 @@ void Lbra_R(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Lbsr_R(void)
+void Lbsr_R()
 { //17
 	*spostword=IMMADDRESS(PC_REG);
 	PC_REG+=2;
@@ -3683,7 +3683,7 @@ void Lbsr_R(void)
 	CycleCounter+=NatEmuCycles97;
 }
 
-void Daa_I(void)
+void Daa_I()
 { //19
 	static unsigned char msn, lsn;
 
@@ -3707,7 +3707,7 @@ void Daa_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Orcc_M(void)
+void Orcc_M()
 { //1A
 	postbyte=MemRead8(PC_REG++);
 	temp8=getcc();
@@ -3716,7 +3716,7 @@ void Orcc_M(void)
 	CycleCounter+=NatEmuCycles32;
 }
 
-void Andcc_M(void)
+void Andcc_M()
 { //1C
 	postbyte=MemRead8(PC_REG++);
 	temp8=getcc();
@@ -3725,7 +3725,7 @@ void Andcc_M(void)
 	CycleCounter+=3;
 }
 
-void Sex_I(void)
+void Sex_I()
 { //1D
 	A_REG= 0-(B_REG>>7);
 	cc[Z] = ZTEST(D_REG);
@@ -3733,7 +3733,7 @@ void Sex_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Exg_M(void)
+void Exg_M()
 { //1E
 	postbyte = MemRead8(PC_REG++);
 	Source = postbyte >> 4;
@@ -3798,7 +3798,7 @@ void Exg_M(void)
 	CycleCounter += NatEmuCycles85;
 }
 
-void Tfr_M(void)
+void Tfr_M()
 { //1F
 	postbyte=MemRead8(PC_REG++);
 	Source= postbyte>>4;
@@ -3840,20 +3840,20 @@ void Tfr_M(void)
 	CycleCounter+=NatEmuCycles64;
 }
 
-void Bra_R(void)
+void Bra_R()
 { //20
 	*spostbyte=MemRead8(PC_REG++);
 	PC_REG+=*spostbyte;
 	CycleCounter+=3;
 }
 
-void Brn_R(void)
+void Brn_R()
 { //21
 	CycleCounter+=3;
 	PC_REG++;
 }
 
-void Bhi_R(void)
+void Bhi_R()
 { //22
 	if  (!(cc[C] | cc[Z]))
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3861,7 +3861,7 @@ void Bhi_R(void)
 	CycleCounter+=3;
 }
 
-void Bls_R(void)
+void Bls_R()
 { //23
 	if (cc[C] | cc[Z])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3869,7 +3869,7 @@ void Bls_R(void)
 	CycleCounter+=3;
 }
 
-void Bhs_R(void)
+void Bhs_R()
 { //24
 	if (!cc[C])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3877,7 +3877,7 @@ void Bhs_R(void)
 	CycleCounter+=3;
 }
 
-void Blo_R(void)
+void Blo_R()
 { //25
 	if (cc[C])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3885,7 +3885,7 @@ void Blo_R(void)
 	CycleCounter+=3;
 }
 
-void Bne_R(void)
+void Bne_R()
 { //26
 	if (!cc[Z])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3893,7 +3893,7 @@ void Bne_R(void)
 	CycleCounter+=3;
 }
 
-void Beq_R(void)
+void Beq_R()
 { //27
 	if (cc[Z])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3901,7 +3901,7 @@ void Beq_R(void)
 	CycleCounter+=3;
 }
 
-void Bvc_R(void)
+void Bvc_R()
 { //28
 	if (!cc[V])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3909,7 +3909,7 @@ void Bvc_R(void)
 	CycleCounter+=3;
 }
 
-void Bvs_R(void)
+void Bvs_R()
 { //29
 	if ( cc[V])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3917,7 +3917,7 @@ void Bvs_R(void)
 	CycleCounter+=3;
 }
 
-void Bpl_R(void)
+void Bpl_R()
 { //2A
 	if (!cc[N])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3925,7 +3925,7 @@ void Bpl_R(void)
 	CycleCounter+=3;
 }
 
-void Bmi_R(void)
+void Bmi_R()
 { //2B
 	if ( cc[N])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3933,7 +3933,7 @@ void Bmi_R(void)
 	CycleCounter+=3;
 }
 
-void Bge_R(void)
+void Bge_R()
 { //2C
 	if (! (cc[N] ^ cc[V]))
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3941,7 +3941,7 @@ void Bge_R(void)
 	CycleCounter+=3;
 }
 
-void Blt_R(void)
+void Blt_R()
 { //2D
 	if ( cc[V] ^ cc[N])
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3949,7 +3949,7 @@ void Blt_R(void)
 	CycleCounter+=3;
 }
 
-void Bgt_R(void)
+void Bgt_R()
 { //2E
 	if ( !( cc[Z] | (cc[N]^cc[V] ) ))
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3957,7 +3957,7 @@ void Bgt_R(void)
 	CycleCounter+=3;
 }
 
-void Ble_R(void)
+void Ble_R()
 { //2F
 	if ( cc[Z] | (cc[N]^cc[V]) )
 		PC_REG+=(signed char)MemRead8(PC_REG);
@@ -3965,33 +3965,33 @@ void Ble_R(void)
 	CycleCounter+=3;
 }
 
-void Leax_X(void)
+void Leax_X()
 { //30
 	X_REG=INDADDRESS(PC_REG++);
 	cc[Z] = ZTEST(X_REG);
 	CycleCounter+=4;
 }
 
-void Leay_X(void)
+void Leay_X()
 { //31
 	Y_REG=INDADDRESS(PC_REG++);
 	cc[Z] = ZTEST(Y_REG);
 	CycleCounter+=4;
 }
 
-void Leas_X(void)
+void Leas_X()
 { //32
 	S_REG=INDADDRESS(PC_REG++);
 	CycleCounter+=4;
 }
 
-void Leau_X(void)
+void Leau_X()
 { //33
 	U_REG=INDADDRESS(PC_REG++);
 	CycleCounter+=4;
 }
 
-void Pshs_M(void)
+void Pshs_M()
 { //34
 	postbyte=MemRead8(PC_REG++);
 	if (postbyte & 0x80)
@@ -4042,7 +4042,7 @@ void Pshs_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Puls_M(void)
+void Puls_M()
 { //35
 	postbyte=MemRead8(PC_REG++);
 	if (postbyte & 0x01)
@@ -4092,7 +4092,7 @@ void Puls_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Pshu_M(void)
+void Pshu_M()
 { //36
 	postbyte=MemRead8(PC_REG++);
 	if (postbyte & 0x80)
@@ -4142,7 +4142,7 @@ void Pshu_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Pulu_M(void)
+void Pulu_M()
 { //37
 	postbyte=MemRead8(PC_REG++);
 	if (postbyte & 0x01)
@@ -4192,20 +4192,20 @@ void Pulu_M(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Rts_I(void)
+void Rts_I()
 { //39
 	pc.B.msb=MemRead8(S_REG++);
 	pc.B.lsb=MemRead8(S_REG++);
 	CycleCounter+=NatEmuCycles51;
 }
 
-void Abx_I(void)
+void Abx_I()
 { //3A
 	X_REG=X_REG+B_REG;
 	CycleCounter+=NatEmuCycles31;
 }
 
-void Rti_I(void)
+void Rti_I()
 { //3B
 	setcc(MemRead8(S_REG++));
 	CycleCounter+=6;
@@ -4232,7 +4232,7 @@ void Rti_I(void)
 	pc.B.lsb=MemRead8(S_REG++);
 }
 
-void Cwai_I(void)
+void Cwai_I()
 { //3C
 	postbyte=MemRead8(PC_REG++);
 	ccbits=getcc();
@@ -4242,7 +4242,7 @@ void Cwai_I(void)
 	SyncWaiting=1;
 }
 
-void Mul_I(void)
+void Mul_I()
 { //3D
 	D_REG = A_REG * B_REG;
 	cc[C] = B_REG >0x7F;
@@ -4250,12 +4250,12 @@ void Mul_I(void)
 	CycleCounter+=NatEmuCycles1110;
 }
 
-void Reset(void) // 3E
+void Reset() // 3E
 {	//Undocumented
 	HD6309Reset();
 }
 
-void Swi1_I(void)
+void Swi1_I()
 { //3F
 	cc[E]=1;
 	MemWrite8( pc.B.lsb,--S_REG);
@@ -4282,7 +4282,7 @@ void Swi1_I(void)
 	cc[F]=1;
 }
 
-void Nega_I(void)
+void Nega_I()
 { //40
 	temp8= 0-A_REG;
 	cc[C] = temp8>0;
@@ -4293,7 +4293,7 @@ void Nega_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Coma_I(void)
+void Coma_I()
 { //43
 	A_REG= 0xFF- A_REG;
 	cc[Z] = ZTEST(A_REG);
@@ -4303,7 +4303,7 @@ void Coma_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Lsra_I(void)
+void Lsra_I()
 { //44
 	cc[C] = A_REG & 1;
 	A_REG= A_REG>>1;
@@ -4312,7 +4312,7 @@ void Lsra_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Rora_I(void)
+void Rora_I()
 { //46
 	postbyte=cc[C]<<7;
 	cc[C] = A_REG & 1;
@@ -4322,7 +4322,7 @@ void Rora_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Asra_I(void)
+void Asra_I()
 { //47
 	cc[C] = A_REG & 1;
 	A_REG= (A_REG & 0x80) | (A_REG >> 1);
@@ -4331,7 +4331,7 @@ void Asra_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Asla_I(void)
+void Asla_I()
 { //48
 	cc[C] = A_REG > 0x7F;
 	cc[V] =  cc[C] ^((A_REG & 0x40)>>6);
@@ -4341,7 +4341,7 @@ void Asla_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Rola_I(void)
+void Rola_I()
 { //49
 	postbyte=cc[C];
 	cc[C] = A_REG > 0x7F;
@@ -4352,7 +4352,7 @@ void Rola_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Deca_I(void)
+void Deca_I()
 { //4A
 	A_REG--;
 	cc[Z] = ZTEST(A_REG);
@@ -4361,7 +4361,7 @@ void Deca_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Inca_I(void)
+void Inca_I()
 { //4C
 	A_REG++;
 	cc[Z] = ZTEST(A_REG);
@@ -4370,7 +4370,7 @@ void Inca_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Tsta_I(void)
+void Tsta_I()
 { //4D
 	cc[Z] = ZTEST(A_REG);
 	cc[N] = NTEST8(A_REG);
@@ -4378,7 +4378,7 @@ void Tsta_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Clra_I(void)
+void Clra_I()
 { //4F
 	A_REG= 0;
 	cc[C] =0;
@@ -4388,7 +4388,7 @@ void Clra_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Negb_I(void)
+void Negb_I()
 { //50
 	temp8= 0-B_REG;
 	cc[C] = temp8>0;
@@ -4399,7 +4399,7 @@ void Negb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Comb_I(void)
+void Comb_I()
 { //53
 	B_REG= 0xFF- B_REG;
 	cc[Z] = ZTEST(B_REG);
@@ -4409,7 +4409,7 @@ void Comb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Lsrb_I(void)
+void Lsrb_I()
 { //54
 	cc[C] = B_REG & 1;
 	B_REG= B_REG>>1;
@@ -4418,7 +4418,7 @@ void Lsrb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Rorb_I(void)
+void Rorb_I()
 { //56
 	postbyte=cc[C]<<7;
 	cc[C] = B_REG & 1;
@@ -4428,7 +4428,7 @@ void Rorb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Asrb_I(void)
+void Asrb_I()
 { //57
 	cc[C] = B_REG & 1;
 	B_REG= (B_REG & 0x80) | (B_REG >> 1);
@@ -4437,7 +4437,7 @@ void Asrb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Aslb_I(void)
+void Aslb_I()
 { //58
 	cc[C] = B_REG > 0x7F;
 	cc[V] =  cc[C] ^((B_REG & 0x40)>>6);
@@ -4447,7 +4447,7 @@ void Aslb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Rolb_I(void)
+void Rolb_I()
 { //59
 	postbyte=cc[C];
 	cc[C] = B_REG > 0x7F;
@@ -4458,7 +4458,7 @@ void Rolb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Decb_I(void)
+void Decb_I()
 { //5A
 	B_REG--;
 	cc[Z] = ZTEST(B_REG);
@@ -4467,7 +4467,7 @@ void Decb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Incb_I(void)
+void Incb_I()
 { //5C
 	B_REG++;
 	cc[Z] = ZTEST(B_REG);
@@ -4476,7 +4476,7 @@ void Incb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Tstb_I(void)
+void Tstb_I()
 { //5D
 	cc[Z] = ZTEST(B_REG);
 	cc[N] = NTEST8(B_REG);
@@ -4484,7 +4484,7 @@ void Tstb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Clrb_I(void)
+void Clrb_I()
 { //5F
 	B_REG=0;
 	cc[C] =0;
@@ -4494,7 +4494,7 @@ void Clrb_I(void)
 	CycleCounter+=NatEmuCycles21;
 }
 
-void Neg_X(void)
+void Neg_X()
 { //60
 	temp16=INDADDRESS(PC_REG++);	
 	postbyte=MemRead8(temp16);
@@ -4507,7 +4507,7 @@ void Neg_X(void)
 	CycleCounter+=6;
 }
 
-void Oim_X(void)
+void Oim_X()
 { //61 6309 DONE
 	postbyte=MemRead8(PC_REG++);
 	temp16=INDADDRESS(PC_REG++);
@@ -4519,7 +4519,7 @@ void Oim_X(void)
 	CycleCounter+=6;
 }
 
-void Aim_X(void)
+void Aim_X()
 { //62 6309 Phase 2
 	postbyte=MemRead8(PC_REG++);
 	temp16=INDADDRESS(PC_REG++);
@@ -4531,7 +4531,7 @@ void Aim_X(void)
 	CycleCounter+=6;
 }
 
-void Com_X(void)
+void Com_X()
 { //63
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4544,7 +4544,7 @@ void Com_X(void)
 	CycleCounter+=6;
 }
 
-void Lsr_X(void)
+void Lsr_X()
 { //64
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4556,7 +4556,7 @@ void Lsr_X(void)
 	CycleCounter+=6;
 }
 
-void Eim_X(void)
+void Eim_X()
 { //65 6309 Untested TESTED NITRO
 	postbyte=MemRead8(PC_REG++);
 	temp16=INDADDRESS(PC_REG++);
@@ -4568,7 +4568,7 @@ void Eim_X(void)
 	CycleCounter+=7;
 }
 
-void Ror_X(void)
+void Ror_X()
 { //66
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4581,7 +4581,7 @@ void Ror_X(void)
 	CycleCounter+=6;
 }
 
-void Asr_X(void)
+void Asr_X()
 { //67
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4593,7 +4593,7 @@ void Asr_X(void)
 	CycleCounter+=6;
 }
 
-void Asl_X(void)
+void Asl_X()
 { //68 
 	temp16=INDADDRESS(PC_REG++);
 	temp8= MemRead8(temp16);
@@ -4606,7 +4606,7 @@ void Asl_X(void)
 	CycleCounter+=6;
 }
 
-void Rol_X(void)
+void Rol_X()
 { //69
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4620,7 +4620,7 @@ void Rol_X(void)
 	CycleCounter+=6;
 }
 
-void Dec_X(void)
+void Dec_X()
 { //6A
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4632,7 +4632,7 @@ void Dec_X(void)
 	CycleCounter+=6;
 }
 
-void Tim_X(void)
+void Tim_X()
 { //6B 6309
 	postbyte=MemRead8(PC_REG++);
 	temp8=MemRead8(INDADDRESS(PC_REG++));
@@ -4643,7 +4643,7 @@ void Tim_X(void)
 	CycleCounter+=7;
 }
 
-void Inc_X(void)
+void Inc_X()
 { //6C
 	temp16=INDADDRESS(PC_REG++);
 	temp8=MemRead8(temp16);
@@ -4655,7 +4655,7 @@ void Inc_X(void)
 	CycleCounter+=6;
 }
 
-void Tst_X(void)
+void Tst_X()
 { //6D
 	temp8=MemRead8(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(temp8);
@@ -4664,13 +4664,13 @@ void Tst_X(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Jmp_X(void)
+void Jmp_X()
 { //6E
 	PC_REG=INDADDRESS(PC_REG++);
 	CycleCounter+=3;
 }
 
-void Clr_X(void)
+void Clr_X()
 { //6F
 	MemWrite8(0,INDADDRESS(PC_REG++));
 	cc[C] = 0;
@@ -4680,7 +4680,7 @@ void Clr_X(void)
 	CycleCounter+=6;
 }
 
-void Neg_E(void)
+void Neg_E()
 { //70
 	temp16=IMMADDRESS(PC_REG);
 	postbyte=MemRead8(temp16);
@@ -4694,7 +4694,7 @@ void Neg_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Oim_E(void)
+void Oim_E()
 { //71 6309 Phase 2
 	postbyte=MemRead8(PC_REG++);
 	temp16=IMMADDRESS(PC_REG);
@@ -4707,7 +4707,7 @@ void Oim_E(void)
 	CycleCounter+=7;
 }
 
-void Aim_E(void)
+void Aim_E()
 { //72 6309 Untested CHECK NITRO
 	postbyte=MemRead8(PC_REG++);
 	temp16=IMMADDRESS(PC_REG);
@@ -4720,7 +4720,7 @@ void Aim_E(void)
 	CycleCounter+=7;
 }
 
-void Com_E(void)
+void Com_E()
 { //73
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4734,7 +4734,7 @@ void Com_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Lsr_E(void)
+void Lsr_E()
 {  //74
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4747,7 +4747,7 @@ void Lsr_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Eim_E(void)
+void Eim_E()
 { //75 6309 Untested CHECK NITRO
 	postbyte=MemRead8(PC_REG++);
 	temp16=IMMADDRESS(PC_REG);
@@ -4760,7 +4760,7 @@ void Eim_E(void)
 	CycleCounter+=7;
 }
 
-void Ror_E(void)
+void Ror_E()
 { //76
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4774,7 +4774,7 @@ void Ror_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Asr_E(void)
+void Asr_E()
 { //77
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4787,7 +4787,7 @@ void Asr_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Asl_E(void)
+void Asl_E()
 { //78 6309
 	temp16=IMMADDRESS(PC_REG);
 	temp8= MemRead8(temp16);
@@ -4801,7 +4801,7 @@ void Asl_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Rol_E(void)
+void Rol_E()
 { //79
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4816,7 +4816,7 @@ void Rol_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Dec_E(void)
+void Dec_E()
 { //7A
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4829,7 +4829,7 @@ void Dec_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Tim_E(void)
+void Tim_E()
 { //7B 6309 NITRO 
 	postbyte=MemRead8(PC_REG++);
 	temp16=IMMADDRESS(PC_REG);
@@ -4841,7 +4841,7 @@ void Tim_E(void)
 	CycleCounter+=7;
 }
 
-void Inc_E(void)
+void Inc_E()
 { //7C
 	temp16=IMMADDRESS(PC_REG);
 	temp8=MemRead8(temp16);
@@ -4854,7 +4854,7 @@ void Inc_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Tst_E(void)
+void Tst_E()
 { //7D
 	temp8=MemRead8(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(temp8);
@@ -4864,13 +4864,13 @@ void Tst_E(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Jmp_E(void)
+void Jmp_E()
 { //7E
 	PC_REG=IMMADDRESS(PC_REG);
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Clr_E(void)
+void Clr_E()
 { //7F
 	MemWrite8(0,IMMADDRESS(PC_REG));
 	cc[C] = 0;
@@ -4881,7 +4881,7 @@ void Clr_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Suba_M(void)
+void Suba_M()
 { //80
 	postbyte=MemRead8(PC_REG++);
 	temp16 = A_REG - postbyte;
@@ -4893,7 +4893,7 @@ void Suba_M(void)
 	CycleCounter+=2;
 }
 
-void Cmpa_M(void)
+void Cmpa_M()
 { //81
 	postbyte=MemRead8(PC_REG++);
 	temp8= A_REG-postbyte;
@@ -4904,7 +4904,7 @@ void Cmpa_M(void)
 	CycleCounter+=2;
 }
 
-void Sbca_M(void)
+void Sbca_M()
 {  //82
 	postbyte=MemRead8(PC_REG++);
 	temp16=A_REG-postbyte-cc[C];
@@ -4916,7 +4916,7 @@ void Sbca_M(void)
 	CycleCounter+=2;
 }
 
-void Subd_M(void)
+void Subd_M()
 { //83
 	temp16=IMMADDRESS(PC_REG);
 	temp32=D_REG-temp16;
@@ -4929,7 +4929,7 @@ void Subd_M(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Anda_M(void)
+void Anda_M()
 { //84
 	A_REG = A_REG & MemRead8(PC_REG++);
 	cc[N] = NTEST8(A_REG);
@@ -4938,7 +4938,7 @@ void Anda_M(void)
 	CycleCounter+=2;
 }
 
-void Bita_M(void)
+void Bita_M()
 { //85
 	temp8 = A_REG & MemRead8(PC_REG++);
 	cc[N] = NTEST8(temp8);
@@ -4947,7 +4947,7 @@ void Bita_M(void)
 	CycleCounter+=2;
 }
 
-void Lda_M(void)
+void Lda_M()
 { //86
 	A_REG = MemRead8(PC_REG++);
 	cc[Z] = ZTEST(A_REG);
@@ -4956,7 +4956,7 @@ void Lda_M(void)
 	CycleCounter+=2;
 }
 
-void Eora_M(void)
+void Eora_M()
 { //88
 	A_REG = A_REG ^ MemRead8(PC_REG++);
 	cc[N] = NTEST8(A_REG);
@@ -4965,7 +4965,7 @@ void Eora_M(void)
 	CycleCounter+=2;
 }
 
-void Adca_M(void)
+void Adca_M()
 { //89
 	postbyte=MemRead8(PC_REG++);
 	temp16= A_REG + postbyte + cc[C];
@@ -4978,7 +4978,7 @@ void Adca_M(void)
 	CycleCounter+=2;
 }
 
-void Ora_M(void)
+void Ora_M()
 { //8A
 	A_REG = A_REG | MemRead8(PC_REG++);
 	cc[N] = NTEST8(A_REG);
@@ -4987,7 +4987,7 @@ void Ora_M(void)
 	CycleCounter+=2;
 }
 
-void Adda_M(void)
+void Adda_M()
 { //8B
 	postbyte=MemRead8(PC_REG++);
 	temp16=A_REG+postbyte;
@@ -5000,7 +5000,7 @@ void Adda_M(void)
 	CycleCounter+=2;
 }
 
-void Cmpx_M(void)
+void Cmpx_M()
 { //8C
 	postword=IMMADDRESS(PC_REG);
 	temp16 = X_REG-postword;
@@ -5012,7 +5012,7 @@ void Cmpx_M(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Bsr_R(void)
+void Bsr_R()
 { //8D
 	*spostbyte=MemRead8(PC_REG++);
 	S_REG--;
@@ -5022,7 +5022,7 @@ void Bsr_R(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ldx_M(void)
+void Ldx_M()
 { //8E
 	X_REG = IMMADDRESS(PC_REG);
 	cc[Z] = ZTEST(X_REG);
@@ -5032,7 +5032,7 @@ void Ldx_M(void)
 	CycleCounter+=3;
 }
 
-void Suba_D(void)
+void Suba_D()
 { //90
 	postbyte=MemRead8( DPADDRESS(PC_REG++));
 	temp16 = A_REG - postbyte;
@@ -5044,7 +5044,7 @@ void Suba_D(void)
 	CycleCounter+=NatEmuCycles43;
 }	
 
-void Cmpa_D(void)
+void Cmpa_D()
 { //91
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp8 = A_REG-postbyte;
@@ -5055,7 +5055,7 @@ void Cmpa_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Scba_D(void)
+void Scba_D()
 { //92
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16=A_REG-postbyte-cc[C];
@@ -5067,7 +5067,7 @@ void Scba_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Subd_D(void)
+void Subd_D()
 { //93
 	temp16= MemRead16(DPADDRESS(PC_REG++));
 	temp32= D_REG-temp16;
@@ -5079,7 +5079,7 @@ void Subd_D(void)
 	CycleCounter+=NatEmuCycles64;
 }
 
-void Anda_D(void)
+void Anda_D()
 { //94
 	A_REG = A_REG & MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(A_REG);
@@ -5088,7 +5088,7 @@ void Anda_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Bita_D(void)
+void Bita_D()
 { //95
 	temp8 = A_REG & MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(temp8);
@@ -5097,7 +5097,7 @@ void Bita_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Lda_D(void)
+void Lda_D()
 { //96
 	A_REG = MemRead8(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(A_REG);
@@ -5106,7 +5106,7 @@ void Lda_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Sta_D(void)
+void Sta_D()
 { //97
 	MemWrite8( A_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(A_REG);
@@ -5115,7 +5115,7 @@ void Sta_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Eora_D(void)
+void Eora_D()
 { //98
 	A_REG= A_REG ^ MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(A_REG);
@@ -5124,7 +5124,7 @@ void Eora_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Adca_D(void)
+void Adca_D()
 { //99
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16= A_REG + postbyte + cc[C];
@@ -5137,7 +5137,7 @@ void Adca_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Ora_D(void)
+void Ora_D()
 { //9A
 	A_REG = A_REG | MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(A_REG);
@@ -5146,7 +5146,7 @@ void Ora_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Adda_D(void)
+void Adda_D()
 { //9B
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16=A_REG+postbyte;
@@ -5159,7 +5159,7 @@ void Adda_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Cmpx_D(void)
+void Cmpx_D()
 { //9C
 	postword=MemRead16(DPADDRESS(PC_REG++));
 	temp16= X_REG - postword ;
@@ -5170,7 +5170,7 @@ void Cmpx_D(void)
 	CycleCounter+=NatEmuCycles64;
 }
 
-void Jsr_D(void)
+void Jsr_D()
 { //9D
 	temp16 = DPADDRESS(PC_REG++);
 	S_REG--;
@@ -5180,7 +5180,7 @@ void Jsr_D(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ldx_D(void)
+void Ldx_D()
 { //9E
 	X_REG=MemRead16(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(X_REG);	
@@ -5189,7 +5189,7 @@ void Ldx_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Stx_D(void)
+void Stx_D()
 { //9F
 	MemWrite16(X_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(X_REG);
@@ -5198,7 +5198,7 @@ void Stx_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Suba_X(void)
+void Suba_X()
 { //A0
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16 = A_REG - postbyte;
@@ -5210,7 +5210,7 @@ void Suba_X(void)
 	CycleCounter+=4;
 }	
 
-void Cmpa_X(void)
+void Cmpa_X()
 { //A1
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp8= A_REG-postbyte;
@@ -5221,7 +5221,7 @@ void Cmpa_X(void)
 	CycleCounter+=4;
 }
 
-void Sbca_X(void)
+void Sbca_X()
 { //A2
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16=A_REG-postbyte-cc[C];
@@ -5233,7 +5233,7 @@ void Sbca_X(void)
 	CycleCounter+=4;
 }
 
-void Subd_X(void)
+void Subd_X()
 { //A3
 	temp16= MemRead16(INDADDRESS(PC_REG++));
 	temp32= D_REG-temp16;
@@ -5245,7 +5245,7 @@ void Subd_X(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Anda_X(void)
+void Anda_X()
 { //A4
 	A_REG = A_REG & MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(A_REG);
@@ -5254,7 +5254,7 @@ void Anda_X(void)
 	CycleCounter+=4;
 }
 
-void Bita_X(void)
+void Bita_X()
 {  //A5
 	temp8 = A_REG & MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(temp8);
@@ -5263,7 +5263,7 @@ void Bita_X(void)
 	CycleCounter+=4;
 }
 
-void Lda_X(void)
+void Lda_X()
 { //A6
 	A_REG = MemRead8(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(A_REG);
@@ -5272,7 +5272,7 @@ void Lda_X(void)
 	CycleCounter+=4;
 }
 
-void Sta_X(void)
+void Sta_X()
 { //A7
 	MemWrite8(A_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(A_REG);
@@ -5281,7 +5281,7 @@ void Sta_X(void)
 	CycleCounter+=4;
 }
 
-void Eora_X(void)
+void Eora_X()
 { //A8
 	A_REG= A_REG ^ MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(A_REG);
@@ -5290,7 +5290,7 @@ void Eora_X(void)
 	CycleCounter+=4;
 }
 
-void Adca_X(void)
+void Adca_X()
 { //A9	
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16= A_REG + postbyte + cc[C];
@@ -5303,7 +5303,7 @@ void Adca_X(void)
 	CycleCounter+=4;
 }
 
-void Ora_X(void)
+void Ora_X()
 { //AA
 	A_REG= A_REG | MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(A_REG);
@@ -5312,7 +5312,7 @@ void Ora_X(void)
 	CycleCounter+=4;
 }
 
-void Adda_X(void)
+void Adda_X()
 { //AB
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16= A_REG+postbyte;
@@ -5325,7 +5325,7 @@ void Adda_X(void)
 	CycleCounter+=4;
 }
 
-void Cmpx_X(void)
+void Cmpx_X()
 { //AC
 	postword=MemRead16(INDADDRESS(PC_REG++));
 	temp16= X_REG - postword ;
@@ -5336,7 +5336,7 @@ void Cmpx_X(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Jsr_X(void)
+void Jsr_X()
 { //AD
 	temp16=INDADDRESS(PC_REG++);
 	S_REG--;
@@ -5346,7 +5346,7 @@ void Jsr_X(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Ldx_X(void)
+void Ldx_X()
 { //AE
 	X_REG=MemRead16(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(X_REG);
@@ -5355,7 +5355,7 @@ void Ldx_X(void)
 	CycleCounter+=5;
 }
 
-void Stx_X(void)
+void Stx_X()
 { //AF
 	MemWrite16(X_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(X_REG);
@@ -5364,7 +5364,7 @@ void Stx_X(void)
 	CycleCounter+=5;
 }
 
-void Suba_E(void)
+void Suba_E()
 { //B0
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16 = A_REG - postbyte;
@@ -5377,7 +5377,7 @@ void Suba_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpa_E(void)
+void Cmpa_E()
 { //B1
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp8= A_REG-postbyte;
@@ -5389,7 +5389,7 @@ void Cmpa_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Sbca_E(void)
+void Sbca_E()
 { //B2
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16=A_REG-postbyte-cc[C];
@@ -5402,7 +5402,7 @@ void Sbca_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Subd_E(void)
+void Subd_E()
 { //B3
 	temp16=MemRead16(IMMADDRESS(PC_REG));
 	temp32=D_REG-temp16;
@@ -5415,7 +5415,7 @@ void Subd_E(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Anda_E(void)
+void Anda_E()
 { //B4
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	A_REG = A_REG & postbyte;
@@ -5426,7 +5426,7 @@ void Anda_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Bita_E(void)
+void Bita_E()
 { //B5
 	temp8 = A_REG & MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(temp8);
@@ -5436,7 +5436,7 @@ void Bita_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Lda_E(void)
+void Lda_E()
 { //B6
 	A_REG= MemRead8(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(A_REG);
@@ -5446,7 +5446,7 @@ void Lda_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Sta_E(void)
+void Sta_E()
 { //B7
 	MemWrite8(A_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(A_REG);
@@ -5456,7 +5456,7 @@ void Sta_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Eora_E(void)
+void Eora_E()
 {  //B8
 	A_REG = A_REG ^ MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(A_REG);
@@ -5466,7 +5466,7 @@ void Eora_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Adca_E(void)
+void Adca_E()
 { //B9
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16= A_REG + postbyte + cc[C];
@@ -5480,7 +5480,7 @@ void Adca_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ora_E(void)
+void Ora_E()
 { //BA
 	A_REG = A_REG | MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(A_REG);
@@ -5490,7 +5490,7 @@ void Ora_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Adda_E(void)
+void Adda_E()
 { //BB
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16=A_REG+postbyte;
@@ -5504,7 +5504,7 @@ void Adda_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpx_E(void)
+void Cmpx_E()
 { //BC
 	postword=MemRead16(IMMADDRESS(PC_REG));
 	temp16 = X_REG-postword;
@@ -5516,7 +5516,7 @@ void Cmpx_E(void)
 	CycleCounter+=NatEmuCycles75;
 }
 
-void Bsr_E(void)
+void Bsr_E()
 { //BD
 	postword=IMMADDRESS(PC_REG);
 	PC_REG+=2;
@@ -5527,7 +5527,7 @@ void Bsr_E(void)
 	CycleCounter+=NatEmuCycles87;
 }
 
-void Ldx_E(void)
+void Ldx_E()
 { //BE
 	X_REG=MemRead16(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(X_REG);
@@ -5537,7 +5537,7 @@ void Ldx_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Stx_E(void)
+void Stx_E()
 { //BF
 	MemWrite16(X_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(X_REG);
@@ -5547,7 +5547,7 @@ void Stx_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Subb_M(void)
+void Subb_M()
 { //C0
 	postbyte=MemRead8(PC_REG++);
 	temp16 = B_REG - postbyte;
@@ -5559,7 +5559,7 @@ void Subb_M(void)
 	CycleCounter+=2;
 }
 
-void Cmpb_M(void)
+void Cmpb_M()
 { //C1
 	postbyte=MemRead8(PC_REG++);
 	temp8= B_REG-postbyte;
@@ -5570,7 +5570,7 @@ void Cmpb_M(void)
 	CycleCounter+=2;
 }
 
-void Sbcb_M(void)
+void Sbcb_M()
 { //C2
 	postbyte=MemRead8(PC_REG++);
 	temp16=B_REG-postbyte-cc[C];
@@ -5582,7 +5582,7 @@ void Sbcb_M(void)
 	CycleCounter+=2;
 }
 
-void Addd_M(void)
+void Addd_M()
 { //C3
 	temp16=IMMADDRESS(PC_REG);
 	temp32= D_REG+ temp16;
@@ -5595,7 +5595,7 @@ void Addd_M(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Andb_M(void)
+void Andb_M()
 { //C4 LOOK
 	B_REG = B_REG & MemRead8(PC_REG++);
 	cc[N] = NTEST8(B_REG);
@@ -5604,7 +5604,7 @@ void Andb_M(void)
 	CycleCounter+=2;
 }
 
-void Bitb_M(void)
+void Bitb_M()
 { //C5
 	temp8 = B_REG & MemRead8(PC_REG++);
 	cc[N] = NTEST8(temp8);
@@ -5613,7 +5613,7 @@ void Bitb_M(void)
 	CycleCounter+=2;
 }
 
-void Ldb_M(void)
+void Ldb_M()
 { //C6
 	B_REG=MemRead8(PC_REG++);
 	cc[Z] = ZTEST(B_REG);
@@ -5622,7 +5622,7 @@ void Ldb_M(void)
 	CycleCounter+=2;
 }
 
-void Eorb_M(void)
+void Eorb_M()
 { //C8
 	B_REG = B_REG ^ MemRead8(PC_REG++);
 	cc[N] =NTEST8(B_REG);
@@ -5631,7 +5631,7 @@ void Eorb_M(void)
 	CycleCounter+=2;
 }
 
-void Adcb_M(void)
+void Adcb_M()
 { //C9
 	postbyte=MemRead8(PC_REG++);
 	temp16= B_REG + postbyte + cc[C];
@@ -5644,7 +5644,7 @@ void Adcb_M(void)
 	CycleCounter+=2;
 }
 
-void Orb_M(void)
+void Orb_M()
 { //CA
 	B_REG= B_REG | MemRead8(PC_REG++);
 	cc[N] = NTEST8(B_REG);
@@ -5653,7 +5653,7 @@ void Orb_M(void)
 	CycleCounter+=2;
 }
 
-void Addb_M(void)
+void Addb_M()
 { //CB
 	postbyte=MemRead8(PC_REG++);
 	temp16=B_REG+postbyte;
@@ -5666,7 +5666,7 @@ void Addb_M(void)
 	CycleCounter+=2;
 }
 
-void Ldd_M(void)
+void Ldd_M()
 { //CC
 	D_REG=IMMADDRESS(PC_REG);
 	cc[Z] = ZTEST(D_REG);
@@ -5676,7 +5676,7 @@ void Ldd_M(void)
 	CycleCounter+=3;
 }
 
-void Ldq_M(void)
+void Ldq_M()
 { //CD 6309 WORK
 	Q_REG = MemRead32(PC_REG);
 	PC_REG+=4;
@@ -5686,7 +5686,7 @@ void Ldq_M(void)
 	CycleCounter+=5;
 }
 
-void Ldu_M(void)
+void Ldu_M()
 { //CE
 	U_REG = IMMADDRESS(PC_REG);
 	cc[Z] = ZTEST(U_REG);
@@ -5696,7 +5696,7 @@ void Ldu_M(void)
 	CycleCounter+=3;
 }
 
-void Subb_D(void)
+void Subb_D()
 { //D0
 	postbyte=MemRead8( DPADDRESS(PC_REG++));
 	temp16 = B_REG - postbyte;
@@ -5708,7 +5708,7 @@ void Subb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Cmpb_D(void)
+void Cmpb_D()
 { //D1
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp8= B_REG-postbyte;
@@ -5719,7 +5719,7 @@ void Cmpb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Sbcb_D(void)
+void Sbcb_D()
 { //D2
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16=B_REG-postbyte-cc[C];
@@ -5731,7 +5731,7 @@ void Sbcb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Addd_D(void)
+void Addd_D()
 { //D3
 	temp16=MemRead16( DPADDRESS(PC_REG++));
 	temp32= D_REG+ temp16;
@@ -5743,7 +5743,7 @@ void Addd_D(void)
 	CycleCounter+=NatEmuCycles64;
 }
 
-void Andb_D(void)
+void Andb_D()
 { //D4 
 	B_REG = B_REG & MemRead8(DPADDRESS(PC_REG++));
 	cc[N] =NTEST8(B_REG);
@@ -5752,7 +5752,7 @@ void Andb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Bitb_D(void)
+void Bitb_D()
 { //D5
 	temp8 = B_REG & MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(temp8);
@@ -5761,7 +5761,7 @@ void Bitb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Ldb_D(void)
+void Ldb_D()
 { //D6
 	B_REG= MemRead8( DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(B_REG);
@@ -5770,7 +5770,7 @@ void Ldb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Stb_D(void)
+void Stb_D()
 { //D7
 	MemWrite8( B_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(B_REG);
@@ -5779,7 +5779,7 @@ void Stb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Eorb_D(void)
+void Eorb_D()
 { //D8	
 	B_REG = B_REG ^ MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(B_REG);
@@ -5788,7 +5788,7 @@ void Eorb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Adcb_D(void)
+void Adcb_D()
 { //D9
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16= B_REG + postbyte + cc[C];
@@ -5801,7 +5801,7 @@ void Adcb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Orb_D(void)
+void Orb_D()
 { //DA
 	B_REG = B_REG | MemRead8(DPADDRESS(PC_REG++));
 	cc[N] = NTEST8(B_REG);
@@ -5810,7 +5810,7 @@ void Orb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Addb_D(void)
+void Addb_D()
 { //DB
 	postbyte=MemRead8(DPADDRESS(PC_REG++));
 	temp16= B_REG+postbyte;
@@ -5823,7 +5823,7 @@ void Addb_D(void)
 	CycleCounter+=NatEmuCycles43;
 }
 
-void Ldd_D(void)
+void Ldd_D()
 { //DC
 	D_REG = MemRead16(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(D_REG);
@@ -5832,7 +5832,7 @@ void Ldd_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Std_D(void)
+void Std_D()
 { //DD
 	MemWrite16(D_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(D_REG);
@@ -5841,7 +5841,7 @@ void Std_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ldu_D(void)
+void Ldu_D()
 { //DE
 	U_REG = MemRead16(DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(U_REG);
@@ -5850,7 +5850,7 @@ void Ldu_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Stu_D(void)
+void Stu_D()
 { //DF
 	MemWrite16(U_REG,DPADDRESS(PC_REG++));
 	cc[Z] = ZTEST(U_REG);
@@ -5859,7 +5859,7 @@ void Stu_D(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Subb_X(void)
+void Subb_X()
 { //E0
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16 = B_REG - postbyte;
@@ -5871,7 +5871,7 @@ void Subb_X(void)
 	CycleCounter+=4;
 }
 
-void Cmpb_X(void)
+void Cmpb_X()
 { //E1
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp8 = B_REG-postbyte;
@@ -5882,7 +5882,7 @@ void Cmpb_X(void)
 	CycleCounter+=4;
 }
 
-void Sbcb_X(void)
+void Sbcb_X()
 { //E2
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16=B_REG-postbyte-cc[C];
@@ -5894,7 +5894,7 @@ void Sbcb_X(void)
 	CycleCounter+=4;
 }
 
-void Addd_X(void)
+void Addd_X()
 { //E3 
 	temp16=MemRead16(INDADDRESS(PC_REG++));
 	temp32= D_REG+ temp16;
@@ -5906,7 +5906,7 @@ void Addd_X(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Andb_X(void)
+void Andb_X()
 { //E4
 	B_REG = B_REG & MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(B_REG);
@@ -5915,7 +5915,7 @@ void Andb_X(void)
 	CycleCounter+=4;
 }
 
-void Bitb_X(void)
+void Bitb_X()
 { //E5 
 	temp8 = B_REG & MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(temp8);
@@ -5924,7 +5924,7 @@ void Bitb_X(void)
 	CycleCounter+=4;
 }
 
-void Ldb_X(void)
+void Ldb_X()
 { //E6
 	B_REG=MemRead8(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(B_REG);
@@ -5933,7 +5933,7 @@ void Ldb_X(void)
 	CycleCounter+=4;
 }
 
-void Stb_X(void)
+void Stb_X()
 { //E7
 	MemWrite8(B_REG,CalculateEA( MemRead8(PC_REG++)));
 	cc[Z] = ZTEST(B_REG);
@@ -5942,7 +5942,7 @@ void Stb_X(void)
 	CycleCounter+=4;
 }
 
-void Eorb_X(void)
+void Eorb_X()
 { //E8
 	B_REG= B_REG ^ MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(B_REG);
@@ -5951,7 +5951,7 @@ void Eorb_X(void)
 	CycleCounter+=4;
 }
 
-void Adcb_X(void)
+void Adcb_X()
 { //E9
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16= B_REG + postbyte + cc[C];
@@ -5964,7 +5964,7 @@ void Adcb_X(void)
 	CycleCounter+=4;
 }
 
-void Orb_X(void)
+void Orb_X()
 { //EA 
 	B_REG = B_REG | MemRead8(INDADDRESS(PC_REG++));
 	cc[N] = NTEST8(B_REG);
@@ -5973,7 +5973,7 @@ void Orb_X(void)
 	CycleCounter+=4;
 }
 
-void Addb_X(void)
+void Addb_X()
 { //EB
 	postbyte=MemRead8(INDADDRESS(PC_REG++));
 	temp16=B_REG+postbyte;
@@ -5986,7 +5986,7 @@ void Addb_X(void)
 	CycleCounter+=4;
 }
 
-void Ldd_X(void)
+void Ldd_X()
 { //EC
 	D_REG=MemRead16(INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(D_REG);
@@ -5995,7 +5995,7 @@ void Ldd_X(void)
 	CycleCounter+=5;
 }
 
-void Std_X(void)
+void Std_X()
 { //ED
 	MemWrite16(D_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(D_REG);
@@ -6004,7 +6004,7 @@ void Std_X(void)
 	CycleCounter+=5;
 }
 
-void Ldu_X(void)
+void Ldu_X()
 { //EE
 	U_REG=MemRead16(INDADDRESS(PC_REG++));
 	cc[Z] =ZTEST(U_REG);
@@ -6013,7 +6013,7 @@ void Ldu_X(void)
 	CycleCounter+=5;
 }
 
-void Stu_X(void)
+void Stu_X()
 { //EF
 	MemWrite16(U_REG,INDADDRESS(PC_REG++));
 	cc[Z] = ZTEST(U_REG);
@@ -6022,7 +6022,7 @@ void Stu_X(void)
 	CycleCounter+=5;
 }
 
-void Subb_E(void)
+void Subb_E()
 { //F0
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16 = B_REG - postbyte;
@@ -6035,7 +6035,7 @@ void Subb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Cmpb_E(void)
+void Cmpb_E()
 { //F1
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp8= B_REG-postbyte;
@@ -6047,7 +6047,7 @@ void Cmpb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Sbcb_E(void)
+void Sbcb_E()
 { //F2
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16=B_REG-postbyte-cc[C];
@@ -6060,7 +6060,7 @@ void Sbcb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Addd_E(void)
+void Addd_E()
 { //F3
 	temp16=MemRead16(IMMADDRESS(PC_REG));
 	temp32= D_REG+ temp16;
@@ -6073,7 +6073,7 @@ void Addd_E(void)
 	CycleCounter+=NatEmuCycles76;
 }
 
-void Andb_E(void)
+void Andb_E()
 {  //F4
 	B_REG = B_REG & MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(B_REG);
@@ -6083,7 +6083,7 @@ void Andb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Bitb_E(void)
+void Bitb_E()
 { //F5
 	temp8 = B_REG & MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(temp8);
@@ -6093,7 +6093,7 @@ void Bitb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ldb_E(void)
+void Ldb_E()
 { //F6
 	B_REG=MemRead8(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(B_REG);
@@ -6103,7 +6103,7 @@ void Ldb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Stb_E(void)
+void Stb_E()
 { //F7 
 	MemWrite8(B_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(B_REG);
@@ -6113,7 +6113,7 @@ void Stb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Eorb_E(void)
+void Eorb_E()
 { //F8
 	B_REG = B_REG ^ MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(B_REG);
@@ -6123,7 +6123,7 @@ void Eorb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Adcb_E(void)
+void Adcb_E()
 { //F9
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16= B_REG + postbyte + cc[C];
@@ -6137,7 +6137,7 @@ void Adcb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Orb_E(void)
+void Orb_E()
 { //FA
 	B_REG = B_REG | MemRead8(IMMADDRESS(PC_REG));
 	cc[N] = NTEST8(B_REG);
@@ -6147,7 +6147,7 @@ void Orb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Addb_E(void)
+void Addb_E()
 { //FB
 	postbyte=MemRead8(IMMADDRESS(PC_REG));
 	temp16=B_REG+postbyte;
@@ -6161,7 +6161,7 @@ void Addb_E(void)
 	CycleCounter+=NatEmuCycles54;
 }
 
-void Ldd_E(void)
+void Ldd_E()
 { //FC
 	D_REG=MemRead16(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(D_REG);
@@ -6171,7 +6171,7 @@ void Ldd_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Std_E(void)
+void Std_E()
 { //FD
 	MemWrite16(D_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(D_REG);
@@ -6181,7 +6181,7 @@ void Std_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Ldu_E(void)
+void Ldu_E()
 { //FE
 	U_REG= MemRead16(IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(U_REG);
@@ -6191,7 +6191,7 @@ void Ldu_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Stu_E(void)
+void Stu_E()
 { //FF
 	MemWrite16(U_REG,IMMADDRESS(PC_REG));
 	cc[Z] = ZTEST(U_REG);
@@ -6201,7 +6201,7 @@ void Stu_E(void)
 	CycleCounter+=NatEmuCycles65;
 }
 
-void Halt(void)
+void Halt()
 {
 	if (EmuState.Debugger.Halt_Enabled()) {
 		HaltedInsPending = 1;
@@ -6213,7 +6213,7 @@ void Halt(void)
 	}
 }
 
-void Break(void)
+void Break()
 {
 	if (EmuState.Debugger.Break_Enabled()) {
 		EmuState.Debugger.Halt();
@@ -6222,7 +6222,7 @@ void Break(void)
 	}
 }
 
-void(*JmpVec1[256])(void) = {
+void(*JmpVec1[256])() = {
 	Neg_D,		// 00
 	Oim_D,		// 01
 	Aim_D,		// 02
@@ -6481,7 +6481,7 @@ void(*JmpVec1[256])(void) = {
 	Stu_E,		// FF
 };
 
-void(*JmpVec2[256])(void) = {
+void(*JmpVec2[256])() = {
 	InvalidInsHandler,		// 00
 	InvalidInsHandler,		// 01
 	InvalidInsHandler,		// 02
@@ -6740,7 +6740,7 @@ void(*JmpVec2[256])(void) = {
 	Sts_E,		// FF
 };
 
-void(*JmpVec3[256])(void) = {
+void(*JmpVec3[256])() = {
 	InvalidInsHandler,		// 00
 	InvalidInsHandler,		// 01
 	InvalidInsHandler,		// 02
@@ -7102,17 +7102,17 @@ int HD6309Exec(int CycleFor)
 	return(CycleFor - CycleCounter);
 }
 
-void Page_2(void) //10
+void Page_2() //10
 {
 	JmpVec2[MemRead8(PC_REG++)](); // Execute instruction pointed to by PC_REG
 }
 
-void Page_3(void) //11
+void Page_3() //11
 {
 	JmpVec3[MemRead8(PC_REG++)](); // Execute instruction pointed to by PC_REG
 }
 
-void cpu_firq(void)
+void cpu_firq()
 {
 	if (EmuState.Debugger.IsTracing())
 		EmuState.Debugger.TraceCaptureInterruptServicing(INT_FIRQ, CycleCounter, HD6309GetState());
@@ -7158,7 +7158,7 @@ void cpu_firq(void)
 		EmuState.Debugger.TraceCaptureInterruptExecuting(INT_FIRQ, CycleCounter, HD6309GetState());
 }
 
-void cpu_irq(void)
+void cpu_irq()
 {
 	if (EmuState.Debugger.IsTracing())
 		EmuState.Debugger.TraceCaptureInterruptServicing(INT_IRQ, CycleCounter, HD6309GetState());
@@ -7188,7 +7188,7 @@ void cpu_irq(void)
 		EmuState.Debugger.TraceCaptureInterruptExecuting(INT_IRQ, CycleCounter, HD6309GetState());
 }
 
-void cpu_nmi(void)
+void cpu_nmi()
 {
 	if (EmuState.Debugger.IsTracing())
 		EmuState.Debugger.TraceCaptureInterruptServicing(INT_NMI, CycleCounter, HD6309GetState());
@@ -7481,7 +7481,7 @@ void setcc (unsigned char bincc)
 	return;
 }
 
-unsigned char getcc(void)
+unsigned char getcc()
 {
 	unsigned char bincc=0,bit=0;
 	for (bit=0;bit<=7;bit++)
@@ -7503,7 +7503,7 @@ void setmd (unsigned char binmd)
 	return;
 }
 
-unsigned char getmd(void)
+unsigned char getmd()
 {
 	unsigned char binmd=0,bit=0;
 	for (bit=6;bit<=7;bit++)
@@ -7534,7 +7534,7 @@ void HD6309DeAssertInterupt(InterruptSource src, Interrupt interrupt)
 	InterruptLine[src] &= BitMask(interrupt);
 }
 
-void InvalidInsHandler(void)
+void InvalidInsHandler()
 {	
 	md[ILLEGAL]=1;
 	mdbits=getmd();
@@ -7542,7 +7542,7 @@ void InvalidInsHandler(void)
 	return;
 }
 
-void DivbyZero(void)
+void DivbyZero()
 {
 	md[ZERODIV]=1;
 	mdbits=getmd();
@@ -7550,7 +7550,7 @@ void DivbyZero(void)
 	return;
 }
 
-void ErrorVector(void)
+void ErrorVector()
 {
 	cc[E]=1;
 	MemWrite8( pc.B.lsb,--S_REG);

--- a/hd6309.h
+++ b/hd6309.h
@@ -18,9 +18,9 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void HD6309Init(void);
+void HD6309Init();
 int  HD6309Exec( int);
-void HD6309Reset(void);
+void HD6309Reset();
 void HD6309AssertInterupt(InterruptSource, Interrupt);
 void HD6309DeAssertInterupt(InterruptSource, Interrupt);
 void HD6309ForcePC(unsigned short);

--- a/joystickinput.cpp
+++ b/joystickinput.cpp
@@ -129,7 +129,7 @@ inline int vccJoystickType();
 
 /*****************************************************************************/
 // Locate connected joysticks.  Called by config.c
-int EnumerateJoysticks(void)
+int EnumerateJoysticks()
 {
 #ifdef _M_ARM
 	return(0);

--- a/joystickinput.h
+++ b/joystickinput.h
@@ -46,7 +46,7 @@ extern JoyStick	LeftJS;
 extern JoyStick RightJS;
 
 HRESULT JoyStickPoll(DIJOYSTATE2 * ,unsigned char);
-int EnumerateJoysticks(void);
+int EnumerateJoysticks();
 bool InitJoyStick (unsigned char);
 
 #ifdef __cplusplus

--- a/logger.cpp
+++ b/logger.cpp
@@ -32,7 +32,7 @@ DWORD dummy;
 
 char LogFileName[MAX_PATH]="VccLog.txt";
 
-//void CpuDump(void) {
+//void CpuDump() {
 //    for (x=0;x<=65535;x++)
 //        PrintLogF("%c",MemRead8(x));
 //}

--- a/mc6809.cpp
+++ b/mc6809.cpp
@@ -79,21 +79,21 @@ static int HaltedInsPending = 0;
 _inline unsigned short CalculateEA(unsigned char);
 static void set_cc_flags(unsigned char);
 static unsigned char get_cc_flags();
-static void cpu_firq(void);
-static void cpu_irq(void);
-static void cpu_nmi(void);
+static void cpu_firq();
+static void cpu_irq();
+static void cpu_nmi();
 static void Do_Opcode(int);
-static void P2_Opcode(void);
-static void P3_Opcode(void);
+static void P2_Opcode();
+static void P3_Opcode();
 
 #include "CpuCommon.h"
 
 //END Fuction Prototypes-----------------------------------
-void MC6809Init(void)
+void MC6809Init()
 {
 }
 
-void MC6809Reset(void)
+void MC6809Reset()
 {
 	// Reset registers to 0
 	D_REG = 0;
@@ -2739,7 +2739,7 @@ void Do_Opcode(int CycleFor)
 } // Do_Opcode ENDS
 
 
-void P2_Opcode(void)
+void P2_Opcode()
 {
 	switch (MemRead8(pc.Reg++)) {
 
@@ -3127,7 +3127,7 @@ void P2_Opcode(void)
 	}
 } // P2_Opcode ends
 
-void P3_Opcode(void)
+void P3_Opcode()
 {
 
 	switch (MemRead8(pc.Reg++)) {
@@ -3248,7 +3248,7 @@ void P3_Opcode(void)
 
 } // P3_Opcode ends
 
-void cpu_firq(void)
+void cpu_firq()
 {
 	if (EmuState.Debugger.IsTracing())
 		EmuState.Debugger.TraceCaptureInterruptServicing(INT_FIRQ, CycleCounter, MC6809GetState());
@@ -3267,7 +3267,7 @@ void cpu_firq(void)
 		EmuState.Debugger.TraceCaptureInterruptExecuting(INT_FIRQ, CycleCounter, MC6809GetState());
 }
 
-void cpu_irq(void)
+void cpu_irq()
 {
 	if (EmuState.Debugger.IsTracing())
 		EmuState.Debugger.TraceCaptureInterruptServicing(INT_IRQ, CycleCounter, MC6809GetState());
@@ -3295,7 +3295,7 @@ void cpu_irq(void)
 		EmuState.Debugger.TraceCaptureInterruptExecuting(INT_IRQ, CycleCounter, MC6809GetState());
 }
 
-void cpu_nmi(void)
+void cpu_nmi()
 {
 	if (EmuState.Debugger.IsTracing())
 		EmuState.Debugger.TraceCaptureInterruptServicing(INT_NMI, CycleCounter, MC6809GetState());
@@ -3333,7 +3333,7 @@ void set_cc_flags (unsigned char bincc)
 	return;
 }
 
-unsigned char get_cc_flags(void)
+unsigned char get_cc_flags()
 {
 	unsigned char bincc=0,bit=0;
 	for (bit=0;bit<=7;bit++)

--- a/mc6809.h
+++ b/mc6809.h
@@ -19,9 +19,9 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void MC6809Init(void);
+void MC6809Init();
 int  MC6809Exec( int);
-void MC6809Reset(void);
+void MC6809Reset();
 void MC6809AssertInterupt(InterruptSource, Interrupt);
 void MC6809DeAssertInterupt(InterruptSource, Interrupt);
 void MC6809ForcePC(unsigned short);

--- a/mc6821.cpp
+++ b/mc6821.cpp
@@ -313,7 +313,7 @@ void pia1_write(unsigned char data,unsigned char port)
 	return;
 }
 
-unsigned char VDG_Mode(void)
+unsigned char VDG_Mode()
 {
 	return( (regb[2] & 248) >>3);
 }
@@ -381,7 +381,7 @@ void irq_fs(int phase)	//60HZ Vertical sync pulse 16.667 mS
 	return;
 }
 
-void AssertCart(void)
+void AssertCart()
 {
 	regb[3]=(regb[3] | 128);
 	if (regb[3] & 1)
@@ -403,14 +403,14 @@ void PiaReset()
 }
 
 // Get analog I/O select.
-unsigned char GetMuxState(void)
+unsigned char GetMuxState()
 {
 	return ( ((rega[1] & 8)>>3) + ((rega[3] & 8) >>2));
 }
 
 // Return 14 bit value for DAC comparator. Coco DAC is six bits
 // but value is extended to allow more resolution.
-unsigned int DACState(void)
+unsigned int DACState()
 {
     int hrval = regb[0]<<6;  // Copy six high bits to integer
     return hrval;
@@ -422,7 +422,7 @@ void SetCart(unsigned char cart)
 	return;
 }
 
-unsigned int GetDACSample(void)
+unsigned int GetDACSample()
 {
 	auto pakSample = PackAudioSample();
 	auto pakLeft = pakSample >> 8;
@@ -443,7 +443,7 @@ unsigned char SetCartAutoStart(unsigned char Tmp)
 	return CartAutoStart;
 }
 
-unsigned char GetCasSample(void)
+unsigned char GetCasSample()
 {
 	return Csample;
 }
@@ -498,7 +498,7 @@ int OpenPrintFile(const char *FileName)
 	return 1;
 }
 
-void ClosePrintFile(void)
+void ClosePrintFile()
 {
 	CloseHandle(hPrintFile);
 	hPrintFile=INVALID_HANDLE_VALUE;

--- a/mc6821.h
+++ b/mc6821.h
@@ -25,20 +25,20 @@ void pia0_write(unsigned char data,unsigned char port);
 unsigned char pia1_read(unsigned char port);
 void pia1_write(unsigned char data,unsigned char port);
 
-void ClosePrintFile(void);
+void ClosePrintFile();
 void SetSerialParams(unsigned char);
 void SetMonState(BOOL);
-unsigned char VDG_Mode(void);
+unsigned char VDG_Mode();
 void irq_hs(int);
 void irq_fs(int);
-void AssertCart(void);
+void AssertCart();
 void SetCart(unsigned char);
 unsigned char SetCartAutoStart(unsigned char);
 void PiaReset();
-unsigned char GetMuxState(void);
-unsigned int DACState(void);
-unsigned int GetDACSample(void);
-unsigned char GetCasSample(void);
+unsigned char GetMuxState();
+unsigned int DACState();
+unsigned int GetDACSample();
+unsigned char GetCasSample();
 void SetCassetteSample(unsigned char);
 int OpenPrintFile(const char *);
 // FIXME: These need to be turned into an enum and the signature of functions

--- a/memdump.cpp
+++ b/memdump.cpp
@@ -81,7 +81,7 @@ void SetDumpPath(const char * dumpfile)
 }
 
 // Dump real memory
-void MemDump(void)
+void MemDump()
 {
 	int fd = OpenDumpFile();
 	const unsigned char * ptr = Get_mem_pointer();
@@ -91,7 +91,7 @@ void MemDump(void)
 }
 
 // Dump CPU memory
-void CpuDump(void)
+void CpuDump()
 {
 	std::array<int,8> regs = GetMmuRegs();
 	const unsigned char * pmem = Get_mem_pointer();

--- a/memdump.h
+++ b/memdump.h
@@ -22,7 +22,7 @@
 
 #ifndef __MEMDUMP_H__
 #define __MEMDUMP_H__
-void CpuDump(void);
-void MemDump(void);
+void CpuDump();
+void MemDump();
 void SetDumpPath(const char *);
 #endif

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -57,14 +57,14 @@ static char MPIPath[MAX_PATH];
 //Array of fuction pointer for each Slot
 static void (*GetModuleNameCalls[NUMSLOTS])(char *,char *,DYNAMICMENUCALLBACK)={nullptr,nullptr,nullptr,nullptr};
 static void (*ConfigModuleCalls[NUMSLOTS])(unsigned char)={nullptr,nullptr,nullptr,nullptr};
-static void (*HeartBeatCalls[NUMSLOTS])(void)={nullptr,nullptr,nullptr,nullptr};
+static void (*HeartBeatCalls[NUMSLOTS])()={nullptr,nullptr,nullptr,nullptr};
 static void (*PakPortWriteCalls[NUMSLOTS])(unsigned char,unsigned char)={nullptr,nullptr,nullptr,nullptr};
 static unsigned char (*PakPortReadCalls[NUMSLOTS])(unsigned char)={nullptr,nullptr,nullptr,nullptr};
 static void (*PakMemWrite8Calls[NUMSLOTS])(unsigned char,unsigned short)={nullptr,nullptr,nullptr,nullptr};
 static unsigned char (*PakMemRead8Calls[NUMSLOTS])(unsigned short)={nullptr,nullptr,nullptr,nullptr};
 static void (*ModuleStatusCalls[NUMSLOTS])(char *)={nullptr,nullptr,nullptr,nullptr};
-static unsigned short (*ModuleAudioSampleCalls[NUMSLOTS])(void)={nullptr,nullptr,nullptr,nullptr};
-static void (*ModuleResetCalls[NUMSLOTS]) (void)={nullptr,nullptr,nullptr,nullptr};
+static unsigned short (*ModuleAudioSampleCalls[NUMSLOTS])()={nullptr,nullptr,nullptr,nullptr};
+static void (*ModuleResetCalls[NUMSLOTS]) ()={nullptr,nullptr,nullptr,nullptr};
 //Set callbacks for the DLL to call
 static void (*SetInteruptCallPointerCalls[NUMSLOTS]) ( PAKINTERUPT)={nullptr,nullptr,nullptr,nullptr};
 static void (*DmaMemPointerCalls[NUMSLOTS]) (MEMREAD8,MEMWRITE8)={nullptr,nullptr,nullptr,nullptr};
@@ -86,7 +86,7 @@ void SetCartSlot0(unsigned char);
 void SetCartSlot1(unsigned char);
 void SetCartSlot2(unsigned char);
 void SetCartSlot3(unsigned char);
-void BuildDynaMenu(void);
+void BuildDynaMenu();
 void DynamicMenuCallback0(const char *,int, int);
 void DynamicMenuCallback1(const char *,int, int);
 void DynamicMenuCallback2(const char *,int, int);
@@ -110,8 +110,8 @@ LRESULT CALLBACK MpiConfigDlg(HWND,UINT,WPARAM,LPARAM);
 unsigned char MountModule(unsigned char,const char *);
 void UnloadModule(unsigned char);
 void UpdateCartDLL(unsigned char slot);
-void LoadConfig(void);
-void WriteConfig(void);
+void LoadConfig();
+void WriteConfig();
 void ReadModuleParms(unsigned char,char *);
 int FileID(const char *);
 
@@ -258,7 +258,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) void HeartBeat(void)
+	__declspec(dllexport) void HeartBeat()
 	{
 		for (int slot=0;slot<NUMSLOTS;slot++)
 			if (HeartBeatCalls[slot] != nullptr)
@@ -323,7 +323,7 @@ extern "C"
 // This gets called at the end of every scan line 262 Lines * 60 Frames = 15780 Hz 15720
 extern "C"
 {
-	__declspec(dllexport) unsigned short ModuleAudioSample(void)
+	__declspec(dllexport) unsigned short ModuleAudioSample()
 	{
 		unsigned short TempSample=0;
 		for (int slot=0;slot<NUMSLOTS;slot++)
@@ -336,7 +336,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char ModuleReset (void)
+	__declspec(dllexport) unsigned char ModuleReset ()
 	{
 		ChipSelectSlot=SwitchSlot;
 		SpareSelectSlot=SwitchSlot;
@@ -649,7 +649,7 @@ void UpdateCartDLL(unsigned char Slot)
 	return;
 }
 
-void LoadConfig(void)
+void LoadConfig()
 {
 	// Get the module name from this DLL (MPI)
 	char ModName[MAX_LOADSTRING]="";
@@ -683,7 +683,7 @@ void LoadConfig(void)
 	return;
 }
 
-void WriteConfig(void)
+void WriteConfig()
 {
 	char ModName[MAX_LOADSTRING]="";
 	if (strcmp(MPIPath, "") != 0) {
@@ -790,7 +790,7 @@ void SetCartSlot3(unsigned char Tmp)
 }
 
 // This gets called on mpi startup and each time a module is inserted or deleted
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
 	// DynamicMenuCallback() resides in VCC pakinterface. Make sure we have it's address
 	if (DynamicMenuCallback == nullptr) {

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -82,7 +82,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char ModuleReset(void)
+	__declspec(dllexport) unsigned char ModuleReset()
 	{
 		char RomPath[MAX_PATH];
 
@@ -122,7 +122,7 @@ extern "C"
 // This gets called at the end of every scan line 262 Lines * 60 Frames = 15780 Hz 15720
 extern "C" 
 {          
-	__declspec(dllexport) unsigned short ModuleAudioSample(void)
+	__declspec(dllexport) unsigned short ModuleAudioSample()
 	{
 		
 		return((LeftChannel<<8) | RightChannel) ;

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -61,14 +61,14 @@ static void (*GetModuleName)(char *,char *,DYNAMICMENUCALLBACK)=nullptr;
 static void (*ConfigModule)(unsigned char)=nullptr;
 static void (*SetInteruptCallPointer)(PAKINTERUPT)=nullptr;
 static void (*DmaMemPointer) (MEMREAD8,MEMWRITE8)=nullptr;
-static void (*HeartBeat)(void)=nullptr;
+static void (*HeartBeat)()=nullptr;
 static void (*PakPortWrite)(unsigned char,unsigned char)=nullptr;
 static unsigned char (*PakPortRead)(unsigned char)=nullptr;
 static void (*PakMemWrite8)(unsigned char,unsigned short)=nullptr;
 static unsigned char (*PakMemRead8)(unsigned short)=nullptr;
 static void (*ModuleStatus)(char *)=nullptr;
-static unsigned short (*ModuleAudioSample)(void)=nullptr;
-static void (*ModuleReset) (void)=nullptr;
+static unsigned short (*ModuleAudioSample)()=nullptr;
+static void (*ModuleReset) ()=nullptr;
 static void (*SetIniPath) (const char *)=nullptr;
 static void (*PakSetCart)(SETCART)=nullptr;
 static char PakPath[MAX_PATH];
@@ -83,14 +83,14 @@ static bool CartMenuCreated = false;
 
 static 	char Modname[MAX_PATH]="Blank";
 
-void PakTimer(void)
+void PakTimer()
 {
 	if (HeartBeat != nullptr)
 		HeartBeat();
 	return;
 }
 
-void ResetBus(void)
+void ResetBus()
 {
 	BankedCartOffset=0;
 	if (ModuleReset !=nullptr)
@@ -152,6 +152,7 @@ void PackMem8Write(unsigned short Address,unsigned char Value)
 void (PakAssertInterupt) (unsigned char interrupt, unsigned char source)
 {
 	(void) source; // not used
+
 	switch (interrupt) {
 	case INT_CART:
 		GimeAssertCartInterupt();
@@ -162,7 +163,7 @@ void (PakAssertInterupt) (unsigned char interrupt, unsigned char source)
 	}
 }
 
-unsigned short PackAudioSample(void)
+unsigned short PackAudioSample()
 {
 	if (ModuleAudioSample !=nullptr)
 		return(ModuleAudioSample());
@@ -170,7 +171,7 @@ unsigned short PackAudioSample(void)
 	return 0;
 }
 
-int LoadCart(void)
+int LoadCart()
 {
 	char inifile[MAX_PATH];
 	GetIniFilePath(inifile);
@@ -378,7 +379,7 @@ int load_ext_rom(const char *filename)
 	return index;
 }
 
-void UnloadDll(void)
+void UnloadDll()
 {
 	GetModuleName=nullptr;
 	ConfigModule=nullptr;
@@ -408,14 +409,14 @@ void GetCurrentModule(char *DefaultModule)
 	return;
 }
 
-void UpdateBusPointer(void)
+void UpdateBusPointer()
 {
 	if (SetInteruptCallPointer!=nullptr)
 		SetInteruptCallPointer(PakAssertInterupt);
 	return;
 }
 
-void UnloadPack(void)
+void UnloadPack()
 {
 	UnloadDll();
 	strcpy(DllPath,"");
@@ -518,7 +519,7 @@ void CallDynamicMenu(const char *MenuName, int MenuId, int Type)
 }
 
 // Create dynamic menu items. This gets called by CallDynamicMenu for each menuitem
-HMENU RefreshDynamicMenu(void)
+HMENU RefreshDynamicMenu()
 {
 	HMENU hMenu0, hMenu;
 

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -18,23 +18,23 @@ This file is part of VCC (Virtual Color Computer).
 
 #pragma once
 
-void PakTimer(void);
+void PakTimer();
 unsigned char PackPortRead (unsigned char);
 void PackPortWrite(unsigned char,unsigned char);
 unsigned char PackMem8Read (unsigned short);
 void PackMem8Write(unsigned short,unsigned char);
 void GetModuleStatus( SystemState *);
-int LoadCart(void);
-unsigned short PackAudioSample(void);
-void ResetBus(void);
+int LoadCart();
+unsigned short PackAudioSample();
+void ResetBus();
 int load_ext_rom(const char *);
 void GetCurrentModule(char *);
 int InsertModule (const char *);
-void UpdateBusPointer(void);
-void UnloadDll(void);
-void UnloadPack(void);
+void UpdateBusPointer();
+void UnloadDll();
+void UnloadPack();
 
-HMENU RefreshDynamicMenu(void);
+HMENU RefreshDynamicMenu();
 void CallDynamicMenu(const char * MenuName,int MenuId,int Type);
 void DynamicMenuActivated(unsigned char);
 

--- a/quickload.cpp
+++ b/quickload.cpp
@@ -103,7 +103,7 @@ unsigned char QuickLoad(char *BinFileName)
 	return 255; //Invalid File type
 } //End Proc
 
-unsigned short GetXferAddr(void)
+unsigned short GetXferAddr()
 {
 	return XferAddress;
 }

--- a/quickload.h
+++ b/quickload.h
@@ -19,6 +19,6 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 unsigned char QuickLoad(char *BinFileName);
-unsigned short GetXferAddr(void);
+unsigned short GetXferAddr();
 
 #endif

--- a/sdc/cloud9.cpp
+++ b/sdc/cloud9.cpp
@@ -37,7 +37,7 @@ static unsigned __int64 CurrentBit=0;
 static unsigned char FormatBit=0; //1 = 12Hour Mode
 static unsigned char CookieRecived=0;
 static unsigned char WriteEnabled=0;
-void SetTime(void);
+void SetTime();
 unsigned char ReadTime(unsigned short port)
 {
 	unsigned char ret_val=0;
@@ -128,7 +128,7 @@ unsigned char ReadTime(unsigned short port)
 }
 
 
-void SetTime(void)
+void SetTime()
 {
 	now.wMilliseconds= (unsigned short)(InBuffer & 15);
 	InBuffer>>=4;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -158,7 +158,7 @@
 
 void (*AssertInt)(unsigned char, unsigned char);
 static DYNAMICMENUCALLBACK DynamicMenuCallback = nullptr;
-void SDCInit(void);
+void SDCInit();
 void LoadRom(unsigned char);
 void (*MemWrite8)(unsigned char,unsigned short)=nullptr;
 void SDCWrite(unsigned char,unsigned char);
@@ -169,26 +169,26 @@ unsigned char MemRead(unsigned short);
 LRESULT CALLBACK SDC_Control(HWND, UINT, WPARAM, LPARAM);
 LRESULT CALLBACK SDC_Configure(HWND, UINT, WPARAM, LPARAM);
 
-void LoadConfig(void);
+void LoadConfig();
 bool SaveConfig(HWND);
-void BuildDynaMenu(void);
+void BuildDynaMenu();
 void CenterDialog(HWND);
-void SelectCardBox(void);
-void update_disk0_box(void);
+void SelectCardBox();
+void update_disk0_box();
 void UpdateFlashItem(int);
 void ModifyFlashItem(int);
-void InitCardBox(void);
-void InitEditBoxes(void);
-void ParseStartup(void);
-void SDCCommand(void);
-void ReadSector(void);
-void StreamImage(void);
-void WriteSector(void);
+void InitCardBox();
+void InitEditBoxes();
+void ParseStartup();
+void SDCCommand();
+void ReadSector();
+void StreamImage();
+void WriteSector();
 bool SeekSector(unsigned char,unsigned int);
 bool ReadDrive(unsigned char,unsigned int);
-void GetDriveInfo(void);
-void SDCControl(void);
-void UpdateSD(void);
+void GetDriveInfo();
+void SDCControl();
+void UpdateSD();
 void AppendPathChar(char *,char c);
 bool LoadFoundFile(struct FileRecord *);
 void FixSDCPath(char *,const char *);
@@ -200,9 +200,9 @@ void CloseDrive(int);
 void OpenFound(int,int);
 void LoadReply(const void *, int);
 void BlockReceive(unsigned char);
-char * LastErrorTxt(void);
+char * LastErrorTxt();
 void FlashControl(unsigned char);
-void LoadDirPage(void);
+void LoadDirPage();
 void SetCurDir(const char *);
 bool SearchFile(const char *);
 void InitiateDir(const char *);
@@ -211,10 +211,10 @@ void RenameFile(const char *);
 void KillFile(const char *);
 void MakeDirectory(const char *);
 bool IsDirectory(const char *);
-void GetMountedImageRec(void);
-void GetSectorCount(void);
-void GetDirectoryLeaf(void);
-void CommandDone(void);
+void GetMountedImageRec();
+void GetSectorCount();
+void GetDirectoryLeaf();
+void CommandDone();
 unsigned char PickReplyByte(unsigned char);
 unsigned char WriteFlashBank(unsigned short);
 
@@ -381,7 +381,7 @@ extern "C"
     }
 
     // Reset module
-    __declspec(dllexport) unsigned char ModuleReset(void)
+    __declspec(dllexport) unsigned char ModuleReset()
     {
         _DLOG("ModuleReset\n");
         SDCInit();
@@ -481,7 +481,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID rsvd)
 //-------------------------------------------------------------
 // Generate menu for configuring the SDC
 //-------------------------------------------------------------
-void BuildDynaMenu(void)
+void BuildDynaMenu()
 {
     DynamicMenuCallback("",MID_BEGIN,MIT_Head);
     DynamicMenuCallback("",MID_ENTRY,MIT_Seperator);
@@ -643,7 +643,7 @@ SDC_Configure(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)
 //------------------------------------------------------------
 // Get SDC settings from ini file
 //------------------------------------------------------------
-void LoadConfig(void)
+void LoadConfig()
 {
     GetPrivateProfileString
         ("DefaultPaths", "MPIPath", "", MPIPath, MAX_PATH, IniFile);
@@ -696,7 +696,7 @@ bool SaveConfig(HWND hDlg)
 //----------------------------------------------------------------------
 // Init the controller. This gets called by ModuleReset
 //----------------------------------------------------------------------
-void SDCInit(void)
+void SDCInit()
 {
 
 #ifdef USE_LOGGING
@@ -731,7 +731,7 @@ void SDCInit(void)
 //------------------------------------------------------------
 // Init flash box
 //------------------------------------------------------------
-void InitEditBoxes(void)
+void InitEditBoxes()
 {
     for (int index=0; index<8; index++) {
         HWND h;
@@ -761,7 +761,7 @@ void update_disk0_box()
 // Init SD card box
 //------------------------------------------------------------
 
-void InitCardBox(void)
+void InitCardBox()
 {
     hSDCardBox = GetDlgItem(hConfigureDlg,ID_SD_BOX);
     SendMessage(hSDCardBox, WM_SETTEXT, 0, (LPARAM)SDCard);
@@ -804,7 +804,7 @@ void UpdateFlashItem(int index)
 //------------------------------------------------------------
 // Dialog to select SD card path in user home directory
 //------------------------------------------------------------
-void SelectCardBox(void)
+void SelectCardBox()
 {
     // Prompt user for path
     BROWSEINFO bi = { nullptr };
@@ -904,7 +904,7 @@ void LoadRom(unsigned char bank)
 //----------------------------------------------------------------------
 // Parse the startup.cfg file
 //----------------------------------------------------------------------
-void ParseStartup(void)
+void ParseStartup()
 {
     char buf[MAX_PATH+10];
     if (!IsDirectory(SDCard)) {
@@ -951,7 +951,7 @@ void ParseStartup(void)
 //----------------------------------------------------------------------
 //  Command done interrupt;
 //----------------------------------------------------------------------
-void CommandDone(void)
+void CommandDone()
 {
     _DLOG("*");
     AssertInt(INT_NMI,IS_NMI);
@@ -1272,7 +1272,7 @@ unsigned char PickReplyByte(unsigned char port)
 //----------------------------------------------------------------------
 //  Dispatch SDC commands
 //----------------------------------------------------------------------
-void SDCCommand(void)
+void SDCCommand()
 {
 
     switch (IF.cmdcode & 0xF0) {
@@ -1334,7 +1334,7 @@ void BlockReceive(unsigned char byte)
 //----------------------------------------------------------------------
 // Get drive information
 //----------------------------------------------------------------------
-void GetDriveInfo(void)
+void GetDriveInfo()
 {
     int drive = IF.cmdcode & 1;
     switch (IF.param1) {
@@ -1374,7 +1374,7 @@ void GetDriveInfo(void)
 // command to learn the full path when restore last session is active.
 // The full path is saved in SDCX.CFG for the next session.
 //----------------------------------------------------------------------
-void GetDirectoryLeaf(void)
+void GetDirectoryLeaf()
 {
     _DLOG("GetDirectoryLeaf CurDir '%s'\n",CurDir);
 
@@ -1415,7 +1415,7 @@ void GetDirectoryLeaf(void)
 //----------------------------------------------------------------------
 //  Update SD Commands.
 //----------------------------------------------------------------------
-void UpdateSD(void)
+void UpdateSD()
 {
     switch (IF.blkbuf[0]) {
     case 0x4D: //M
@@ -1609,7 +1609,7 @@ bool ReadDrive(unsigned char cmdcode, unsigned int lsn)
 //    b1 single sided flag
 //    b2 eight bit transfer flag
 //----------------------------------------------------------------------
-void ReadSector(void)
+void ReadSector()
 {
     unsigned int lsn = (IF.param1 << 16) + (IF.param2 << 8) + IF.param3;
 
@@ -1625,7 +1625,7 @@ void ReadSector(void)
 //----------------------------------------------------------------------
 // Stream image data
 //----------------------------------------------------------------------
-void StreamImage(void)
+void StreamImage()
 {
     // If already streaming continue
     if (streaming) {
@@ -1661,7 +1661,7 @@ void StreamImage(void)
 //----------------------------------------------------------------------
 // Write logical sector
 //----------------------------------------------------------------------
-void WriteSector(void)
+void WriteSector()
 {
     DWORD cnt = 0;
     int drive = IF.cmdcode & 1;
@@ -1695,7 +1695,7 @@ void WriteSector(void)
 //----------------------------------------------------------------------
 // Get most recent windows error text
 //----------------------------------------------------------------------
-char * LastErrorTxt(void) {
+char * LastErrorTxt() {
     static char msg[200];
     DWORD error_code = GetLastError();
     FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM |
@@ -1741,7 +1741,7 @@ void GetMountedImageRec()
 // IF.param1  0: Next disk 1-9: specific disk.
 // IF.param2 b0: Blink Enable
 //----------------------------------------------------------------------
-void SDCControl(void)
+void SDCControl()
 {
     // If streaming is in progress abort it.
     if (streaming) {
@@ -2515,7 +2515,7 @@ void InitiateDir(const char * path)
 // the pattern used in SearchFile. Can be called multiple times until
 // there are no more matches.
 //----------------------------------------------------------------------
-void LoadDirPage(void)
+void LoadDirPage()
 {
     memset(DirPage,0,sizeof(DirPage));
 

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -32,9 +32,9 @@ This file is part of VCC (Virtual Color Computer).
 
 using Surface32 = VCC::VideoArray<unsigned int, 640 * 480>;
 
-void SetupDisplay(void); //This routine gets called every time a software video register get updated.
-void MakeRGBPalette (void);
-void MakeCMPpalette(void);
+void SetupDisplay(); //This routine gets called every time a software video register get updated.
+void MakeRGBPalette ();
+void MakeCMPpalette();
 void RenderPMODE4NTSC(Surface32 surface32, size_t surfaceDest, int XpitchDest, const unsigned char* cocoSrc, char scanLines);
 
 //extern STRConfig CurrentConfig;
@@ -9727,14 +9727,14 @@ void SetBoarderChange ()
 	return;
 }
 
-void InvalidateBoarder(void)
+void InvalidateBoarder()
 {
 	BoarderChange=5;
 	return;
 }
 
 
-void SetupDisplay(void)
+void SetupDisplay()
 {
 
 	static unsigned char CC2Bpp[8]={1,0,1,0,1,0,1,0};
@@ -9847,13 +9847,13 @@ void SetupDisplay(void)
 	return;
 }
 
-void GimeInit(void)
+void GimeInit()
 {
 	//Nothing but good to have.
 	return;
 }
 
-void GimeReset(void)
+void GimeReset()
 {
 	CC3Vmode=0;
 	CC3Vres=0;
@@ -9890,7 +9890,7 @@ void SetVideoBank(unsigned char data)
 }
 
 
-void MakeRGBPalette (void)
+void MakeRGBPalette ()
 {
 	unsigned char Index=0;
 	unsigned char r,g,b;
@@ -9912,7 +9912,7 @@ void MakeRGBPalette (void)
 	return;
 }
 
-void MakeCMPpalette(void)	
+void MakeCMPpalette()	
 {
 	double r,g,b;
 	unsigned char rr,gg,bb;

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -49,12 +49,12 @@ void SetGimeBoarderColor(unsigned char);
 void SetVidMask(unsigned int);
 void InvalidateBoarder();
 
-void GimeInit(void);
-void GimeReset(void);
+void GimeInit();
+void GimeReset();
 void SetVideoBank(unsigned char);
 unsigned char SetMonitorType(unsigned char );
 void SetBoarderChange ();
-int GetBytesPerRow(void);
+int GetBytesPerRow();
 unsigned char GetHorizontalBorderSize();
 unsigned short GetDisplayedPixelsPerLine();
 unsigned int GetStartOfVidram();

--- a/tcc1014mmu.cpp
+++ b/tcc1014mmu.cpp
@@ -51,7 +51,7 @@ static unsigned short MmuPrefix=0;
 static unsigned int RamSize=0;
 std::atomic_bool mem_initializing;
 
-void UpdateMmuArray(void);
+void UpdateMmuArray();
 
 /*****************************************************************************************
 * MmuInit Initilize and allocate memory for RAM Internal and External ROM Images.        *
@@ -104,7 +104,7 @@ unsigned char * MmuInit(unsigned char RamConfig)
 	return memory;
 }
 
-void MmuReset(void)
+void MmuReset()
 {
 	unsigned int Index1=0,Index2=0;
 	MmuTask=0;
@@ -197,14 +197,14 @@ void Set_MmuEnabled (unsigned char usingmmu)
 	return;
 }
  
-unsigned char * Getint_rom_pointer(void)
+unsigned char * Getint_rom_pointer()
 {
 	return InternalRomBuffer;
 }
 
 // LoadRom() loads Coco3.rom. It is called by MmuInit() here
 // and by SoftReset() in Vcc.c. If LoadRom() fails VCC can not run.
-void LoadRom(void)
+void LoadRom()
 {
 	char RomPath[MAX_PATH]={};
 	unsigned short index=0;
@@ -406,7 +406,7 @@ void SetMmuPrefix(unsigned char data)
 	return;
 }
 
-void UpdateMmuArray(void)
+void UpdateMmuArray()
 {
 	if (MapType)
 	{

--- a/tcc1014mmu.h
+++ b/tcc1014mmu.h
@@ -48,7 +48,7 @@ unsigned short MemRead16(unsigned short);
 unsigned char MemRead8(unsigned short);
 unsigned char SafeMemRead8(unsigned short);
 unsigned char * MmuInit(unsigned char);
-unsigned char *	Getint_rom_pointer(void);
+unsigned char *	Getint_rom_pointer();
 unsigned short GetMem(unsigned long);
 void SetMem(unsigned long, unsigned short);
 bool MemCheckWrite(unsigned short address);
@@ -57,16 +57,16 @@ void __fastcall fMemWrite8(unsigned char,unsigned short );
 unsigned char __fastcall fMemRead8(unsigned short);
 
 void SetMapType(unsigned char);
-void LoadRom(void);
+void LoadRom();
 void Set_MmuTask(unsigned char);
 void SetMmuRegister(unsigned char,unsigned char);
 void Set_MmuEnabled (unsigned char );
 void SetRomMap(unsigned char );
 void SetVectors(unsigned char);
-void MmuReset(void);
+void MmuReset();
 void SetDistoRamBank(unsigned char);
 void SetMmuPrefix(unsigned char);
-unsigned char * Get_mem_pointer(void);
+unsigned char * Get_mem_pointer();
 
 // FIXME: These need to be turned into an enum and the signature of functions
 // that use them updated.

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -282,7 +282,7 @@ void SetTimerLSB() //95
 	return;
 }
 
-void GimeAssertKeyboardInterupt(void) 
+void GimeAssertKeyboardInterupt() 
 {
 	if ((GimeRegisters[0x93] & 2) && EnhancedFIRQFlag == 1)
 	{
@@ -296,7 +296,7 @@ void GimeAssertKeyboardInterupt(void)
 	}
 }
 
-void GimeAssertVertInterupt(void)
+void GimeAssertVertInterupt()
 {
 	if ((GimeRegisters[0x93] & 8) && EnhancedFIRQFlag == 1)
 	{
@@ -310,7 +310,7 @@ void GimeAssertVertInterupt(void)
 	}
 }
 
-void GimeAssertHorzInterupt(void)
+void GimeAssertHorzInterupt()
 {
 	if ((GimeRegisters[0x93] & 16) && EnhancedFIRQFlag == 1)
 	{
@@ -326,7 +326,7 @@ void GimeAssertHorzInterupt(void)
 
 // Timer [F]IRQ bit gets set even if interrupt is not enabled.
 // TODO: What about other gime interrupts? Are they simular?
-void GimeAssertTimerInterupt(void)
+void GimeAssertTimerInterupt()
 {
 	if (GimeRegisters[0x93] & 32) 
 	{
@@ -344,7 +344,7 @@ void GimeAssertTimerInterupt(void)
 }
 
 // CART
-void GimeAssertCartInterupt(void)
+void GimeAssertCartInterupt()
 {
 	if (GimeRegisters[0x93] & 1)
 	{
@@ -430,12 +430,12 @@ void mc6883_reset()
 	return;
 }
 
-unsigned char VDG_Offset(void)
+unsigned char VDG_Offset()
 {
 	return Dis_Offset;
 }
 
-unsigned char VDG_Modes(void)
+unsigned char VDG_Modes()
 {
 	return VDG_Mode;
 }

--- a/tcc1014registers.h
+++ b/tcc1014registers.h
@@ -21,16 +21,16 @@ This file is part of VCC (Virtual Color Computer).
 
 void GimeWrite(unsigned char,unsigned char);
 unsigned char GimeRead(unsigned char);
-void GimeAssertKeyboardInterupt(void);
+void GimeAssertKeyboardInterupt();
 unsigned char GimeGetKeyboardInteruptState();
-void GimeAssertHorzInterupt(void);
-void GimeAssertVertInterupt(void);
-void GimeAssertTimerInterupt(void);
-void GimeAssertCartInterupt(void);
+void GimeAssertHorzInterupt();
+void GimeAssertVertInterupt();
+void GimeAssertTimerInterupt();
+void GimeAssertCartInterupt();
 unsigned char sam_read(unsigned char);
 void sam_write(unsigned char);
 void mc6883_reset();
-unsigned char VDG_Offset(void);
-unsigned char VDG_Modes(void);
+unsigned char VDG_Offset();
+unsigned char VDG_Modes();
 
 #endif

--- a/throttle.cpp
+++ b/throttle.cpp
@@ -27,7 +27,7 @@ static _LARGE_INTEGER MasterClock,Now;
 static unsigned char FrameSkip=0;
 static float fMasterClock=0;
 
-void CalibrateThrottle(void)
+void CalibrateThrottle()
 {
 	timeBeginPeriod(1);	//Needed to get max resolution from the timer normally its 10Ms
 	QueryPerformanceFrequency(&MasterClock);
@@ -37,7 +37,7 @@ void CalibrateThrottle(void)
 }
 
 
-void StartRender(void)
+void StartRender()
 {
 	QueryPerformanceCounter(&StartTime);
 	return;
@@ -73,7 +73,7 @@ Sleep(1);
 	}
 }
 
-void FrameWait(void)
+void FrameWait()
 {
 	//If we have more that 2Ms till the end of the frame
 	QueryPerformanceCounter(&CurrentTime);
@@ -96,7 +96,7 @@ void FrameWait(void)
 }
 
 //Done at end of render;
-float CalculateFPS(void) 
+float CalculateFPS() 
 {
 	const int frameUpdateRate = FRAMEINTERVAL;
 	static unsigned int frameCount=0;

--- a/throttle.h
+++ b/throttle.h
@@ -18,10 +18,10 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void CalibrateThrottle(void);
-void StartRender(void);
+void CalibrateThrottle();
+void StartRender();
 void EndRender(unsigned char);
-void FrameWait(void);
-float CalculateFPS(void);
+void FrameWait();
+float CalculateFPS();
 
 #endif


### PR DESCRIPTION
This removes superfluous `void` as a single non-parameter in function declarations and definitions.