### PR TITLE
Clean up cartridge/pak function and callback signatures

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -54,8 +54,8 @@ static unsigned char RGBDiskRom[EXTROMSIZE];
 static char FloppyPath[MAX_PATH];
 static char RomFileName[MAX_PATH]="";
 static char TempRomFileName[MAX_PATH]="";
-void (*AssertInt)(unsigned char,unsigned char)=nullptr;
-static CARTMENUCALLBACK CartMenuCallback = nullptr;
+AssertInteruptModuleCallback AssertInt = nullptr;
+static AppendCartridgeMenuModuleCallback CartMenuCallback = nullptr;
 unsigned char PhysicalDriveA=0,PhysicalDriveB=0,OldPhysicalDriveA=0,OldPhysicalDriveB=0;
 static unsigned char *RomPointer[3]={ExternalRom,DiskRom,RGBDiskRom};
 static unsigned char SelectRom=0;
@@ -106,7 +106,7 @@ BOOL WINAPI DllMain(
 
 extern "C"
 {
-	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);
@@ -176,7 +176,7 @@ extern "C"
 // This captures the Fuction transfer point for the CPU assert interupt
 extern "C"
 {
-	__declspec(dllexport) void AssertInterupt(PAKINTERUPT Dummy)
+	__declspec(dllexport) void AssertInterupt(AssertInteruptModuleCallback Dummy)
 	{
 		AssertInt=Dummy;
 		return;

--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -17,11 +17,9 @@ This file is part of VCC (Virtual Color Computer).
     You should have received a copy of the GNU General Public License
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <vcc/common/ModuleDefs.h>
 
-// Comment next line to exclude becker code
-#define COMBINE_BECKER
-
-extern "C" void (*AssertInt)(unsigned char,unsigned char);
+extern AssertInteruptModuleCallback AssertInt;
 void BuildDynaMenu();
 
 // FIXME: These need to be turned into a scoped enum and the signature of functions

--- a/FD502/fd502.rc
+++ b/FD502/fd502.rc
@@ -5,7 +5,6 @@
 #error Fd502.rc is not editable by Visual C++, edit it by hand.
 #endif //APSTUDIO_INVOKED
 
-#include "fd502.h"
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS

--- a/FD502/fd502.vcxproj
+++ b/FD502/fd502.vcxproj
@@ -62,7 +62,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COMBINE_BECKER;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile />
     <Link>
@@ -72,7 +72,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Legacy|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_USRDLL;fd502_EXPORTS;_LEGACY_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COMBINE_BECKER;_USRDLL;fd502_EXPORTS;_LEGACY_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/arch:SSE</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
@@ -86,7 +86,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COMBINE_BECKER;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/arch:SSE</AdditionalOptions>
     </ClCompile>
     <ResourceCompile />

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -3,8 +3,8 @@
 
 namespace detail
 {
-	void NullAssetCartridgeLine(unsigned char) {}
-	void NullAddMenuItem(const char *, int, int) {}
+	void NullAssetCartridgeLine(bool) {}
+	void NullAddMenuItem(const char *, int, MenuItemType) {}
 }
 
 
@@ -60,7 +60,7 @@ std::string Cartridge::GetCatalogId() const
 
 
 
-void Cartridge::SetCartLineAssertCallback(SETCART callback)
+void Cartridge::SetCartLineAssertCallback(AssertCartridgeLineModuleCallback callback)
 {
 	AssetCartridgeLinePtr = callback;
 }
@@ -74,7 +74,7 @@ void Cartridge::SetConfigurationPath(std::string path)
 }
 
 
-void Cartridge::SetMenuBuilderCallback(CARTMENUCALLBACK callback)
+void Cartridge::SetMenuBuilderCallback(AppendCartridgeMenuModuleCallback callback)
 {
 	AddMenuItemPtr = callback;
 }

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -17,8 +17,8 @@ public:
 	virtual std::string GetName() const;
 	virtual std::string GetCatalogId() const;
 
-	virtual void SetCartLineAssertCallback(SETCART callback);
-	virtual void SetMenuBuilderCallback(CARTMENUCALLBACK addMenuCallback);
+	virtual void SetCartLineAssertCallback(AssertCartridgeLineModuleCallback callback);
+	virtual void SetMenuBuilderCallback(AppendCartridgeMenuModuleCallback addMenuCallback);
 	virtual void SetConfigurationPath(std::string path);
 
 	virtual std::string GetStatusMessage() const;
@@ -40,7 +40,7 @@ protected:
 
 	void AddMenuItem(const char * name, int id, MenuItemType type)
 	{
-		AddMenuItemPtr(name, id, static_cast<int> (type));
+		AddMenuItemPtr(name, id, type);
 	}
 
 	virtual void LoadConfiguration(const std::string& filename);
@@ -48,12 +48,12 @@ protected:
 
 private:
 
-	friend void ModuleName(char *ModName, char *CatNumber, CARTMENUCALLBACK addMenuCallback);
+	friend void ModuleName(char *ModName, char *CatNumber, AppendCartridgeMenuModuleCallback addMenuCallback);
 	friend void ModuleStatus(char *statusBuffer);
 	friend void ModuleConfig(unsigned char menuId);
 	friend void SetIniPath(const char *iniFilePath);
 	friend void ModuleReset();
-	friend void SetCart(SETCART Pointer);
+	friend void SetCart(AssertCartridgeLineModuleCallback Pointer);
 	friend unsigned char PakMemRead8(unsigned short address);
 	friend void PackPortWrite(unsigned char port, unsigned char data);
 	friend unsigned char PackPortRead(unsigned char port);
@@ -66,7 +66,7 @@ private:
 	std::string			m_Name;
 	std::string			m_CatalogId;
 	std::string			m_ConfigurationPath;
-	SETCART				AssetCartridgeLinePtr = detail::NullAssetCartridgeLine;
-	CARTMENUCALLBACK 	AddMenuItemPtr = detail::NullAddMenuItem;
+	AssertCartridgeLineModuleCallback	AssetCartridgeLinePtr = detail::NullAssetCartridgeLine;
+	AppendCartridgeMenuModuleCallback 	AddMenuItemPtr = detail::NullAddMenuItem;
 };
 

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -2,7 +2,7 @@
 #include "Cartridge.h"
 
 
-GMC_EXPORT void ModuleName(char *moduleName, char *catalogId, CARTMENUCALLBACK addMenuCallback)
+GMC_EXPORT void ModuleName(char *moduleName, char *catalogId, AppendCartridgeMenuModuleCallback addMenuCallback)
 {
 	Cartridge::m_Singleton->SetMenuBuilderCallback(addMenuCallback);
 
@@ -29,7 +29,7 @@ GMC_EXPORT void ModuleReset()
 }
 
 
-GMC_EXPORT void SetCart(SETCART callback)
+GMC_EXPORT void SetCart(AssertCartridgeLineModuleCallback callback)
 {
 	Cartridge::m_Singleton->SetCartLineAssertCallback(callback);
 }

--- a/GMC/CartridgeTrampolines.h
+++ b/GMC/CartridgeTrampolines.h
@@ -2,12 +2,12 @@
 #include "GMC.h"
 
 
-GMC_EXPORT void ModuleName(char *ModName, char *CatNumber, CARTMENUCALLBACK addMenuCallback);
+GMC_EXPORT void ModuleName(char *ModName, char *CatNumber, AppendCartridgeMenuModuleCallback addMenuCallback);
 GMC_EXPORT void ModuleStatus(char *statusBuffer);
 GMC_EXPORT void ModuleConfig(unsigned char /*menuId*/);
 GMC_EXPORT void SetIniPath(const char *iniFilePath);
 GMC_EXPORT void ModuleReset();
-GMC_EXPORT void SetCart(SETCART Pointer);
+GMC_EXPORT void SetCart(AssertCartridgeLineModuleCallback Pointer);
 GMC_EXPORT unsigned char PakMemRead8(unsigned short address);
 GMC_EXPORT void PackPortWrite(unsigned char port, unsigned char data);
 GMC_EXPORT unsigned char PackPortRead(unsigned char port);

--- a/GMC/detail/default_handlers.h
+++ b/GMC/detail/default_handlers.h
@@ -1,5 +1,5 @@
 namespace detail
 {
-	void NullAssetCartridgeLine(unsigned char);
-	void NullAddMenuItem(const char*, int, int);
+	void NullAssetCartridgeLine(bool);
+	void NullAddMenuItem(const char*, int, MenuItemType);
 }

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -42,7 +42,7 @@ static char HardDiskPath[MAX_PATH];
 
 static unsigned char (*MemRead8)(unsigned short);
 static void (*MemWrite8)(unsigned char,unsigned short);
-static CARTMENUCALLBACK CartMenuCallback = nullptr;
+static AppendCartridgeMenuModuleCallback CartMenuCallback = nullptr;
 static unsigned char ClockEnabled=1,ClockReadOnly=1;
 LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
 
@@ -89,7 +89,7 @@ unsigned char MemRead(unsigned short Address)
 extern "C"
 {
     __declspec(dllexport) void
-    ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+    ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
     {
         LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
         LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);
@@ -217,7 +217,7 @@ extern "C"
 extern "C"
 {
     __declspec(dllexport) void
-    MemPointers(MEMREAD8 Temp1,MEMWRITE8 Temp2)
+    MemPointers(ReadMemoryByteModuleCallback Temp1,WriteMemoryByteModuleCallback Temp2)
     {
         MemRead8  = Temp1;
         MemWrite8 = Temp2;

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -22,7 +22,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "defines.h"
 #include "memboard.h"
 
-static CARTMENUCALLBACK DynamicMenuCallback = nullptr;
+static AppendCartridgeMenuModuleCallback DynamicMenuCallback = nullptr;
 
 
 static HINSTANCE g_hinstDLL;
@@ -42,7 +42,7 @@ BOOL WINAPI DllMain(
 
 extern "C" 
 {          
-	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -32,7 +32,7 @@ This file is part of VCC (Virtual Color Computer).
 static char FileName[MAX_PATH] { 0 };
 static char IniFile[MAX_PATH]  { 0 };
 static char SuperIDEPath[MAX_PATH];
-static CARTMENUCALLBACK CartMenuCallback = nullptr;
+static AppendCartridgeMenuModuleCallback CartMenuCallback = nullptr;
 static unsigned char BaseAddress=0x50;
 void BuildCartMenu();
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM );
@@ -63,7 +63,7 @@ BOOL WINAPI DllMain(
 
 extern "C" 
 {          
-	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -46,7 +46,7 @@ static HINSTANCE g_hDLL = nullptr;      // DLL handle
 static HWND g_hDlg = nullptr;           // Config dialog
 static char IniFile[MAX_PATH];       // Ini file name
 static char IniSect[MAX_LOADSTRING]; // Ini file section
-static CARTMENUCALLBACK CartMenuCallback = nullptr;
+static AppendCartridgeMenuModuleCallback CartMenuCallback = nullptr;
 
 // Status for Vcc status line
 char AciaStat[32];
@@ -67,7 +67,7 @@ char AciaFileRdPath[MAX_PATH]; // Path for file reads
 char AciaFileWrPath[MAX_PATH]; // Path for file writes
 
 static unsigned char Rom[8192];
-void (*AssertInt)(unsigned char, unsigned char);
+AssertInteruptModuleCallback AssertInt = nullptr;
 unsigned char LoadExtRom(const char *);
 
 //------------------------------------------------------------------------
@@ -93,7 +93,7 @@ DllMain(HINSTANCE hinst, DWORD reason, LPVOID foo)
 //-----------------------------------------------------------------------
 extern "C"
 __declspec(dllexport) void
-ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
 {
     LoadString(g_hDLL,IDS_MODULE_NAME,ModName,MAX_LOADSTRING);
     LoadString(g_hDLL,IDS_CATNUMBER,CatNumber,MAX_LOADSTRING);
@@ -179,7 +179,7 @@ __declspec(dllexport) void HeartBeat()
 // Dll export supply transfer point for interrupt
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) void AssertInterupt(ASSERTINTERUPT Dummy)
+__declspec(dllexport) void AssertInterupt(AssertInteruptModuleCallback Dummy)
 {
     AssertInt=Dummy;
     return;

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -22,6 +22,7 @@
 
 // FIXME: This should be defined on the command line
 #define DIRECTINPUT_VERSION 0x0800
+#include <vcc/common/ModuleDefs.h>
 #include <Windows.h>
 #include <windowsx.h>
 #include <stdio.h>
@@ -67,7 +68,7 @@ extern char AciaTcpHost[MAX_PATH];    // Tcpip hostname
 extern char AciaFileRdPath[MAX_PATH]; // Path for file reads
 extern char AciaFileWrPath[MAX_PATH]; // Path for file writes
 
-extern void (*AssertInt)(unsigned char, unsigned char);
+extern AssertInteruptModuleCallback AssertInt;
 
 // Device
 extern void sc6551_init();

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -250,7 +250,7 @@ void sc6551_heartbeat()
             StatReg |= StatRxF;
             // Assert CART if interrupts not disabled or already asserted.
             if (!((CmdReg & CmdRxI) || (StatReg & StatIRQ))) {
-                AssertInt(INT_CART, 0);
+                AssertInt(INT_CART, IS_NMI);
                 StatReg |= StatIRQ;
             }
         }

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -21,7 +21,7 @@ static SOCKET dwSocket = 0;
 
 // vcc stuff
 static HINSTANCE g_hinstDLL=NULL;
-static void (*PakSetCart)(unsigned char)=NULL;
+static AssertCartridgeLineModuleCallback PakSetCart = nullptr;
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
 static char IniFile[MAX_PATH]="";
 static unsigned char HDBRom[8192];
@@ -60,7 +60,7 @@ char msg[MAX_PATH];
 // log lots of stuff...
 static boolean logging = false;
 
-static CARTMENUCALLBACK CartMenuCallback = NULL;
+static AppendCartridgeMenuModuleCallback CartMenuCallback = NULL;
 unsigned char LoadExtRom(const char *);
 void SetDWTCPConnectionEnable(unsigned int enable);
 int dw_setaddr(const char *bufdwaddr);
@@ -399,7 +399,7 @@ void SetDWTCPConnectionEnable(unsigned int enable)
 }
 
 // dll exported functions
-extern "C" __declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+extern "C" __declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME, ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);		
@@ -452,7 +452,7 @@ extern "C" __declspec(dllexport) unsigned char PackPortRead(unsigned char Port)
 		return(0);
 	}
 */
-extern "C" __declspec(dllexport) unsigned char SetCart(SETCART Pointer)
+extern "C" __declspec(dllexport) unsigned char SetCart(AssertCartridgeLineModuleCallback Pointer)
 	{
 		
 		PakSetCart=Pointer;

--- a/libcommon/include/vcc/common/ModuleDefs.h
+++ b/libcommon/include/vcc/common/ModuleDefs.h
@@ -16,23 +16,27 @@
 //	along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+#include <vcc/common/interrupts.h>
 
-// Module DLL capability pointers
-typedef void (*CARTMENUCALLBACK)(const char* MenuName, int MenuId, int MenuType);
-typedef void (*GETNAME)(char*, char*, CARTMENUCALLBACK);
-typedef void (*CONFIGIT)(unsigned char);
-typedef void (*HEARTBEAT) (void);
-typedef unsigned char (*PACKPORTREAD)(unsigned char);
-typedef void (*PACKPORTWRITE)(unsigned char, unsigned char);
-typedef void (*PAKINTERUPT)(unsigned char, unsigned char);
-typedef unsigned char (*MEMREAD8)(unsigned short);
-typedef void (*SETCART)(unsigned char);
-typedef void (*SETCARTPOINTER)(SETCART);
-typedef void (*MEMWRITE8)(unsigned char, unsigned short);
-typedef void (*MODULESTATUS)(char*);
-typedef void (*DMAMEMPOINTERS) (MEMREAD8, MEMWRITE8);
-typedef void (*SETINTERUPTCALLPOINTER) (PAKINTERUPT);
-typedef unsigned short (*MODULEAUDIOSAMPLE)(void);
-typedef void (*MODULERESET)(void);
-typedef void (*SETINIPATH)(const char*);
-typedef void (*ASSERTINTERUPT)(unsigned char, unsigned char);
+// FIXME: this needs to come from the common library but is currently part of the
+// main vcc app. Update this when it is migrated.
+enum MenuItemType;
+
+using WriteMemoryByteModuleCallback = void (*)(unsigned char value, unsigned short address);
+using ReadMemoryByteModuleCallback = unsigned char (*)(unsigned short address);
+using AssertCartridgeLineModuleCallback = void (*)(bool lineState);
+using AssertInteruptModuleCallback = void (*)(Interrupt interrupt, InterruptSource interrupt_source);
+using AppendCartridgeMenuModuleCallback = void (*)(const char* menu_name, int menu_id, MenuItemType menu_type);
+
+using GetNameModuleFunction = void (*)(char* name_text, char* catalog_id_text, AppendCartridgeMenuModuleCallback addMenuItemCallback);
+using SetDMACallbacksModuleFunction = void (*)(ReadMemoryByteModuleCallback, WriteMemoryByteModuleCallback);
+using SetAssertInterruptCallbackModuleFunction = void (*)(AssertInteruptModuleCallback callback);
+using SetConfigurationPathModuleFunction = void (*)(const char* path);
+using SetAssertCartridgeLineCallbackModuleFunction = void (*)(AssertCartridgeLineModuleCallback callback);
+using ResetModuleFunction = void (*)();
+using HeartBeatModuleFunction = void (*)();
+using GetStatusModuleFunction = void (*)(char* status_text);
+using WritePortModuleFunction = void (*)(unsigned char port, unsigned char value);
+using ReadPortModuleFunction = unsigned char (*)(unsigned char port);
+using SampleAudioModuleFunction = unsigned short (*)();
+using OnMenuItemClickedModuleFunction = void (*)(unsigned char itemId);

--- a/mc6821.cpp
+++ b/mc6821.cpp
@@ -123,7 +123,7 @@ static unsigned char rega_dd[4]={0,0,0,0};
 static unsigned char regb_dd[4]={0,0,0,0};
 static unsigned char LeftChannel=0,RightChannel=0;
 static unsigned char Asample=0,Ssample=0,Csample=0;
-static unsigned char CartInserted=0,CartAutoStart=1;
+static bool CartInserted = false, CartAutoStart = true;
 static unsigned char AddLF=0;
 static HANDLE hPrintFile=INVALID_HANDLE_VALUE;
 void CaptureBit(unsigned char);
@@ -416,9 +416,9 @@ unsigned int DACState()
     return hrval;
 }
 
-void SetCart(unsigned char cart)
+void SetCart(bool lineState)
 {
-	CartInserted=cart;
+	CartInserted = lineState;
 	return;
 }
 

--- a/mc6821.h
+++ b/mc6821.h
@@ -32,7 +32,7 @@ unsigned char VDG_Mode();
 void irq_hs(int);
 void irq_fs(int);
 void AssertCart();
-void SetCart(unsigned char);
+void SetCart(bool lineState);
 unsigned char SetCartAutoStart(unsigned char);
 void PiaReset();
 unsigned char GetMuxState();

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -24,7 +24,7 @@ This file is part of VCC (Virtual Color Computer).
 
 static HINSTANCE g_hinstDLL=nullptr;
 static unsigned char LeftChannel=0,RightChannel=0;
-static void (*PakSetCart)(unsigned char)=nullptr;
+static AssertCartridgeLineModuleCallback PakSetCart = nullptr;
 unsigned char LoadExtRom(const char *);
 static unsigned char Rom[8192];
 BOOL WINAPI DllMain(
@@ -43,7 +43,7 @@ BOOL WINAPI DllMain(
 
 extern "C" 
 {          
-	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,CARTMENUCALLBACK /*Temp*/)
+	__declspec(dllexport) void ModuleName(char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback /*Temp*/)
 	{
 		LoadString(g_hinstDLL,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 		LoadString(g_hinstDLL,IDS_CATNUMBER,CatNumber, MAX_LOADSTRING);		
@@ -100,7 +100,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char SetCart(SETCART Pointer)
+	__declspec(dllexport) unsigned char SetCart(AssertCartridgeLineModuleCallback Pointer)
 	{
 		PakSetCart=Pointer;
 

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -157,8 +157,8 @@
 // Functions
 //======================================================================
 
-void (*AssertInt)(unsigned char, unsigned char);
-static CARTMENUCALLBACK CartMenuCallback = nullptr;
+AssertInteruptModuleCallback AssertInt = nullptr;;
+static AppendCartridgeMenuModuleCallback CartMenuCallback = nullptr;
 void SDCInit();
 void LoadRom(unsigned char);
 void (*MemWrite8)(unsigned char,unsigned short)=nullptr;
@@ -353,7 +353,7 @@ extern "C"
 {
     // Register the DLL and build menu
     __declspec(dllexport) void ModuleName
-        (char *ModName,char *CatNumber,CARTMENUCALLBACK Temp)
+        (char *ModName,char *CatNumber,AppendCartridgeMenuModuleCallback Temp)
     {
         LoadString(hinstDLL, IDS_MODULE_NAME, ModName, MAX_LOADSTRING);
         LoadString(hinstDLL, IDS_CATNUMBER, CatNumber, MAX_LOADSTRING);
@@ -444,7 +444,7 @@ extern "C"
     }
 
     // Capture pointers for MemRead8 and MemWrite8 functions.
-    __declspec(dllexport) void MemPointers(MEMREAD8 Temp1,MEMWRITE8 Temp2)
+    __declspec(dllexport) void MemPointers(ReadMemoryByteModuleCallback Temp1,WriteMemoryByteModuleCallback Temp2)
     {
         MemRead8=Temp1;
         MemWrite8=Temp2;
@@ -452,7 +452,7 @@ extern "C"
     }
 
     // Supply transfer point for interrupt
-    __declspec(dllexport) void AssertInterupt(ASSERTINTERUPT Dummy)
+    __declspec(dllexport) void AssertInterupt(AssertInteruptModuleCallback Dummy)
     {
         AssertInt=Dummy;
         return;


### PR DESCRIPTION
This cleans up the cartridge module function signatures and usage across all modules.

- Updates names of module functions and callbacks
- Updates signatures of module functions and callbacks to use correct types for enumerated parameters
- REmoves unused/unnecessary code and variables from pakinterface.cpp
- Updates functions in FD502 cartridge to match signatures of module functions
- Updates functions in GMC cartridge to match signatures of module functions
- Updates functions in HardDisk cartridge to match signatures of module functions
- Updates functions in Ramdisk cartridge to match signatures of module functions
- Updates functions in SuperIDE cartridge to match signatures of module functions
- Updates functions in acia cartridge to match signatures of module functions
- Updates functions in becker cartridge to match signatures of module functions
- Updates functions in sdc cartridge to match signatures of module functions
- Updates functions in MPI cartridge to match signatures of module functions
