### PR TITLE
fix dll exports in libcommon and multiple defines of USE_OPENGL in config

### DIFF
--- a/BuildConfig.h
+++ b/BuildConfig.h
@@ -26,6 +26,13 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 //
+// Legacy does not support opengl so disable it.
+//
+#ifdef _LEGACY_VCC
+#undef USE_OPENGL
+#endif
+
+//
 // Enable the use of OpenGL display driver
 //
 #ifndef USE_OPENGL
@@ -99,13 +106,6 @@
 // 
 // Edit options above rather than these:
 //
-
-//
-// Legacy does not support opengl so disable it.
-//
-#ifdef _LEGACY_VCC
-#define USE_OPENGL false
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Options that are always off for release

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -79,7 +79,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Legacy|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_USRDLL;sdc_EXPORTS;_LEGACY_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_USRDLL;LIBCOMMON_EXPORTS;_LEGACY_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/arch:SSE</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>


### PR DESCRIPTION
- Adds LIBCOMMON_EXPORTS to preprocessor defines in Legacy solution settings
- Fixes multiple defines of USE_OPENGL in config.h