### PR TITLE
General updates

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -71,7 +71,6 @@ void LoadConfig();
 void SaveConfig();
 long CreateDiskHeader(const char *,unsigned char,unsigned char,unsigned char);
 void Load_Disk(unsigned char);
-void CenterDialog(HWND hDlg);
 
 static HWND g_hConfDlg = nullptr;
 static HINSTANCE g_hinstDLL;
@@ -249,16 +248,6 @@ extern "C"
 #endif
 		return ;
 	}
-}
-
-void CenterDialog(HWND hDlg)
-{
-    RECT rPar, rDlg;
-    GetWindowRect(GetParent(hDlg), &rPar);
-    GetWindowRect(hDlg, &rDlg);
-    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
-    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
-    SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
 LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -52,7 +52,6 @@ void LoadConfig();
 void SaveConfig();
 void BuildDynaMenu();
 int CreateDisk(HWND,int);
-void CenterDialog(HWND hDlg);
 
 static HINSTANCE g_hinstDLL;
 static HWND hConfDlg = nullptr;
@@ -139,16 +138,6 @@ extern "C"
         BuildDynaMenu();
         return;
     }
-}
-
-void CenterDialog(HWND hDlg)
-{
-    RECT rPar, rDlg;
-    GetWindowRect(GetParent(hDlg), &rPar);
-    GetWindowRect(hDlg, &rDlg);
-    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
-    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
-    SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
 LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -37,7 +37,6 @@ void BuildCartMenu();
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
 void LoadConfig();
 void SaveConfig();
-void CenterDialog(HWND);
 
 //------------------------------------------------------------------------
 // Globals
@@ -525,19 +524,6 @@ LRESULT CALLBACK Config(HWND hDlg,UINT msg,WPARAM wParam,LPARAM /*lParam*/)
         return TRUE;
     }
     return FALSE;
