### PR TITLE
update cartridge loader to support cartridge implemention

### DIFF
--- a/libcommon/include/vcc/core/cartridge_context.h
+++ b/libcommon/include/vcc/core/cartridge_context.h
@@ -15,14 +15,37 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include "multipak_cartridge.h"
-#include "host_cartridge_context.h"
-#include "configuration_dialog.h"
-#include <Windows.h>
+#pragma once
+#include <vcc/core/detail/exports.h>
+#include <vcc/core/interrupts.h>
+#include <string>
 
-extern HINSTANCE gModuleInstance;
-extern const std::shared_ptr<host_cartridge_context> gHostContext;
-extern multipak_cartridge gMultiPakInterface;
-extern configuration_dialog gConfigurationDialog;
-extern std::string gLastAccessedPath;
-extern std::string gConfigurationFilename;
+
+// FIXME: this needs to come from the common library but is currently part of the
+// main vcc app. Update this when it is migrated.
+enum MenuItemType;
+
+namespace vcc { namespace core
+{
+
+	struct LIBCOMMON_EXPORT cartridge_context
+	{
+		using path_type = ::std::string;
+
+
+		virtual ~cartridge_context() = default;
+
+		virtual path_type configuration_path() const = 0;
+
+		virtual void reset() = 0;
+
+		virtual void assert_cartridge_line(bool line_state) = 0;
+		virtual void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) = 0;
+
+		virtual void write_memory_byte(unsigned char value, unsigned short address) = 0;
+		virtual unsigned char read_memory_byte(unsigned short address) = 0;
+
+		virtual void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) = 0;
+	};
+
+} }

--- a/libcommon/include/vcc/core/cartridge_factory.h
+++ b/libcommon/include/vcc/core/cartridge_factory.h
@@ -15,14 +15,11 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include "multipak_cartridge.h"
-#include "host_cartridge_context.h"
-#include "configuration_dialog.h"
-#include <Windows.h>
+#pragma once
+#include <vcc/core/cartridge.h>
+#include <vcc/core/cartridge_context.h>
+#include <memory>
 
-extern HINSTANCE gModuleInstance;
-extern const std::shared_ptr<host_cartridge_context> gHostContext;
-extern multipak_cartridge gMultiPakInterface;
-extern configuration_dialog gConfigurationDialog;
-extern std::string gLastAccessedPath;
-extern std::string gConfigurationFilename;
+using CreatePakFactoryFunction = std::unique_ptr<::vcc::core::cartridge> (*)(std::unique_ptr<::vcc::core::cartridge_context> context);
+using GetPakFactoryFunction = CreatePakFactoryFunction(*)();
+

--- a/libcommon/include/vcc/core/cartridge_loader.h
+++ b/libcommon/include/vcc/core/cartridge_loader.h
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <vcc/core/cartridge.h>
+#include <vcc/core/cartridge_context.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 #include <vcc/core/utils/dll_deleter.h>
 #include <string>
@@ -58,7 +59,7 @@ namespace vcc { namespace core
 		cartridge_loader_status load_result = cartridge_loader_status::not_loaded;
 	};
 
