### PR TITLE
Fix race condition when accessing a cartridge/program pak

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -30,7 +30,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::Reset()
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		ExecutionMode_ = ExecutionMode::Run;
 		PendingCommand_ = ExecutionMode::Halt;
@@ -50,7 +50,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::RegisterClient(HWND window, std::unique_ptr<Client> client)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		if (!client)
 		{
@@ -68,7 +68,7 @@ namespace VCC { namespace Debugger
 	
 	void Debugger::RemoveClient(HWND window)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		if (RegisteredClients_.find(window) == RegisteredClients_.end())
 		{
@@ -99,7 +99,7 @@ namespace VCC { namespace Debugger
 		}
 
 		{
-			SectionLocker lock(Section_);
+			vcc::core::utils::section_locker lock(Section_);
 			returnPc = ProcessorState_.PC;
 		}
 
@@ -116,7 +116,7 @@ namespace VCC { namespace Debugger
 
 	CPUState Debugger::GetProcessorStateCopy() const
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		return ProcessorState_;
 	}
@@ -142,7 +142,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetBreakpoints(breakpointsbuffer_type breakpoints)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		Breakpoints_ = move(breakpoints);
 		BreakpointsChanged_ = true;
@@ -244,12 +244,12 @@ namespace VCC { namespace Debugger
 
 	void Debugger::LockTrace() const
 	{
-		Section_.Lock();
+		Section_.lock();
 	}
 	
 	void Debugger::UnlockTrace() const
 	{
-		Section_.Unlock();
+		Section_.unlock();
 	}
 
 
@@ -279,14 +279,14 @@ namespace VCC { namespace Debugger
 		TraceEnabled_ = false;
 		TraceRunning_ = false;
 		{
-			SectionLocker lock(Section_);
+			vcc::core::utils::section_locker lock(Section_);
 			Decoder_->Reset(TraceMaxSamples_);
 		}
 	}
 
 	void Debugger::SetTraceMaxSamples(long samples)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		TraceMaxSamples_ = samples;
 		Decoder_->Reset(TraceMaxSamples_);
@@ -294,7 +294,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceStartTriggers(triggerbuffer_type startTriggers)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		TraceStartTriggers_ = move(startTriggers);
 		TraceTriggerChanged_ = true;
@@ -302,7 +302,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceStopTriggers(triggerbuffer_type stopTriggers)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		TraceStopTriggers_ = move(stopTriggers);
 		TraceTriggerChanged_ = true;
@@ -310,7 +310,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceOptions(bool screen, bool emulation)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		TraceScreen_ = screen;
 		TraceEmulation_ = emulation;
@@ -318,7 +318,7 @@ namespace VCC { namespace Debugger
 
 	long Debugger::GetTraceSamples() const
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		return Decoder_->GetSampleCount();
 	}
@@ -330,7 +330,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceMark(int mark, long sample)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		TraceMarks_[mark] = sample;
 	}
@@ -338,14 +338,14 @@ namespace VCC { namespace Debugger
 
 	void Debugger::ClearTraceMarks()
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		TraceMarks_.clear();
 	}
 
 	void Debugger::GetTraceMarkSamples(tracebuffer_type &result) const
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		result.clear();
 
@@ -360,7 +360,7 @@ namespace VCC { namespace Debugger
 	void Debugger::QueueRun()
 	{
 		ApplyHaltpoints(true);
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Run;
 		HasPendingCommand_ = true;
@@ -368,7 +368,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::QueueStep()
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Step;
 		HasPendingCommand_ = true;
@@ -377,7 +377,7 @@ namespace VCC { namespace Debugger
 	void Debugger::QueueHalt()
 	{
 		ApplyHaltpoints(false);
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Halt;
 		HasPendingCommand_ = true;
@@ -397,7 +397,7 @@ namespace VCC { namespace Debugger
 	void Debugger::Update()
 	{
 		{
-			SectionLocker lock(Section_);
+			vcc::core::utils::section_locker lock(Section_);
 
 			ProcessorState_ = CPUGetState();
 
@@ -457,7 +457,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::QueueWrite(unsigned short addr, unsigned char value)
 	{
-		SectionLocker lock(Section_);
+		vcc::core::utils::section_locker lock(Section_);
 
 		PendingWrite_ = PendingWrite(addr, value);
 		HasPendingWrite_ = true;

--- a/Debugger.h
+++ b/Debugger.h
@@ -19,6 +19,7 @@
 #pragma once
 #include "DebuggerUtils.h"
 #include "MachineDefs.h"
+#include <vcc/core/utils/critical_section.h>
 #include <string>
 #include <vector>
 #include <functional>
@@ -145,7 +146,7 @@ namespace VCC { namespace Debugger
 
 	private:
 
-		mutable CriticalSection			Section_;
+		mutable vcc::core::utils::critical_section	Section_;
 		bool							HasPendingCommand_ = false;
 		ExecutionMode					PendingCommand_ = ExecutionMode::Halt;
 		breakpointsbuffer_type			Breakpoints_;

--- a/DebuggerUtils.h
+++ b/DebuggerUtils.h
@@ -21,64 +21,6 @@
 #include <string>
 #include <vector>
 
-namespace VCC
-{
-
-	class CriticalSection
-	{
-	public:
-
-		CriticalSection()
-		{
-			InitializeCriticalSection(&Section_);
-		}
-
-		~CriticalSection()
-		{
-			DeleteCriticalSection(&Section_);
-		}
-
-		CriticalSection(const CriticalSection&) = delete;
-		CriticalSection& operator=(const CriticalSection&) = delete;
-
-		void Lock()
-		{
-			EnterCriticalSection(&Section_);
-		}
-
-		void Unlock()
-		{
-			LeaveCriticalSection(&Section_);
-		}
-
-
-	private:
-
-		CRITICAL_SECTION	Section_;
-	};
-
-
-	class SectionLocker
-	{
-	public:
-		explicit SectionLocker(CriticalSection& section)
-			: Section_(section)
-		{
-			Section_.Lock();
-		}
-
-		~SectionLocker()
-		{
-			Section_.Unlock();
-		}
-
-
-	private:
-
-		CriticalSection& Section_;
-	};
-
-}
 
 
 

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -114,7 +114,7 @@ std::string FmtLine(
 /*            Static Variables                    */
 /**************************************************/
 
-CriticalSection Section_;
+vcc::core::utils::critical_section Section_;
 
 HINSTANCE hVccInst;
 
@@ -790,7 +790,7 @@ void UnHilitePC()
 /***************************************************/
 void ApplyHaltPoint(Haltpoint &hp,bool flag)
 {
-    SectionLocker lock(Section_);
+	vcc::core::utils::section_locker lock(Section_);
     if (flag) {
         if (!hp.placed) {
             // Be sure really not placed

--- a/MMUMonitor.cpp
+++ b/MMUMonitor.cpp
@@ -31,7 +31,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	const COLORREF rgbViolet = RGB(100,   0, 170);
 	const COLORREF rgbGray   = RGB(120, 120, 120);
 
-	CriticalSection Section_;
+	vcc::core::utils::critical_section Section_;
 	MMUState MMUState_;
 
 	HWND MMUMonitorWindow = nullptr;
@@ -44,7 +44,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		void OnReset() override {
 		}
 		void OnUpdate() override {
-			SectionLocker lock(Section_);
+			vcc::core::utils::section_locker lock(Section_);
 			MMUState_ = GetMMUState();
 		}
 	};
@@ -107,7 +107,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Quick pull out MMU state
 		MMUState regs;
 		{
-			SectionLocker lock(Section_);
+			vcc::core::utils::section_locker lock(Section_);
 			regs = MMUState_;
 		}
 

--- a/libcommon/include/vcc/core/utils/critical_section.h
+++ b/libcommon/include/vcc/core/utils/critical_section.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <vcc/core/detail/exports.h>
+#include <Windows.h>
+
+
+namespace vcc { namespace core { namespace utils
+{
+
+	class critical_section
+	{
+	public:
+
+		critical_section()
+		{
+			InitializeCriticalSection(&section_);
+		}
+
+		~critical_section()
+		{
+			DeleteCriticalSection(&section_);
+		}
+
+		critical_section(const critical_section&) = delete;
+		critical_section& operator=(const critical_section&) = delete;
+
+		void lock()
+		{
+			EnterCriticalSection(&section_);
+		}
+
+		void unlock()
+		{
+			LeaveCriticalSection(&section_);
+		}
+
+
+	private:
+
+		CRITICAL_SECTION	section_;
+	};
+
+
+	class section_locker
+	{
+	public:
+
+		explicit section_locker(critical_section& section)
+			: section_(section)
+		{
+			section_.lock();
+		}
+
+		~section_locker()
+		{
+			section_.unlock();
+		}
+
+		section_locker& operator=(const section_locker&) = delete;
+		section_locker& operator=(section_locker&&) = delete;
+
+
+	private:
+
+		critical_section& section_;
+	};
+
+} } }

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -124,6 +124,7 @@
     <ClInclude Include="include\vcc\core\legacy_cartridge_definitions.h" />
     <ClInclude Include="include\vcc\core\limits.h" />
     <ClInclude Include="include\vcc\core\utils\configuration_serializer.h" />
+    <ClInclude Include="include\vcc\core\utils\critical_section.h" />
     <ClInclude Include="include\vcc\core\utils\dll_deleter.h" />
     <ClInclude Include="include\vcc\core\utils\filesystem.h" />
     <ClInclude Include="include\vcc\core\utils\winapi.h" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -128,6 +128,9 @@
     <ClInclude Include="include\vcc\core\utils\winapi.h">
       <Filter>Header Files\core\utils</Filter>
     </ClInclude>
+    <ClInclude Include="include\vcc\core\utils\critical_section.h">
+      <Filter>Header Files\core\utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="resource\libcommon.rc">


### PR DESCRIPTION
The pakinterface does not perform any resource locking to prevent access to the program pak or executing code in the program pak DLL while it is in the process of being ejected. The primary race condition occurs when the program pak is being unloaded while the audio system is sampling audio from the pak. This usually results in a hardware exception being thrown once the DLL has been unloaded.

This change adds a locking guards around all calls into the program pak and ejecting a program pak. It also moves the CriticalSection class into vcc/core/utils.