-}
-
-//------------------------------------------------------------
-// Center a dialog box in parent window
-//------------------------------------------------------------
-void CenterDialog(HWND hDlg)
-{
-    RECT rPar, rDlg;
-    GetWindowRect(GetParent(hDlg), &rPar);
-    GetWindowRect(hDlg, &rDlg);
-    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
-    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
-    SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
 //----------------------------------------------------------------

--- a/libcommon/include/vcc/common/DialogOps.h
+++ b/libcommon/include/vcc/common/DialogOps.h
@@ -24,6 +24,7 @@
 // It should be called by cartridge DLL's when they are unloaded.
 //-------------------------------------------------------------------------------------------
 LIBCOMMON_EXPORT void CloseCartDialog(HWND hDlg);
+LIBCOMMON_EXPORT void CenterDialog(HWND hDlg);
 
 //-------------------------------------------------------------------------------------------
 // FileDialog wraps dialogs for users to select files.

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -45,12 +45,12 @@ namespace vcc { namespace core
 		virtual void start();
 		virtual void reset();
 		virtual void heartbeat();
-		virtual void write_port(unsigned char portId, unsigned char value);
-		virtual unsigned char read_port(unsigned char portId);
-		virtual unsigned char read_memory_byte(unsigned short memoryAddress);
+		virtual void write_port(unsigned char port_id, unsigned char value);
+		virtual unsigned char read_port(unsigned char port_id);
+		virtual unsigned char read_memory_byte(unsigned short memory_address);
 		virtual void status(char* status);
 		virtual unsigned short sample_audio();
-		virtual void menu_item_clicked(unsigned char menuItemId);
+		virtual void menu_item_clicked(unsigned char menu_item_id);
 
 
 	protected:

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -39,8 +39,8 @@ namespace vcc { namespace core
 
 		virtual ~cartridge() = default;
 
-		virtual const name_type& name() const = 0;
-		virtual const catalog_id_type& catalog_id() const = 0;
+		virtual name_type name() const = 0;
+		virtual catalog_id_type catalog_id() const = 0;
 
 		virtual void start() = 0;
 		virtual void reset() = 0;

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -39,24 +39,18 @@ namespace vcc { namespace core
 
 		virtual ~cartridge() = default;
 
-		virtual const name_type& name() const;
-		virtual const catalog_id_type& catalog_id() const;
+		virtual const name_type& name() const = 0;
+		virtual const catalog_id_type& catalog_id() const = 0;
 
-		virtual void start();
-		virtual void reset();
-		virtual void heartbeat();
-		virtual void write_port(unsigned char port_id, unsigned char value);
-		virtual unsigned char read_port(unsigned char port_id);
-		virtual unsigned char read_memory_byte(unsigned short memory_address);
-		virtual void status(char* status);
-		virtual unsigned short sample_audio();
-		virtual void menu_item_clicked(unsigned char menu_item_id);
-
-
-	protected:
-
-		virtual void initialize_pak();
-		virtual void initialize_bus();
+		virtual void start() = 0;
+		virtual void reset() = 0;
+		virtual void heartbeat() = 0;
+		virtual void write_port(unsigned char port_id, unsigned char value) = 0;
+		virtual unsigned char read_port(unsigned char port_id) = 0;
+		virtual unsigned char read_memory_byte(unsigned short memory_address) = 0;
+		virtual void status(char* status) = 0;
+		virtual unsigned short sample_audio() = 0;
+		virtual void menu_item_clicked(unsigned char menu_item_id) = 0;
 	};
 
 } }

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -15,69 +15,43 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
+#pragma once
 #include <vcc/core/cartridge.h>
 
 
-namespace vcc { namespace core
+namespace vcc { namespace core { namespace cartridges
 {
 
-	const cartridge::name_type& cartridge::name() const
+	struct LIBCOMMON_EXPORT basic_cartridge : public ::vcc::core::cartridge
 	{
-		static const name_type local_name;
+	public:
 
-		return local_name;
-	}
-	
-	const cartridge::catalog_id_type& cartridge::catalog_id() const
-	{
-		static const catalog_id_type local_id;
-
-		return local_id;
-	}
+		using name_type = std::string;
+		using catalog_id_type = std::string;
 
 
-	void cartridge::start()
-	{
-		initialize_pak();
-		initialize_bus();
-	}
+	public:
 
-	void cartridge::reset()
-	{}
+		using cartridge::cartridge;
 
-	void cartridge::heartbeat()
-	{}
+		const name_type& name() const override;
+		const catalog_id_type& catalog_id() const override;
 
-	void cartridge::write_port(unsigned char port_id, unsigned char value)
-	{}
+		void start() override;
+		void reset() override;
+		void heartbeat() override;
+		void write_port(unsigned char port_id, unsigned char value) override;
+		unsigned char read_port(unsigned char port_id) override;
+		unsigned char read_memory_byte(unsigned short memory_address) override;
+		void status(char* status) override;
+		unsigned short sample_audio() override;
+		void menu_item_clicked(unsigned char menu_item_id) override;
 
-	unsigned char cartridge::read_port(unsigned char port_id)
-	{ 
-		return {};
-	}
 
-	unsigned char cartridge::read_memory_byte(unsigned short memory_address)
-	{
-		return {};
-	}
+	protected:
 
-	void cartridge::status(char* status_text)
-	{
-		*status_text = 0;
-	}
+		virtual void initialize_pak();
+		virtual void initialize_bus();
+	};
 
-	unsigned short cartridge::sample_audio()
-	{
-		return {};
-	}
-
-	void cartridge::menu_item_clicked(unsigned char menu_item_id)
-	{}
-
-	void cartridge::initialize_pak()
-	{}
-
-	void cartridge::initialize_bus()
-	{}
-
-} }
+} } }

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -34,8 +34,8 @@ namespace vcc { namespace core { namespace cartridges
 
 		using cartridge::cartridge;
 
-		const name_type& name() const override;
-		const catalog_id_type& catalog_id() const override;
+		name_type name() const override;
+		catalog_id_type catalog_id() const override;
 
 		void start() override;
 		void reset() override;

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -16,7 +16,7 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridge.h>
+#include <vcc/core/cartridges/basic_cartridge.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 #include <Windows.h>
 #include <string>
@@ -25,7 +25,7 @@
 namespace vcc { namespace core { namespace cartridges
 {
 
-	class legacy_cartridge: public cartridge
+	class legacy_cartridge: public basic_cartridge
 	{
 	public:
 

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -49,11 +49,11 @@ namespace vcc { namespace core { namespace cartridges
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void heartbeat() override;
 		LIBCOMMON_EXPORT void status(char* status) override;
-		LIBCOMMON_EXPORT void write_port(unsigned char portId, unsigned char value) override;
-		LIBCOMMON_EXPORT unsigned char read_port(unsigned char portId) override;
-		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memoryAddress) override;
+		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;
+		LIBCOMMON_EXPORT unsigned char read_port(unsigned char port_id) override;
+		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memory_address) override;
 		LIBCOMMON_EXPORT unsigned short sample_audio() override;
-		LIBCOMMON_EXPORT void menu_item_clicked(unsigned char menuItemId) override;
+		LIBCOMMON_EXPORT void menu_item_clicked(unsigned char menu_item_id) override;
 
 
 	protected:

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -43,8 +43,8 @@ namespace vcc { namespace core { namespace cartridges
 			AssertInteruptModuleCallback assertCallback,
 			AssertCartridgeLineModuleCallback assertCartCallback);
 
-		LIBCOMMON_EXPORT const name_type& name() const override;
-		LIBCOMMON_EXPORT const catalog_id_type& catalog_id() const override;
+		LIBCOMMON_EXPORT name_type name() const override;
+		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
 
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void heartbeat() override;

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -16,7 +16,7 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridge.h>
+#include <vcc/core/cartridges/basic_cartridge.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 #include <vector>
 
@@ -24,7 +24,7 @@
 namespace vcc { namespace core { namespace cartridges
 {
 
-	class rom_cartridge : public cartridge
+	class rom_cartridge : public basic_cartridge
 	{
 	public:
 
@@ -34,7 +34,7 @@ namespace vcc { namespace core { namespace cartridges
 
 	public:
 
-		using cartridge::cartridge;
+		using basic_cartridge::basic_cartridge;
 
 
 		LIBCOMMON_EXPORT rom_cartridge(

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -44,8 +44,8 @@ namespace vcc { namespace core { namespace cartridges
 			buffer_type buffer,
 			bool enable_bank_switching);
 		
-		LIBCOMMON_EXPORT const name_type& name() const override;
-		LIBCOMMON_EXPORT const catalog_id_type& catalog_id() const override;
+		LIBCOMMON_EXPORT name_type name() const override;
+		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
 
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -48,8 +48,8 @@ namespace vcc { namespace core { namespace cartridges
 		LIBCOMMON_EXPORT const catalog_id_type& catalog_id() const override;
 
 		LIBCOMMON_EXPORT void reset() override;
-		LIBCOMMON_EXPORT void write_port(unsigned char portId, unsigned char value) override;
-		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memoryAddress) override;
+		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;
+		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memory_address) override;
 
 
 	protected:

--- a/libcommon/include/vcc/core/utils/critical_section.h
+++ b/libcommon/include/vcc/core/utils/critical_section.h
@@ -23,12 +23,12 @@ namespace vcc { namespace core { namespace utils
 		critical_section(const critical_section&) = delete;
 		critical_section& operator=(const critical_section&) = delete;
 
-		void lock()
+		void lock() const
 		{
 			EnterCriticalSection(&section_);
 		}
 
-		void unlock()
+		void unlock() const
 		{
 			LeaveCriticalSection(&section_);
 		}
@@ -36,7 +36,7 @@ namespace vcc { namespace core { namespace utils
 
 	private:
 
-		CRITICAL_SECTION	section_;
+		mutable CRITICAL_SECTION section_;
 	};
 
 
@@ -44,7 +44,7 @@ namespace vcc { namespace core { namespace utils
 	{
 	public:
 
-		explicit section_locker(critical_section& section)
+		explicit section_locker(const critical_section& section)
 			: section_(section)
 		{
 			section_.lock();
@@ -61,7 +61,7 @@ namespace vcc { namespace core { namespace utils
 
 	private:
 
-		critical_section& section_;
+		const critical_section& section_;
 	};
 
 } } }

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -98,7 +98,7 @@
     <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="src\core\cartridge.cpp" />
+    <ClCompile Include="src\core\cartridges\basic_cartridge.cpp" />
     <ClCompile Include="src\core\cartridges\legacy_cartridge.cpp" />
     <ClCompile Include="src\core\cartridges\rom_cartridge.cpp" />
     <ClCompile Include="src\core\cartridge_loader.cpp" />
@@ -115,6 +115,7 @@
     <ClInclude Include="include\vcc\common\FileOps.h" />
     <ClInclude Include="include\vcc\common\logger.h" />
     <ClInclude Include="include\vcc\core\cartridge.h" />
+    <ClInclude Include="include\vcc\core\cartridges\basic_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\legacy_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\null_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\rom_cartridge.h" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -51,9 +51,6 @@
     <ClCompile Include="src\logger.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
-    <ClCompile Include="src\core\cartridge.cpp">
-      <Filter>Source Files\core</Filter>
-    </ClCompile>
     <ClCompile Include="src\core\cartridges\legacy_cartridge.cpp">
       <Filter>Source Files\core\cartridges</Filter>
     </ClCompile>
@@ -74,6 +71,9 @@
     </ClCompile>
     <ClCompile Include="src\core\utils\winapi.cpp">
       <Filter>Source Files\core\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\core\cartridges\basic_cartridge.cpp">
+      <Filter>Source Files\core\cartridges</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -130,6 +130,9 @@
     </ClInclude>
     <ClInclude Include="include\vcc\core\utils\critical_section.h">
       <Filter>Header Files\core\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\cartridges\basic_cartridge.h">
+      <Filter>Header Files\core\cartridges</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/src/DialogOps.cpp
+++ b/libcommon/src/DialogOps.cpp
@@ -115,6 +115,23 @@ void FileDialog::getdir(char * Dir, int maxsize) const {
 	if (char * p = strrchr(Dir,'\\')) *p = '\0';
 }
 
+
+//------------------------------------------------------------
+// Center a dialog box in parent window
+//------------------------------------------------------------
+void CenterDialog(HWND hDlg)
+{
+	RECT rPar;
+	GetWindowRect(GetParent(hDlg), &rPar);
+
+	RECT rDlg;
+	GetWindowRect(hDlg, &rDlg);
+
+	const auto x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
+	const auto y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
+	SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
+
 //-------------------------------------------------------------------------------------------
 // CloseCartDialog should be called by cartridge DLL's when they are unloaded.
 //-------------------------------------------------------------------------------------------

--- a/libcommon/src/core/cartridge.cpp
+++ b/libcommon/src/core/cartridge.cpp
@@ -48,15 +48,15 @@ namespace vcc { namespace core
 	void cartridge::heartbeat()
 	{}
 
-	void cartridge::write_port(unsigned char portId, unsigned char value)
+	void cartridge::write_port(unsigned char port_id, unsigned char value)
 	{}
 
-	unsigned char cartridge::read_port(unsigned char portId)
+	unsigned char cartridge::read_port(unsigned char port_id)
 	{ 
 		return {};
 	}
 
-	unsigned char cartridge::read_memory_byte(unsigned short memoryAddress)
+	unsigned char cartridge::read_memory_byte(unsigned short memory_address)
 	{
 		return {};
 	}
@@ -71,7 +71,7 @@ namespace vcc { namespace core
 		return {};
 	}
 
-	void cartridge::menu_item_clicked(unsigned char menuItemId)
+	void cartridge::menu_item_clicked(unsigned char menu_item_id)
 	{}
 
 	void cartridge::initialize_pak()

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -21,18 +21,14 @@
 namespace vcc { namespace core { namespace cartridges
 {
 
-	const basic_cartridge::name_type& basic_cartridge::name() const
+	basic_cartridge::name_type basic_cartridge::name() const
 	{
-		static const name_type local_name;
-
-		return local_name;
+		return {};
 	}
 	
-	const basic_cartridge::catalog_id_type& basic_cartridge::catalog_id() const
+	basic_cartridge::catalog_id_type basic_cartridge::catalog_id() const
 	{
-		static const catalog_id_type local_id;
-
-		return local_id;
+		return {};
 	}
 
 
@@ -61,9 +57,9 @@ namespace vcc { namespace core { namespace cartridges
 		return {};
 	}
 
-	void basic_cartridge::status(char* status_text)
+	void basic_cartridge::status(char* status_buffer)
 	{
-		*status_text = 0;
+		*status_buffer = 0;
 	}
 
 	unsigned short basic_cartridge::sample_audio()

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -15,14 +15,69 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#pragma once
 #include <vcc/core/cartridges/basic_cartridge.h>
 
 
 namespace vcc { namespace core { namespace cartridges
 {
 
-	class LIBCOMMON_EXPORT null_cartridge : public basic_cartridge
-	{};
+	const basic_cartridge::name_type& basic_cartridge::name() const
+	{
+		static const name_type local_name;
+
+		return local_name;
+	}
+	
+	const basic_cartridge::catalog_id_type& basic_cartridge::catalog_id() const
+	{
+		static const catalog_id_type local_id;
+
+		return local_id;
+	}
+
+
+	void basic_cartridge::start()
+	{
+		initialize_pak();
+		initialize_bus();
+	}
+
+	void basic_cartridge::reset()
+	{}
+
+	void basic_cartridge::heartbeat()
+	{}
+
+	void basic_cartridge::write_port(unsigned char port_id, unsigned char value)
+	{}
+
+	unsigned char basic_cartridge::read_port(unsigned char port_id)
+	{ 
+		return {};
+	}
+
+	unsigned char basic_cartridge::read_memory_byte(unsigned short memory_address)
+	{
+		return {};
+	}
+
+	void basic_cartridge::status(char* status_text)
+	{
+		*status_text = 0;
+	}
+
+	unsigned short basic_cartridge::sample_audio()
+	{
+		return {};
+	}
+
+	void basic_cartridge::menu_item_clicked(unsigned char menu_item_id)
+	{}
+
+	void basic_cartridge::initialize_pak()
+	{}
+
+	void basic_cartridge::initialize_bus()
+	{}
 
 } } }

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -156,12 +156,12 @@ namespace vcc { namespace core { namespace cartridges
 		//		ModuleConfig		==>		PakProcessMenuItem
 	}
 
-	const legacy_cartridge::name_type& legacy_cartridge::name() const
+	legacy_cartridge::name_type legacy_cartridge::name() const
 	{
 		return name_;
 	}
 
-	const legacy_cartridge::catalog_id_type& legacy_cartridge::catalog_id() const
+	legacy_cartridge::catalog_id_type legacy_cartridge::catalog_id() const
 	{
 		return catalog_id_;
 	}
@@ -176,9 +176,9 @@ namespace vcc { namespace core { namespace cartridges
 		heartbeat_();
 	}
 
-	void legacy_cartridge::status(char* status_text)
+	void legacy_cartridge::status(char* status_buffer)
 	{
-		status_(status_text);
+		status_(status_buffer);
 	}
 
 	void legacy_cartridge::write_port(unsigned char port_id, unsigned char value)

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -181,19 +181,19 @@ namespace vcc { namespace core { namespace cartridges
 		status_(status_text);
 	}
 
-	void legacy_cartridge::write_port(unsigned char portId, unsigned char value)
+	void legacy_cartridge::write_port(unsigned char port_id, unsigned char value)
 	{
-		write_port_(portId, value);
+		write_port_(port_id, value);
 	}
 
-	unsigned char legacy_cartridge::read_port(unsigned char portId)
+	unsigned char legacy_cartridge::read_port(unsigned char port_id)
 	{ 
-		return read_port_(portId);
+		return read_port_(port_id);
 	}
 
-	unsigned char legacy_cartridge::read_memory_byte(unsigned short memoryAddress)
+	unsigned char legacy_cartridge::read_memory_byte(unsigned short memory_address)
 	{
-		return read_memory_byte_(memoryAddress);
+		return read_memory_byte_(memory_address);
 	}
 
 	unsigned short legacy_cartridge::sample_audio()
@@ -201,9 +201,9 @@ namespace vcc { namespace core { namespace cartridges
 		return sample_audio_();
 	}
 
-	void legacy_cartridge::menu_item_clicked(unsigned char menuItemId)
+	void legacy_cartridge::menu_item_clicked(unsigned char menu_item_id)
 	{
-		menu_item_clicked_(menuItemId);
+		menu_item_clicked_(menu_item_id);
 	}
 
 	void legacy_cartridge::initialize_pak()
@@ -218,11 +218,11 @@ namespace vcc { namespace core { namespace cartridges
 		const auto getModuleName(GetImportedProcAddress(handle_, "ModuleName", default_get_module_name));
 		getModuleName(buffer, buffer, addMenuItemCallback_);
 
-		const auto setIniPath(GetImportedProcAddress(handle_, "SetIniPath", default_set_ini_path));
-		setIniPath(configurationPath_.c_str());
-
 		const auto pakSetCart(GetImportedProcAddress(handle_, "SetCart", default_set_cart_pointer));
 		pakSetCart(assertCartCallback_);
+
+		const auto setIniPath(GetImportedProcAddress(handle_, "SetIniPath", default_set_ini_path));
+		setIniPath(configurationPath_.c_str());
 	}
 
 } } }

--- a/libcommon/src/core/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/core/cartridges/rom_cartridge.cpp
@@ -53,17 +53,17 @@ namespace vcc { namespace core { namespace cartridges
 		bank_offset_ = 0;
 	}
 
-	void rom_cartridge::write_port(unsigned char portId, unsigned char value)
+	void rom_cartridge::write_port(unsigned char port_id, unsigned char value)
 	{
-		if (enable_bank_switching_ && portId == 0x40)
+		if (enable_bank_switching_ && port_id == 0x40)
 		{
 			bank_offset_ = (value & 0x0f) << 14;
 		}
 	}
 
-	unsigned char rom_cartridge::read_memory_byte(unsigned short memoryAddress)
+	unsigned char rom_cartridge::read_memory_byte(unsigned short memory_address)
 	{
-		return buffer_[((memoryAddress & 32767) + bank_offset_) % buffer_.size()];
+		return buffer_[((memory_address & 32767) + bank_offset_) % buffer_.size()];
 	}
 
 	void rom_cartridge::initialize_bus()

--- a/libcommon/src/core/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/core/cartridges/rom_cartridge.cpp
@@ -37,12 +37,12 @@ namespace vcc { namespace core { namespace cartridges
 	{}
 
 
-	const rom_cartridge::name_type& rom_cartridge::name() const
+	rom_cartridge::name_type rom_cartridge::name() const
 	{
 		return name_;
 	}
 
-	const rom_cartridge::catalog_id_type& rom_cartridge::catalog_id() const
+	rom_cartridge::catalog_id_type rom_cartridge::catalog_id() const
 	{
 		return catalog_id_;
 	}

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -76,7 +76,6 @@ std::vector<CartMenuItem> SlotMenu[4] {};
 void UpdateSlotContent(int);
 void UpdateSlotConfig(int);
 void UpdateSlotSelect(int);
-void CenterDialog(HWND);
 void SetCartSlot0(bool lineState);
 void SetCartSlot1(bool lineState);
 void SetCartSlot2(bool lineState);
@@ -367,16 +366,6 @@ extern "C"
 		PakSetCart=Pointer;
 		return;
 	}
-}
-
-void CenterDialog(HWND hDlg)
-{
-	RECT rPar, rDlg;
-	GetWindowRect(GetParent(hDlg), &rPar);
-	GetWindowRect(hDlg, &rDlg);
-	int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
-	int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
-	SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
 LRESULT CALLBACK MpiConfigDlg(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -173,7 +173,6 @@ LRESULT CALLBACK SDC_Configure(HWND, UINT, WPARAM, LPARAM);
 void LoadConfig();
 bool SaveConfig(HWND);
 void BuildCartMenu();
-void CenterDialog(HWND);
 void SelectCardBox();
 void update_disk0_box();
 void UpdateFlashItem(int);
@@ -489,19 +488,6 @@ void BuildCartMenu()
     CartMenuCallback("SDC Config",ControlId(10),MIT_StandAlone);
     CartMenuCallback("SDC Control",ControlId(11),MIT_StandAlone);
     CartMenuCallback("",MID_FINISH,MIT_Head);
-}
-
-//------------------------------------------------------------
-// Center a dialog box in parent window
-//------------------------------------------------------------
-void CenterDialog(HWND hDlg)
-{
-    RECT rPar, rDlg;
-    GetWindowRect(GetParent(hDlg), &rPar);
-    GetWindowRect(hDlg, &rDlg);
-    int x = rPar.left + (rPar.right - rPar.left - (rDlg.right - rDlg.left)) / 2;
-    int y = rPar.top + (rPar.bottom - rPar.top - (rDlg.bottom - rDlg.top)) / 2;
-    SetWindowPos(hDlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION
A handful of minor changes used by in-progress changes.

- Moves `CenterDialog` into `DialogOps` and remove duplicates in cartridge implementations.
- Update names of parameters in `cartridge`, `legacy_cartridge`, and `rom_cartridge` to be more consistent.
- Updates the `cartridge` definition to be an abstract class (pretend interface).
- Adds `basic_cartridge` that provides default implementations of all abstract functions in `cartridge`.
- Changes `name` and `catalog_id` in `cartridge` (and derived types) to return string by value instead of by reference.