-	struct LIBCOMMON_EXPORT cartridge_loader_context
+	struct cartridge_loader_context
 	{
 		const AppendCartridgeMenuModuleCallback addMenuItemCallback;
 		const ReadMemoryByteModuleCallback readData;
@@ -69,13 +70,15 @@ namespace vcc { namespace core
 
 	LIBCOMMON_EXPORT cartridge_file_type determine_cartridge_type(const std::string& filename);
 	LIBCOMMON_EXPORT cartridge_loader_result load_rom_cartridge(
-		const cartridge_loader_context& context,
+		std::unique_ptr<cartridge_context> context,
 		const std::string& filename);
 	LIBCOMMON_EXPORT cartridge_loader_result load_legacy_cartridge(
+		std::unique_ptr<cartridge_context> cartridge_context,
 		const cartridge_loader_context& context,
 		const std::string& filename,
 		const std::string& iniPath);
 	LIBCOMMON_EXPORT cartridge_loader_result load_cartridge(
+		std::unique_ptr<cartridge_context> cartridge_context,
 		const cartridge_loader_context& context,
 		const std::string& filename,
 		const std::string& iniPath);

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -17,8 +17,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <vcc/core/cartridges/basic_cartridge.h>
-#include <vcc/core/legacy_cartridge_definitions.h>
+#include <vcc/core/cartridge_context.h>
 #include <vector>
+#include <memory>
 
 
 namespace vcc { namespace core { namespace cartridges
@@ -28,6 +29,7 @@ namespace vcc { namespace core { namespace cartridges
 	{
 	public:
 
+		using context_type = ::vcc::core::cartridge_context;
 		using buffer_type = std::vector<uint8_t>;
 		using size_type = std::size_t;
 
@@ -38,7 +40,7 @@ namespace vcc { namespace core { namespace cartridges
 
 
 		LIBCOMMON_EXPORT rom_cartridge(
-			AssertCartridgeLineModuleCallback assertCartCallback,
+			std::unique_ptr<context_type> context,
 			name_type name,
 			catalog_id_type catalog_id,
 			buffer_type buffer,
@@ -59,7 +61,7 @@ namespace vcc { namespace core { namespace cartridges
 
 	private:
 
-		const AssertCartridgeLineModuleCallback assertCartCallback_;
+		const std::unique_ptr<context_type> context_;
 		const name_type name_;
 		const catalog_id_type catalog_id_;
 		const buffer_type buffer_;

--- a/libcommon/include/vcc/core/rom_image.h
+++ b/libcommon/include/vcc/core/rom_image.h
@@ -15,14 +15,62 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include "multipak_cartridge.h"
-#include "host_cartridge_context.h"
-#include "configuration_dialog.h"
-#include <Windows.h>
+#pragma once
+#include <vcc/core/detail/exports.h>
+#include <string>
+#include <vector>
 
-extern HINSTANCE gModuleInstance;
-extern const std::shared_ptr<host_cartridge_context> gHostContext;
-extern multipak_cartridge gMultiPakInterface;
-extern configuration_dialog gConfigurationDialog;
-extern std::string gLastAccessedPath;
-extern std::string gConfigurationFilename;
+namespace vcc { namespace core
+{
+
+	class rom_image
+	{
+	public:
+
+		using path_type = std::string;
+		using container_type = std::vector<unsigned char>;
+		using value_type = container_type::value_type;
+		using size_type = container_type::size_type;
+
+
+	public:
+
+		LIBCOMMON_EXPORT rom_image() = default;
+		LIBCOMMON_EXPORT ~rom_image() = default;
+
+		bool empty() const
+		{
+			return data_.empty();
+		}
+
+		path_type filename() const
+		{
+			return filename_;
+		}
+
+		LIBCOMMON_EXPORT bool load(path_type filename);
+
+		void clear()
+		{
+			filename_.clear();
+			data_.clear();
+		}
+
+		value_type read_memory_byte(size_type memory_address) const
+		{
+			if (data_.empty())
+			{
+				return 0;
+			}
+
+			return data_[memory_address % data_.size()];
+		}
+
+
+	private:
+
+		path_type filename_;
+		container_type data_;
+	};
+
+} }

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -102,6 +102,7 @@
     <ClCompile Include="src\core\cartridges\legacy_cartridge.cpp" />
     <ClCompile Include="src\core\cartridges\rom_cartridge.cpp" />
     <ClCompile Include="src\core\cartridge_loader.cpp" />
+    <ClCompile Include="src\core\rom_image.cpp" />
     <ClCompile Include="src\core\utils\configuration_serializer.cpp" />
     <ClCompile Include="src\core\utils\filesystem.cpp" />
     <ClCompile Include="src\core\utils\winapi.cpp" />
@@ -119,11 +120,14 @@
     <ClInclude Include="include\vcc\core\cartridges\legacy_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\null_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\rom_cartridge.h" />
+    <ClInclude Include="include\vcc\core\cartridge_context.h" />
+    <ClInclude Include="include\vcc\core\cartridge_factory.h" />
     <ClInclude Include="include\vcc\core\cartridge_loader.h" />
     <ClInclude Include="include\vcc\core\detail\exports.h" />
     <ClInclude Include="include\vcc\core\interrupts.h" />
     <ClInclude Include="include\vcc\core\legacy_cartridge_definitions.h" />
     <ClInclude Include="include\vcc\core\limits.h" />
+    <ClInclude Include="include\vcc\core\rom_image.h" />
     <ClInclude Include="include\vcc\core\utils\configuration_serializer.h" />
     <ClInclude Include="include\vcc\core\utils\critical_section.h" />
     <ClInclude Include="include\vcc\core\utils\dll_deleter.h" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="src\core\cartridges\basic_cartridge.cpp">
       <Filter>Source Files\core\cartridges</Filter>
     </ClCompile>
+    <ClCompile Include="src\core\rom_image.cpp">
+      <Filter>Source Files\core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource\resource.h">
@@ -133,6 +136,15 @@
     </ClInclude>
     <ClInclude Include="include\vcc\core\cartridges\basic_cartridge.h">
       <Filter>Header Files\core\cartridges</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\cartridge_context.h">
+      <Filter>Header Files\core</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\cartridge_factory.h">
+      <Filter>Header Files\core</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\core\rom_image.h">
+      <Filter>Header Files\core</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/src/core/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/core/cartridges/rom_cartridge.cpp
@@ -22,13 +22,13 @@ namespace vcc { namespace core { namespace cartridges
 {
 
 	rom_cartridge::rom_cartridge(
-		AssertCartridgeLineModuleCallback assertCartCallback,
+		std::unique_ptr<context_type> context,
 		name_type name,
 		catalog_id_type catalog_id,
 		buffer_type buffer,
 		bool enable_bank_switching)
 		:
-		assertCartCallback_(assertCartCallback),
+		context_(move(context)),
 		name_(move(name)),
 		catalog_id_(move(catalog_id)),
 		buffer_(move(buffer)),
@@ -68,7 +68,7 @@ namespace vcc { namespace core { namespace cartridges
 
 	void rom_cartridge::initialize_bus()
 	{
-		assertCartCallback_(true);
+		context_->assert_cartridge_line(true);
 	}
 
 } } }

--- a/libcommon/src/core/rom_image.cpp
+++ b/libcommon/src/core/rom_image.cpp
@@ -15,14 +15,40 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include "multipak_cartridge.h"
-#include "host_cartridge_context.h"
-#include "configuration_dialog.h"
+#include <vcc/core/rom_image.h>
+#include <fstream>
 #include <Windows.h>
 
-extern HINSTANCE gModuleInstance;
-extern const std::shared_ptr<host_cartridge_context> gHostContext;
-extern multipak_cartridge gMultiPakInterface;
-extern configuration_dialog gConfigurationDialog;
-extern std::string gLastAccessedPath;
-extern std::string gConfigurationFilename;
+
+namespace vcc { namespace core
+{
+
+	bool rom_image::load(path_type filename)
+	{
+		std::ifstream input(filename, std::ios::binary);
+		if (!input.is_open())
+		{
+			return false;
+		}
+
+		std::streamoff begin = input.tellg();
+		input.seekg(0, std::ios::end);
+		std::streamoff end = input.tellg();
+		std::streamoff file_length = end - begin;
+		input.seekg(0, std::ios::beg);
+
+		std::vector<unsigned char> rom_data(static_cast<size_t>(file_length));
+		input.read(reinterpret_cast<char*>(&rom_data[0]), rom_data.size());
+
+		if (file_length != rom_data.size())
+		{
+			return false;
+		}
+
+		filename_ = move(filename);
+		data_ = move(rom_data);
+
+		return true;
+	}
+
+} }

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -16,9 +16,9 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include "host_cartridge_context.h"
 #include <vcc/core/cartridge.h>
 #include <vcc/core/cartridge_loader.h>
+#include <vcc/core/cartridge_context.h>
 #include "../CartridgeMenu.h"
 
 
@@ -37,7 +37,7 @@ namespace vcc { namespace modules { namespace mpi
 		using cartridge_ptr_type = ::std::unique_ptr<::vcc::core::cartridge>;
 		using menu_item_type = CartMenuItem;
 		using menu_item_collection_type = std::vector<menu_item_type>;
-		using context_type = host_cartridge_context;// ::vcc::core::cartridge_context;
+		using context_type = ::vcc::core::cartridge_context;
 
 
 	public:

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -1,5 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
 #pragma once
-//#include <vcc/core/cartridge_context.h>
+#include <vcc/core/cartridge_context.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 
 extern "C" __declspec(dllexport) void ModuleName(char*, char*, AppendCartridgeMenuModuleCallback);
@@ -7,31 +24,51 @@ extern "C" __declspec(dllexport) void MemPointers(ReadMemoryByteModuleCallback, 
 extern "C" __declspec(dllexport) void AssertInterupt(AssertInteruptModuleCallback);
 extern "C" __declspec(dllexport) void SetCart(AssertCartridgeLineModuleCallback);
 
-class host_cartridge_context //: public ::vcc::core::cartridge_context
+class host_cartridge_context : public ::vcc::core::cartridge_context
 {
 public:
 
-	void write_memory_byte(unsigned char value, unsigned short address) //override
+	// FIXME: Remove this when we derive from cartridge_context
+	using path_type = ::std::string;
+
+
+public:
+
+	explicit host_cartridge_context(const path_type& configuration_filename)
+		: configuration_filename_(configuration_filename)
+	{}
+
+	path_type configuration_path() const override
+	{
+		return configuration_filename_;
+	}
+
+	void reset() override
+	{
+		// FIXME-CHET: this needs to do something
+	}
+
+	void write_memory_byte(unsigned char value, unsigned short address) override
 	{
 		write_memory_byte_(value, address);
 	}
 
-	unsigned char read_memory_byte(unsigned short address) //override
+	unsigned char read_memory_byte(unsigned short address) override
 	{
 		return read_memory_byte_(address);
 	}
 
-	void assert_cartridge_line(bool line_state) //override
+	void assert_cartridge_line(bool line_state) override
 	{
 		assert_cartridge_line_(line_state);
 	}
 
-	void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) //override
+	void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) override
 	{
 		assert_interrupt_(interrupt, interrupt_source);
 	}
 
-	void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) //override
+	void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) override
 	{
 		add_menu_item_(menu_name, menu_id, menu_type);
 	}
@@ -47,6 +84,7 @@ private:
 
 private:
 
+	const path_type&					configuration_filename_;
 	WriteMemoryByteModuleCallback		write_memory_byte_ = [](unsigned char, unsigned short) {};
 	ReadMemoryByteModuleCallback		read_memory_byte_ = [](unsigned short) -> unsigned char { return 0; };
 	AssertCartridgeLineModuleCallback	assert_cartridge_line_ = [](bool) {};

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -27,10 +27,10 @@
 #define EXPORT_PUBLIC_API extern "C" __declspec(dllexport)
 
 HINSTANCE gModuleInstance = nullptr;
-const std::shared_ptr<host_cartridge_context> gHostContext(std::make_shared<host_cartridge_context>());
+std::string gConfigurationFilename;
+const std::shared_ptr<host_cartridge_context> gHostContext(std::make_shared<host_cartridge_context>(gConfigurationFilename));
 multipak_cartridge gMultiPakInterface(gHostContext);
 configuration_dialog gConfigurationDialog(gMultiPakInterface);
-std::string gConfigurationFilename;
 
 
 BOOL WINAPI DllMain(HINSTANCE module_instance, DWORD reason, LPVOID /*reserved*/)

--- a/mpi/mpi.vcxproj
+++ b/mpi/mpi.vcxproj
@@ -104,6 +104,7 @@
     <ClInclude Include="mpi.h" />
     <ClInclude Include="multipak_cartridge.h" />
     <ClInclude Include="configuration_dialog.h" />
+    <ClInclude Include="multipak_cartridge_context.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/mpi/mpi.vcxproj.filters
+++ b/mpi/mpi.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="host_cartridge_context.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="multipak_cartridge_context.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -30,7 +30,7 @@ class multipak_cartridge : public ::vcc::core::cartridge
 {
 public:
 
-	using context_type = host_cartridge_context;// ::vcc::core::cartridge_context;
+	using context_type = ::vcc::core::cartridge_context;
 	using mount_status_type = ::vcc::core::cartridge_loader_status;
 	using slot_id_type = ::std::size_t;
 	using path_type = ::std::string;

--- a/mpi/multipak_cartridge_context.h
+++ b/mpi/multipak_cartridge_context.h
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include "multipak_cartridge.h"
+#include <vcc/core/cartridge_context.h>
+
+
+class multipak_cartridge_context : public ::vcc::core::cartridge_context
+{
+public:
+
+	multipak_cartridge_context(size_t slot_id, ::vcc::core::cartridge_context& parent_context, multipak_cartridge& multipak)
+		:
+		slot_id_(slot_id),
+		parent_context_(parent_context),
+		multipak_(multipak)
+	{}
+
+	path_type configuration_path() const override
+	{
+		return parent_context_.configuration_path();
+	}
+
+	void reset() override
+	{
+		parent_context_.reset();
+	}
+
+	void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) override
+	{
+		multipak_.append_menu_item(slot_id_, { menu_name, static_cast<unsigned int>(menu_id), menu_type });
+	}
+
+	void write_memory_byte(unsigned char value, unsigned short address) override
+	{
+		parent_context_.write_memory_byte(value, address);
+	}
+
+	unsigned char read_memory_byte(unsigned short address) override
+	{
+		return parent_context_.read_memory_byte(address);
+	}
+
+	void assert_cartridge_line(bool line_state) override
+	{
+		multipak_.assert_cartridge_line(slot_id_, line_state);
+	}
+
+	void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) override
+	{
+		parent_context_.assert_interrupt(interrupt, interrupt_source);
+	}
+
+
+private:
+
+	const size_t slot_id_;
+	::vcc::core::cartridge_context& parent_context_;
+	multipak_cartridge& multipak_;
+};


### PR DESCRIPTION
Updates cartridge loader and clients (pakinterface, mpi) to support loading a cartridge implementing the `cartridge` interface.

* Adds `cartridge_context` to provide a fluent interface to the host environment.
* Adds cartridge factory definitions for the functions exported by the dll to create a `cartridge`.
* Updates `cartridge_loader` to search for `GetPakFactory` in the loaded dll and if present use it to construct a `cartridge`.
* Updates `rom_cartridge` to use the `cartridge_context` interface instead of callbacks.
* Adds basic support for loading a ROM image (separate from loading a ROM cartridge/program pak).
* Updates MPI implementation to provide addition implementations of `cartridge_context` for use in mounting a cartridge.
