### PR TITLE
add name and catalog id to cartridge and add utility classes

### DIFF
--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -39,6 +39,9 @@ namespace vcc { namespace core
 
 		virtual ~cartridge() = default;
 
+		virtual const name_type& name() const;
+		virtual const catalog_id_type& catalog_id() const;
+
 		virtual void start();
 		virtual void reset();
 		virtual void heartbeat();

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -43,6 +43,9 @@ namespace vcc { namespace core { namespace cartridges
 			AssertInteruptModuleCallback assertCallback,
 			AssertCartridgeLineModuleCallback assertCartCallback);
 
+		LIBCOMMON_EXPORT const name_type& name() const override;
+		LIBCOMMON_EXPORT const catalog_id_type& catalog_id() const override;
+
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void heartbeat() override;
 		LIBCOMMON_EXPORT void status(char* status) override;
@@ -62,6 +65,8 @@ namespace vcc { namespace core { namespace cartridges
 
 		const HMODULE handle_;
 		const path_type configurationPath_;
+		const name_type name_;
+		const catalog_id_type catalog_id_;
 
 		// callbacks
 		const AppendCartridgeMenuModuleCallback addMenuItemCallback_;
@@ -78,7 +83,6 @@ namespace vcc { namespace core { namespace cartridges
 		const ReadPortModuleFunction read_port_;
 		const ReadMemoryByteModuleFunction read_memory_byte_;
 		const SampleAudioModuleFunction sample_audio_;
-		const BuildMenuModuleFunction build_menu_;
 		const MenuItemClickedModuleFunction menu_item_clicked_;
 	};
 

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -39,9 +39,14 @@ namespace vcc { namespace core { namespace cartridges
 
 		LIBCOMMON_EXPORT rom_cartridge(
 			AssertCartridgeLineModuleCallback assertCartCallback,
+			name_type name,
+			catalog_id_type catalog_id,
 			buffer_type buffer,
 			bool enable_bank_switching);
 		
+		LIBCOMMON_EXPORT const name_type& name() const override;
+		LIBCOMMON_EXPORT const catalog_id_type& catalog_id() const override;
+
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void write_port(unsigned char portId, unsigned char value) override;
 		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memoryAddress) override;
@@ -55,6 +60,8 @@ namespace vcc { namespace core { namespace cartridges
 	private:
 
 		const AssertCartridgeLineModuleCallback assertCartCallback_;
+		const name_type name_;
+		const catalog_id_type catalog_id_;
 		const buffer_type buffer_;
 		const bool enable_bank_switching_;
 		size_type bank_offset_;

--- a/libcommon/include/vcc/core/legacy_cartridge_definitions.h
+++ b/libcommon/include/vcc/core/legacy_cartridge_definitions.h
@@ -40,5 +40,4 @@ using WritePortModuleFunction = void (*)(unsigned char port, unsigned char value
 using ReadMemoryByteModuleFunction = unsigned char (*)(unsigned short address);
 using ReadPortModuleFunction = unsigned char (*)(unsigned char port);
 using SampleAudioModuleFunction = unsigned short (*)();
-using BuildMenuModuleFunction = void (*)(AppendCartridgeMenuModuleCallback addMenuItemCallback);
 using MenuItemClickedModuleFunction = void (*)(unsigned char itemId);

--- a/libcommon/include/vcc/core/utils/configuration_serializer.h
+++ b/libcommon/include/vcc/core/utils/configuration_serializer.h
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include <vcc/core/detail/exports.h>
+#include <string>
+
+
+namespace vcc { namespace core
+{
+
+	class configuration_serializer
+	{
+	public:
+
+		using path_type = ::std::string;
+		using string_type = ::std::string;
+
+	public:
+
+		LIBCOMMON_EXPORT explicit configuration_serializer(path_type path);
+
+		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, int value) const;
+		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, const string_type& value) const;
+
+		LIBCOMMON_EXPORT int read(const string_type& section, const string_type& key, int default_value) const;
+		LIBCOMMON_EXPORT string_type read(const string_type& section, const string_type& key, const string_type& default_value = {}) const;
+
+
+	private:
+
+		const path_type path_;
+	};
+} }

--- a/libcommon/include/vcc/core/utils/filesystem.h
+++ b/libcommon/include/vcc/core/utils/filesystem.h
@@ -15,25 +15,19 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/common/std.h>
-#include <Windows.h>
+#pragma once
+#include <vcc/core/detail/exports.h>
 #include <string>
-#include <codecvt>
+#include <Windows.h>
 
 
-namespace vcc { namespace common
+namespace vcc { namespace core { namespace utils
 {
 
-	LIBCOMMON_EXPORT std::string LoadStdString(HINSTANCE instance, UINT id)
-	{
-		LPWSTR buffer_ptr = nullptr;
-		const auto buffer_length(LoadStringW(instance, id, reinterpret_cast<LPWSTR>(&buffer_ptr), 0));
-		if (buffer_length < 1 || buffer_ptr == nullptr)
-		{
-			return { };
-		}
+	LIBCOMMON_EXPORT std::string get_module_path(HMODULE module_handle = nullptr);
+	LIBCOMMON_EXPORT std::string find_pak_module_path(std::string path);
+	LIBCOMMON_EXPORT std::string get_directory_from_path(std::string path);
+	LIBCOMMON_EXPORT std::string get_filename(std::string path);
+	LIBCOMMON_EXPORT std::string strip_application_path(std::string path);
 
-		return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(buffer_ptr, buffer_ptr + buffer_length);
-	}
-
-} }
+} } }

--- a/libcommon/include/vcc/core/utils/winapi.h
+++ b/libcommon/include/vcc/core/utils/winapi.h
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include <vcc/core/detail/exports.h>
+#include <Windows.h>
+#include <string>
+
+
+namespace vcc { namespace core { namespace utils
+{
+
+	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id);
+
+} } }

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -102,17 +102,18 @@
     <ClCompile Include="src\core\cartridges\legacy_cartridge.cpp" />
     <ClCompile Include="src\core\cartridges\rom_cartridge.cpp" />
     <ClCompile Include="src\core\cartridge_loader.cpp" />
+    <ClCompile Include="src\core\utils\configuration_serializer.cpp" />
+    <ClCompile Include="src\core\utils\filesystem.cpp" />
+    <ClCompile Include="src\core\utils\winapi.cpp" />
     <ClCompile Include="src\DialogOps.cpp" />
     <ClCompile Include="src\Fileops.cpp" />
     <ClCompile Include="src\logger.cpp" />
     <ClCompile Include="src\main.cpp" />
-    <ClCompile Include="src\std.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\vcc\common\DialogOps.h" />
     <ClInclude Include="include\vcc\common\FileOps.h" />
     <ClInclude Include="include\vcc\common\logger.h" />
-    <ClInclude Include="include\vcc\common\std.h" />
     <ClInclude Include="include\vcc\core\cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\legacy_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\null_cartridge.h" />
@@ -122,7 +123,10 @@
     <ClInclude Include="include\vcc\core\interrupts.h" />
     <ClInclude Include="include\vcc\core\legacy_cartridge_definitions.h" />
     <ClInclude Include="include\vcc\core\limits.h" />
+    <ClInclude Include="include\vcc\core\utils\configuration_serializer.h" />
     <ClInclude Include="include\vcc\core\utils\dll_deleter.h" />
+    <ClInclude Include="include\vcc\core\utils\filesystem.h" />
+    <ClInclude Include="include\vcc\core\utils\winapi.h" />
     <ClInclude Include="resource\resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -37,6 +37,9 @@
     <Filter Include="Header Files\core\detail">
       <UniqueIdentifier>{fd029ab9-8064-4e1f-9460-edb495cf58ab}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\core\utils">
+      <UniqueIdentifier>{c3048278-09ca-471f-9cff-e11566354e5d}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogOps.cpp">
@@ -57,14 +60,20 @@
     <ClCompile Include="src\core\cartridges\rom_cartridge.cpp">
       <Filter>Source Files\core\cartridges</Filter>
     </ClCompile>
-    <ClCompile Include="src\std.cpp">
-      <Filter>Source Files\common</Filter>
-    </ClCompile>
     <ClCompile Include="src\main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\core\cartridge_loader.cpp">
       <Filter>Source Files\core</Filter>
+    </ClCompile>
+    <ClCompile Include="src\core\utils\configuration_serializer.cpp">
+      <Filter>Source Files\core\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\core\utils\filesystem.cpp">
+      <Filter>Source Files\core\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\core\utils\winapi.cpp">
+      <Filter>Source Files\core\utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -92,9 +101,6 @@
     <ClInclude Include="include\vcc\core\cartridges\rom_cartridge.h">
       <Filter>Header Files\core\cartridges</Filter>
     </ClInclude>
-    <ClInclude Include="include\vcc\common\std.h">
-      <Filter>Header Files\common</Filter>
-    </ClInclude>
     <ClInclude Include="include\vcc\core\utils\dll_deleter.h">
       <Filter>Header Files\core\utils</Filter>
     </ClInclude>
@@ -112,6 +118,15 @@
     </ClInclude>
     <ClInclude Include="include\vcc\core\cartridge_loader.h">
       <Filter>Header Files\core</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\utils\filesystem.h">
+      <Filter>Header Files\core\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\utils\configuration_serializer.h">
+      <Filter>Header Files\core\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\utils\winapi.h">
+      <Filter>Header Files\core\utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/src/core/cartridge.cpp
+++ b/libcommon/src/core/cartridge.cpp
@@ -21,6 +21,21 @@
 namespace vcc { namespace core
 {
 
+	const cartridge::name_type& cartridge::name() const
+	{
+		static const name_type local_name;
+
+		return local_name;
+	}
+	
+	const cartridge::catalog_id_type& cartridge::catalog_id() const
+	{
+		static const catalog_id_type local_id;
+
+		return local_id;
+	}
+
+
 	void cartridge::start()
 	{
 		initialize_pak();

--- a/libcommon/src/core/cartridge_loader.cpp
+++ b/libcommon/src/core/cartridge_loader.cpp
@@ -26,6 +26,24 @@
 namespace vcc { namespace core
 {
 
+	namespace
+	{
+
+		std::string extract_filename(std::string name)
+		{
+			name = name.substr(name.find_last_of("/\\") + 1);
+			const auto endIndex = name.find_last_of('.');
+			if (endIndex > 0)
+			{
+				name = name.substr(0, endIndex);
+			}
+
+			return name;
+		}
+
+	}
+
+
 	cartridge_file_type determine_cartridge_type(const std::string& filename)
 	{
 		std::ifstream input(filename, std::ios::binary);
@@ -77,7 +95,12 @@ namespace vcc { namespace core
 
 		return {
 			nullptr,
-			std::make_unique<vcc::core::cartridges::rom_cartridge>(context.assertCartridgeLine, move(romImage), enable_bank_switching),
+			std::make_unique<vcc::core::cartridges::rom_cartridge>(
+				context.assertCartridgeLine,
+				extract_filename(filename),
+				"",
+				move(romImage),
+				enable_bank_switching),
 			cartridge_loader_status::success
 		};
 	}

--- a/libcommon/src/core/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/core/cartridges/rom_cartridge.cpp
@@ -23,14 +23,29 @@ namespace vcc { namespace core { namespace cartridges
 
 	rom_cartridge::rom_cartridge(
 		AssertCartridgeLineModuleCallback assertCartCallback,
+		name_type name,
+		catalog_id_type catalog_id,
 		buffer_type buffer,
 		bool enable_bank_switching)
 		:
 		assertCartCallback_(assertCartCallback),
+		name_(move(name)),
+		catalog_id_(move(catalog_id)),
 		buffer_(move(buffer)),
 		enable_bank_switching_(enable_bank_switching),
 		bank_offset_(0)
 	{}
+
+
+	const rom_cartridge::name_type& rom_cartridge::name() const
+	{
+		return name_;
+	}
+
+	const rom_cartridge::catalog_id_type& rom_cartridge::catalog_id() const
+	{
+		return catalog_id_;
+	}
 
 
 	void rom_cartridge::reset()

--- a/libcommon/src/core/utils/configuration_serializer.cpp
+++ b/libcommon/src/core/utils/configuration_serializer.cpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include <vcc/core/utils/configuration_serializer.h>
+#include <Windows.h>
+
+
+namespace vcc { namespace core
+{
+
+	configuration_serializer::configuration_serializer(path_type path)
+		: path_(move(path))
+	{
+	}
+
+	void configuration_serializer::write(
+		const string_type& section,
+		const string_type& key,
+		int value) const
+	{
+		WritePrivateProfileString(
+			section.c_str(),
+			key.c_str(),
+			std::to_string(value).c_str(),
+			path_.c_str());
+	}
+
+	void configuration_serializer::write(
+		const string_type& section,
+		const string_type& key,
+		const string_type& value) const
+	{
+		WritePrivateProfileString(section.c_str(), key.c_str(), value.c_str(), path_.c_str());
+	}
+
+	int configuration_serializer::read(const string_type& section, const string_type& key, int default_value) const
+	{
+		return GetPrivateProfileInt(section.c_str(), key.c_str(), default_value, path_.c_str());
+	}
+
+	configuration_serializer::string_type configuration_serializer::read(
+		const string_type& section,
+		const string_type& key,
+		const string_type& default_value) const
+	{
+		// FIXME: Need to determine the size of the string
+		char loaded_string[MAX_PATH] = {};
+
+		GetPrivateProfileString(
+			section.c_str(),
+			key.c_str(),
+			default_value.c_str(),
+			loaded_string,
+			MAX_PATH,
+			path_.c_str());
+
+		return loaded_string;
+	}
+
+} }

--- a/libcommon/src/core/utils/filesystem.cpp
+++ b/libcommon/src/core/utils/filesystem.cpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include <vcc/core/utils/filesystem.h>
+#include <vcc/core/utils/winapi.h>
+
+
+namespace vcc { namespace core { namespace utils
+{
+
+
+	LIBCOMMON_EXPORT std::string get_module_path(HMODULE module_handle)
+	{
+		std::string text(MAX_PATH, 0);
+
+		for (;;)
+		{
+			DWORD ret = GetModuleFileName(module_handle, &text[0], text.size());
+			if (ret == 0)
+			{
+				// An error occurred; return an empty string
+				return {};
+			}
+
+			if (ret < text.size())
+			{
+				text.resize(ret);
+
+				return text;
+			}
+
+			// Buffer was too small, double its size and try again
+			text.resize(text.size() * 2);
+		}
+	}
+
+	LIBCOMMON_EXPORT std::string find_pak_module_path(std::string path)
+	{
+		if (path.empty())
+		{
+			return path;
+		}
+
+		auto file_handle(CreateFile(path.c_str(), 0, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+		if (file_handle == INVALID_HANDLE_VALUE)
+		{
+			const auto application_path = get_directory_from_path(::vcc::core::utils::get_module_path());
+			const auto alternate_path = application_path + path;
+			file_handle = CreateFile(alternate_path.c_str(), 0, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+			if (file_handle == INVALID_HANDLE_VALUE)
+			{
+				path = alternate_path;
+			}
+		}
+
+		CloseHandle(file_handle);
+
+		return path;
+	}
+
+	LIBCOMMON_EXPORT std::string get_directory_from_path(std::string path)
+	{
+		const auto last_separator(path.find_last_of('\\'));
+		if (last_separator != std::string::npos)
+		{
+			path.resize(last_separator + 1);
+		}
+
+		return path;
+	}		
+
+	LIBCOMMON_EXPORT std::string strip_application_path(std::string path)
+	{
+		const auto module_path = get_directory_from_path(vcc::core::utils::get_module_path(nullptr));
+		auto temp_path(get_directory_from_path(path));
+		if (module_path == temp_path)	// If they match remove the Path
+		{
+			path = get_filename(path);
+		}
+
+		return path;
+	}
+
+	LIBCOMMON_EXPORT std::string get_filename(std::string path)
+	{
+		const auto last_seperator = path.find_last_of('\\');
+		if (last_seperator == std::string::npos)
+		{
+			return path;
+		}
+
+		path.erase(0, last_seperator + 1);
+
+		return path;
+	}
+
+} } }

--- a/libcommon/src/core/utils/winapi.cpp
+++ b/libcommon/src/core/utils/winapi.cpp
@@ -15,15 +15,23 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#pragma once
-#include <vcc/core/detail/exports.h>
-#include <Windows.h>
-#include <string>
+#include <vcc/core/utils/winapi.h>
+#include <codecvt>
 
 
-namespace vcc { namespace common
+namespace vcc { namespace core { namespace utils
 {
 
-	LIBCOMMON_EXPORT std::string LoadStdString(HINSTANCE instance, UINT id);
+	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id)
+	{
+		LPWSTR buffer_ptr = nullptr;
+		const auto buffer_length(LoadStringW(instance, id, reinterpret_cast<LPWSTR>(&buffer_ptr), 0));
+		if (buffer_length < 1 || buffer_ptr == nullptr)
+		{
+			return { };
+		}
 
-} }
+		return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(buffer_ptr, buffer_ptr + buffer_length);
+	}
+
+} } }

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -632,7 +632,7 @@ void UpdateCartDLL(unsigned char Slot)
 		FileDialog dlg;
 		dlg.setTitle("Load Program Pack");
 		dlg.setInitialDir(MPIPath);
-		dlg.setFilter("DLL Packs\0*.dll\0Rom Packs\0*.ROM;*.ccc;*.pak\0\0");
+		dlg.setFilter("All Supported Formats (*.dll;*.ccc;*.rom)\0*.dll;*.ccc;*.rom\0DLL Packs\0*.dll\0Rom Packs\0*.ROM;*.ccc;*.pak\0\0");
 		dlg.setFlags(OFN_FILEMUSTEXIST);
 		if (dlg.show(0,hConfDlg)) {
 			MountModule(Slot,dlg.path());

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -29,10 +29,10 @@
 #include <vcc/core/legacy_cartridge_definitions.h>
 #include <vcc/core/cartridges/null_cartridge.h>
 #include <vcc/core/utils/dll_deleter.h>
+#include <vcc/core/utils/winapi.h>
 #include <vcc/common/logger.h>
 #include <vcc/common/FileOps.h>
 #include <vcc/common/DialogOps.h>
-#include <vcc/common/std.h>
 #include <fstream>
 #include <Windows.h>
 #include <commdlg.h>
@@ -134,7 +134,7 @@ void PakLoadCartridgeUI()
 	FileDialog dlg;
 	dlg.setTitle(TEXT("Load Program Pack"));
 	dlg.setInitialDir(pakPath);
-	dlg.setFilter("DLL Packs\0*.dll\0Rom Packs\0*.ROM;*.ccc;*.pak\0\0");
+	dlg.setFilter("All Supported Formats (*.dll;*.ccc;*.rom)\0*.dll;*.ccc;*.rom\0DLL Packs\0*.dll\0Rom Packs\0*.ROM;*.ccc;*.pak\0\0");
 	dlg.setFlags(OFN_FILEMUSTEXIST);
 	if (dlg.show()) {
 		if (PakLoadCartridge(dlg.path()) == cartridge_loader_status::success) {
@@ -166,7 +166,7 @@ cartridge_loader_status PakLoadCartridge(const char* filename)
 	}
 
 	const auto string_id_ptr(string_id_map.find(result));
-	auto error_string(vcc::common::LoadStdString(
+	auto error_string(vcc::core::utils::load_string(
 		EmuState.WindowInstance,
 		string_id_ptr != string_id_map.end() ? string_id_ptr->second : IDS_UNKNOWN_ERROR));
 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -27,9 +27,7 @@
 #include "resource.h"
 #include <vcc/core/limits.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
-#include <vcc/core/cartridges/legacy_cartridge.h>
 #include <vcc/core/cartridges/null_cartridge.h>
-#include <vcc/core/cartridges/rom_cartridge.h>
 #include <vcc/core/utils/dll_deleter.h>
 #include <vcc/common/logger.h>
 #include <vcc/common/FileOps.h>
@@ -48,7 +46,6 @@ using cartridge_loader_result = vcc::core::cartridge_loader_result;
 extern SystemState EmuState;
 
 static char DllPath[MAX_PATH] = "";
-static char PakName[MAX_PATH] = "";
 static cartridge_loader_result::handle_type gActiveModule;
 static cartridge_loader_result::cartridge_ptr_type gActiveCartrige(std::make_unique<vcc::core::cartridges::null_cartridge>());
 
@@ -110,10 +107,10 @@ void BeginCartMenu()
 {
 	CartMenu.add("", MID_BEGIN, MIT_Head, 0);
 	CartMenu.add("Cartridge", MID_ENTRY, MIT_Head);
-	if (PakName[0])
+	if (!gActiveCartrige->name().empty())
 	{
 		char tmp[64] = {};
-		snprintf(tmp, 64, "Eject %s", PakName);
+		snprintf(tmp, 64, "Eject %s", gActiveCartrige->name().c_str());
 		CartMenu.add(tmp, ControlId(2), MIT_Slave);
 	}
 	CartMenu.add("Load Cart", ControlId(1), MIT_Slave);
@@ -201,8 +198,6 @@ static cartridge_loader_status load_any_cartridge(const char *filename, const ch
 
 	UnloadDll();
 	strcpy(DllPath, filename);
-	strncpy(PakName, filename, MAX_PATH);
-	PathStripPath(PakName);
 	gActiveCartrige = move(loadedCartridge.cartridge);
 	gActiveModule = move(loadedCartridge.handle);
 	BeginCartMenu();
@@ -219,7 +214,6 @@ void UnloadDll()
 {
 	gActiveCartrige = std::make_unique<vcc::core::cartridges::null_cartridge>();
 	gActiveModule.reset();
-	PakName[0] = 0;
 
 	BeginCartMenu();
 	gActiveCartrige->start();
@@ -265,5 +259,3 @@ void CartMenuActivated(unsigned int MenuID)
 	}
 	return;
 }
-
-


### PR DESCRIPTION
Adds `name()` and `catalog_id()` functions to catalog types. The default and null implementations return empty strings, the ROM returns the filename without extension, and legacy cartridge return the appropriate text of the cartridge. The legacy cartridge support for this is somewhat of a hack as it depends on specific behavior of the `ModuleName` function. Currently the ACIA pak is the only one that performs any initialization which seems fine calling it multiple times.

THe following additions and changes have been made as part of the current effort to refactor the MPI implementation

- add configuration serializer utility class
- add filesystem support (C++ versions of FileOps)
- add file type filter to file selection dialogs to show all supported cartridge types (DLL and ROM paks) and make default
- move and rename LoadStdString in vcc/common/std to load_string in vcc/common/winapi
