### PR TITLE
Refactor C API cartridge interface

### DIFF
--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -19,8 +19,9 @@ This file is part of VCC (Virtual Color Computer).
 */
 #include <vcc/core/legacy_cartridge_definitions.h>
 
-extern AssertInteruptModuleCallback AssertInt;
-void BuildDynaMenu();
+extern void*const& gHostKey;
+extern PakAssertInteruptHostCallback AssertInt;
+void BuildCartridgeMenu();
 
 // FIXME: These need to be turned into a scoped enum and the signature of functions
 // that use them updated.

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -245,7 +245,7 @@ int mount_disk_image(const char *filename,unsigned char drive)
 {
 	unsigned int Temp=0;
 	Temp=MountDisk(filename,drive);
-	BuildDynaMenu();
+	BuildCartridgeMenu();
 	return(!Temp);
 }
 
@@ -264,13 +264,12 @@ void unmount_disk_image(unsigned char drive)
 	return;
 }
 
-void DiskStatus(char *Status)
+void DiskStatus(char* text_buffer, size_t buffer_size)
 {
 	if (MotorOn==1) 
-		sprintf(Status,"FD-502:Drv:%1.1i %s Trk:%2.2i Sec:%2.2i Hd:%1.1i",CurrentDisk,ImageFormat[Drive[CurrentDisk].ImageType],Drive[CurrentDisk].HeadPosition,SectorReg,Side);
+		sprintf(text_buffer,"FD-502:Drv:%1.1i %s Trk:%2.2i Sec:%2.2i Hd:%1.1i",CurrentDisk,ImageFormat[Drive[CurrentDisk].ImageType],Drive[CurrentDisk].HeadPosition,SectorReg,Side);
 	else
-		sprintf(Status,"FD-502:Idle");
-	return;
+		sprintf(text_buffer,"FD-502:Idle");
 }
 
 unsigned char MountDisk(const char *FileName,unsigned char disk)
@@ -953,7 +952,7 @@ void DispatchCommand(unsigned char Tmp)
 			StatusReg=READY;
 			ExecTimeWaiter=1;
 			if ((Tmp & 15) != 0)
-				AssertInt(INT_NMI,IS_NMI);
+				AssertInt(gHostKey, INT_NMI,IS_NMI);
 //			WriteLog("FORCEINTERUPT",0);
 			break;
 
@@ -1298,7 +1297,7 @@ long GetSectorInfo (SectorInfo *Sector,const unsigned char *TempBuffer)
 void CommandDone()
 {
 	if (InteruptEnable)
-		AssertInt(INT_NMI,IS_NMI);
+		AssertInt(gHostKey, INT_NMI,IS_NMI);
 	TransferBufferSize=0;
 	CurrentCommand=IDLE;
 }

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -22,7 +22,7 @@ unsigned char disk_io_read(unsigned char port);
 void disk_io_write(unsigned char data,unsigned char port);	
 int mount_disk_image(const char *,unsigned char );
 void unmount_disk_image(unsigned char drive);
-void DiskStatus(char *);
+void DiskStatus(char* text_buffer, size_t buffer_size);
 void PingFdc();
 unsigned char SetTurboDisk( unsigned char);
 //unsigned char UseKeyboardLeds(unsigned char);

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -3,8 +3,8 @@
 
 namespace detail
 {
-	void NullAssetCartridgeLine(bool) {}
-	void NullAddMenuItem(const char *, int, MenuItemType) {}
+	void NullAssetCartridgeLine(void*, bool) {}
+	void NullAddMenuItem(void*, const char *, int, MenuItemType) {}
 }
 
 
@@ -60,7 +60,13 @@ std::string Cartridge::GetCatalogId() const
 
 
 
-void Cartridge::SetCartLineAssertCallback(AssertCartridgeLineModuleCallback callback)
+void Cartridge::SetHostKey(void* key)
+{
+	m_HostKey = key;
+}
+
+
+void Cartridge::SetCartLineAssertCallback(PakAssertCartridgeLineHostCallback callback)
 {
 	AssetCartridgeLinePtr = callback;
 }
@@ -74,7 +80,7 @@ void Cartridge::SetConfigurationPath(std::string path)
 }
 
 
-void Cartridge::SetMenuBuilderCallback(AppendCartridgeMenuModuleCallback callback)
+void Cartridge::SetMenuBuilderCallback(PakAppendCartridgeMenuHostCallback callback)
 {
 	AddMenuItemPtr = callback;
 }

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -17,8 +17,9 @@ public:
 	virtual std::string GetName() const;
 	virtual std::string GetCatalogId() const;
 
-	virtual void SetCartLineAssertCallback(AssertCartridgeLineModuleCallback callback);
-	virtual void SetMenuBuilderCallback(AppendCartridgeMenuModuleCallback addMenuCallback);
+	virtual void SetHostKey(void* key);
+	virtual void SetCartLineAssertCallback(PakAssertCartridgeLineHostCallback callback);
+	virtual void SetMenuBuilderCallback(PakAppendCartridgeMenuHostCallback addMenuCallback);
 	virtual void SetConfigurationPath(std::string path);
 
 	virtual std::string GetStatusMessage() const;
@@ -35,12 +36,12 @@ protected:
 
 	void AssetCartridgeLine(bool state) const
 	{
-		AssetCartridgeLinePtr(state);
+		AssetCartridgeLinePtr(m_HostKey, state);
 	}
 
 	void AddMenuItem(const char * name, int id, MenuItemType type)
 	{
-		AddMenuItemPtr(name, id, type);
+		AddMenuItemPtr(m_HostKey, name, id, type);
 	}
 
 	virtual void LoadConfiguration(const std::string& filename);
@@ -48,25 +49,29 @@ protected:
 
 private:
 
-	friend void ModuleName(char *ModName, char *CatNumber, AppendCartridgeMenuModuleCallback addMenuCallback);
-	friend void ModuleStatus(char *statusBuffer);
-	friend void ModuleConfig(unsigned char menuId);
-	friend void SetIniPath(const char *iniFilePath);
-	friend void ModuleReset();
-	friend void SetCart(AssertCartridgeLineModuleCallback Pointer);
-	friend unsigned char PakMemRead8(unsigned short address);
-	friend void PackPortWrite(unsigned char port, unsigned char data);
-	friend unsigned char PackPortRead(unsigned char port);
-	friend unsigned short ModuleAudioSample();
+	friend const char* PakGetName();
+	friend const char* PakCatalogName();
+	friend void PakInitialize(
+		void* const host_key,
+		const char* const configuration_path,
+		const pak_initialization_parameters* const parameters);
+	friend void PakGetStatus(char* text_buffer, size_t buffer_size);
+	friend void PakMenuItemClicked(unsigned char menuId);
+	friend void PakReset();
+	friend unsigned char PakReadMemoryByte(unsigned short address);
+	friend void PakWritePort(unsigned char port, unsigned char data);
+	friend unsigned char PakReadPort(unsigned char port);
+	friend unsigned short PakSampleAudio();
 
 private:
 
 	static Cartridge*	m_Singleton;
 
+	void*				m_HostKey = nullptr;
 	std::string			m_Name;
 	std::string			m_CatalogId;
 	std::string			m_ConfigurationPath;
-	AssertCartridgeLineModuleCallback	AssetCartridgeLinePtr = detail::NullAssetCartridgeLine;
-	AppendCartridgeMenuModuleCallback 	AddMenuItemPtr = detail::NullAddMenuItem;
+	PakAssertCartridgeLineHostCallback	AssetCartridgeLinePtr = detail::NullAssetCartridgeLine;
+	PakAppendCartridgeMenuHostCallback 	AddMenuItemPtr = detail::NullAddMenuItem;
 };
 

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -2,41 +2,41 @@
 #include "Cartridge.h"
 
 
-GMC_EXPORT void ModuleName(char *moduleName, char *catalogId, AppendCartridgeMenuModuleCallback addMenuCallback)
+GMC_EXPORT const char* PakGetName()
 {
-	Cartridge::m_Singleton->SetMenuBuilderCallback(addMenuCallback);
+	return Cartridge::m_Singleton->GetName().c_str();
+}
 
-	strcpy(moduleName, Cartridge::m_Singleton->GetName().c_str());
-	strcpy(catalogId, Cartridge::m_Singleton->GetCatalogId().c_str());
+GMC_EXPORT const char* PakCatalogName()
+{
+	return Cartridge::m_Singleton->GetCatalogId().c_str();
+}
+
+GMC_EXPORT void PakInitialize(
+	void* const host_key,
+	const char* const configuration_path,
+	const pak_initialization_parameters* const parameters)
+{
+	Cartridge::m_Singleton->SetHostKey(host_key);
+	Cartridge::m_Singleton->SetMenuBuilderCallback(parameters->add_menu_item);
+	Cartridge::m_Singleton->SetCartLineAssertCallback(parameters->assert_cartridge_line);
+	Cartridge::m_Singleton->SetConfigurationPath(configuration_path);
 }
 
 
-GMC_EXPORT void ModuleConfig(unsigned char menuId)
+GMC_EXPORT void PakMenuItemClicked(unsigned char menuId)
 {
 	Cartridge::m_Singleton->OnMenuItemSelected(menuId);
 }
 
 
-GMC_EXPORT void SetIniPath(const char *iniFilePath)
-{
-	Cartridge::m_Singleton->SetConfigurationPath(iniFilePath);
-}
-
-
-GMC_EXPORT void ModuleReset()
+GMC_EXPORT void PakReset()
 {
 	Cartridge::m_Singleton->OnReset();
 }
 
 
-GMC_EXPORT void SetCart(AssertCartridgeLineModuleCallback callback)
-{
-	Cartridge::m_Singleton->SetCartLineAssertCallback(callback);
-}
-
-
-
-GMC_EXPORT void ModuleStatus(char *statusBuffer)
+GMC_EXPORT void PakGetStatus(char* text_buffer, size_t buffer_size)
 {
 	auto message(Cartridge::m_Singleton->GetStatusMessage());
 	if (message.size() > 63)
@@ -44,11 +44,11 @@ GMC_EXPORT void ModuleStatus(char *statusBuffer)
 		message.resize(63);
 	}
 
-	strcpy(statusBuffer, message.c_str());
+	strcpy(text_buffer, message.c_str());
 }
 
 
-GMC_EXPORT unsigned char PakMemRead8(unsigned short address)
+GMC_EXPORT unsigned char PakReadMemoryByte(unsigned short address)
 {
 	return Cartridge::m_Singleton->OnReadMemory(address);
 }
@@ -56,20 +56,20 @@ GMC_EXPORT unsigned char PakMemRead8(unsigned short address)
 
 
 
-GMC_EXPORT void PackPortWrite(unsigned char port, unsigned char data)
+GMC_EXPORT void PakWritePort(unsigned char port, unsigned char data)
 {
 	Cartridge::m_Singleton->OnWritePort(port, data);
 }
 
 
-GMC_EXPORT unsigned char PackPortRead(unsigned char port)
+GMC_EXPORT unsigned char PakReadPort(unsigned char port)
 {
 	return Cartridge::m_Singleton->OnReadPort(port);
 }
 
 
 // This gets called at the end of every scan line 262 Lines * 60 Frames = 15780 Hz 15720
-GMC_EXPORT unsigned short ModuleAudioSample()
+GMC_EXPORT unsigned short PakSampleAudio()
 {
 	return Cartridge::m_Singleton->UpdateAudio();
 }

--- a/GMC/CartridgeTrampolines.h
+++ b/GMC/CartridgeTrampolines.h
@@ -1,14 +1,17 @@
 #pragma once
 #include "GMC.h"
 
+GMC_EXPORT const char* PakGetName();
+GMC_EXPORT const char* PakCatalogName();
+GMC_EXPORT void PakInitialize(
+	void* const host_key,
+	const char* const configuration_path,
+	const pak_initialization_parameters* const parameters);
 
-GMC_EXPORT void ModuleName(char *ModName, char *CatNumber, AppendCartridgeMenuModuleCallback addMenuCallback);
-GMC_EXPORT void ModuleStatus(char *statusBuffer);
-GMC_EXPORT void ModuleConfig(unsigned char /*menuId*/);
-GMC_EXPORT void SetIniPath(const char *iniFilePath);
-GMC_EXPORT void ModuleReset();
-GMC_EXPORT void SetCart(AssertCartridgeLineModuleCallback Pointer);
-GMC_EXPORT unsigned char PakMemRead8(unsigned short address);
-GMC_EXPORT void PackPortWrite(unsigned char port, unsigned char data);
-GMC_EXPORT unsigned char PackPortRead(unsigned char port);
-GMC_EXPORT unsigned short ModuleAudioSample();
+GMC_EXPORT void PakGetStatus(char* text_buffer, size_t buffer_size);
+GMC_EXPORT void PakMenuItemClicked(unsigned char /*menuId*/);
+GMC_EXPORT void PakReset();
+GMC_EXPORT unsigned char PakReadMemoryByte(unsigned short address);
+GMC_EXPORT void PakWritePort(unsigned char port, unsigned char data);
+GMC_EXPORT unsigned char PakReadPort(unsigned char port);
+GMC_EXPORT unsigned short PakSampleAudio();

--- a/GMC/detail/default_handlers.h
+++ b/GMC/detail/default_handlers.h
@@ -1,5 +1,5 @@
 namespace detail
 {
-	void NullAssetCartridgeLine(bool);
-	void NullAddMenuItem(const char*, int, MenuItemType);
+	void NullAssetCartridgeLine(void*, bool);
+	void NullAddMenuItem(void*, const char*, int, MenuItemType);
 }

--- a/HardDisk/cc3vhd.cpp
+++ b/HardDisk/cc3vhd.cpp
@@ -226,9 +226,9 @@ void HDcommand(unsigned char Command) {
     }
 }
 
-void DiskStatus(char *Temp)
+void DiskStatus(char* text_buffer, size_t buffer_size)
 {
-    strcpy(Temp,DStatus);
+    strcpy(text_buffer,DStatus);
     ScanCount++;
 
     if (SectorOffset.All != LastSectorNum) {

--- a/HardDisk/cc3vhd.h
+++ b/HardDisk/cc3vhd.h
@@ -25,7 +25,7 @@ void UnmountHD(int);
 int MountHD(const char*, int);
 unsigned char IdeRead(unsigned char);
 void IdeWrite (unsigned char, unsigned char);
-void DiskStatus(char *);
+void DiskStatus(char* text_buffer, size_t buffer_size);
 void VhdReset();
 
 constexpr auto DRIVESIZE = 512u; // Mb

--- a/SuperIDE/IdeBus.cpp
+++ b/SuperIDE/IdeBus.cpp
@@ -314,9 +314,9 @@ HANDLE OpenDisk(const char *ImageFile,unsigned char DiskNum)
 	return hTemp;
 }
 
-void DiskStatus(char *Temp)
+void DiskStatus(char* text_buffer, size_t buffer_size)
 {
-	strcpy(Temp,CurrStatus);
+	strcpy(text_buffer,CurrStatus);
 	ScanCount++;
 	if (Lba != LastLba)
 	{

--- a/SuperIDE/IdeBus.h
+++ b/SuperIDE/IdeBus.h
@@ -32,7 +32,7 @@ struct IDEINTERFACE {
 void IdeInit();
 void IdeRegWrite(unsigned char,unsigned short);
 unsigned short IdeRegRead(unsigned char);
-void DiskStatus(char *);
+void DiskStatus(char* text_buffer, size_t buffer_size);
 unsigned char MountDisk(const char *,unsigned char );
 unsigned char DropDisk(unsigned char);
 void QueryDisk(unsigned char,char *);

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -68,7 +68,8 @@ extern char AciaTcpHost[MAX_PATH];    // Tcpip hostname
 extern char AciaFileRdPath[MAX_PATH]; // Path for file reads
 extern char AciaFileWrPath[MAX_PATH]; // Path for file writes
 
-extern AssertInteruptModuleCallback AssertInt;
+extern PakAssertInteruptHostCallback AssertInt;
+extern void* const& gHostKey;
 
 // Device
 extern void sc6551_init();

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -250,7 +250,7 @@ void sc6551_heartbeat()
             StatReg |= StatRxF;
             // Assert CART if interrupts not disabled or already asserted.
             if (!((CmdReg & CmdRxI) || (StatReg & StatIRQ))) {
-                AssertInt(INT_CART, IS_NMI);
+                AssertInt(gHostKey, INT_CART, IS_NMI);
                 StatReg |= StatIRQ;
             }
         }

--- a/becker/becker.h
+++ b/becker/becker.h
@@ -10,7 +10,7 @@
 // functions
 void MemWrite(unsigned char,unsigned short );
 unsigned char MemRead(unsigned short );
-void BuildDynaMenu();
+void BuildCartridgeMenu();
 
 extern const unsigned char Rom[8192];
 

--- a/iobus.cpp
+++ b/iobus.cpp
@@ -154,7 +154,7 @@ unsigned char port_read(unsigned short addr)
 			temp=GimeRead(port);
 		break;
 		default:
-			temp=PackPortRead (port);
+			temp=PakReadPort (port);
 		}
 	return temp;
 }
@@ -268,7 +268,7 @@ void port_write(unsigned char data,unsigned short addr)
 			GimeWrite(port,data);
 		break;
 		default:
-			PackPortWrite (port,data);
+			PakWritePort (port,data);
 	}
 	return;
 }

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -48,7 +48,7 @@ namespace vcc { namespace core
 		virtual void write_port(unsigned char port_id, unsigned char value) = 0;
 		virtual unsigned char read_port(unsigned char port_id) = 0;
 		virtual unsigned char read_memory_byte(unsigned short memory_address) = 0;
-		virtual void status(char* status) = 0;
+		virtual void status(char* text_buffer, size_t buffer_size) = 0;
 		virtual unsigned short sample_audio() = 0;
 		virtual void menu_item_clicked(unsigned char menu_item_id) = 0;
 	};

--- a/libcommon/include/vcc/core/cartridge_loader.h
+++ b/libcommon/include/vcc/core/cartridge_loader.h
@@ -61,26 +61,31 @@ namespace vcc { namespace core
 
 	struct cartridge_loader_context
 	{
-		const AppendCartridgeMenuModuleCallback addMenuItemCallback;
-		const ReadMemoryByteModuleCallback readData;
-		const WriteMemoryByteModuleCallback writeData;
-		const AssertInteruptModuleCallback assertInterrupt;
-		const AssertCartridgeLineModuleCallback assertCartridgeLine;
+		const PakAssertInteruptHostCallback pak_assert_interrupt;
+		const PakAssertCartridgeLineHostCallback pak_assert_cartridge_line;
+		const PakWriteMemoryByteHostCallback pak_write_memory_byte;
+		const PakReadMemoryByteHostCallback pak_read_memory_byte;
+		const PakAppendCartridgeMenuHostCallback pak_add_menu_item;
 	};
 
 	LIBCOMMON_EXPORT cartridge_file_type determine_cartridge_type(const std::string& filename);
+
 	LIBCOMMON_EXPORT cartridge_loader_result load_rom_cartridge(
-		std::unique_ptr<cartridge_context> context,
-		const std::string& filename);
+		const std::string& filename,
+		std::unique_ptr<cartridge_context> cartridge_context);
+
 	LIBCOMMON_EXPORT cartridge_loader_result load_legacy_cartridge(
-		std::unique_ptr<cartridge_context> cartridge_context,
-		const cartridge_loader_context& context,
 		const std::string& filename,
-		const std::string& iniPath);
+		std::unique_ptr<cartridge_context> cartridge_context,
+		void* const host_context,
+		const std::string& iniPath,
+		const pak_initialization_parameters& pak_parameters);
+
 	LIBCOMMON_EXPORT cartridge_loader_result load_cartridge(
-		std::unique_ptr<cartridge_context> cartridge_context,
-		const cartridge_loader_context& context,
 		const std::string& filename,
-		const std::string& iniPath);
+		std::unique_ptr<cartridge_context> cartridge_context,
+		void* const host_context,
+		const std::string& iniPath,
+		const pak_initialization_parameters& pak_parameters);
 
 } }

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -43,7 +43,7 @@ namespace vcc { namespace core { namespace cartridges
 		void write_port(unsigned char port_id, unsigned char value) override;
 		unsigned char read_port(unsigned char port_id) override;
 		unsigned char read_memory_byte(unsigned short memory_address) override;
-		void status(char* status) override;
+		void status(char* text_buffer, size_t buffer_size) override;
 		unsigned short sample_audio() override;
 		void menu_item_clicked(unsigned char menu_item_id) override;
 

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -16,7 +16,7 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridges/basic_cartridge.h>
+#include <vcc/core/cartridge.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 #include <Windows.h>
 #include <string>
@@ -25,7 +25,7 @@
 namespace vcc { namespace core { namespace cartridges
 {
 
-	class legacy_cartridge: public basic_cartridge
+	class legacy_cartridge: public cartridge
 	{
 	public:
 
@@ -35,55 +35,43 @@ namespace vcc { namespace core { namespace cartridges
 	public:
 
 		LIBCOMMON_EXPORT legacy_cartridge(
-			HMODULE moduleHandle,
-			const path_type& configurationPath,
-			AppendCartridgeMenuModuleCallback addMenuItemCallback,
-			ReadMemoryByteModuleCallback readDataFunction,
-			WriteMemoryByteModuleCallback writeDataFunction,
-			AssertInteruptModuleCallback assertCallback,
-			AssertCartridgeLineModuleCallback assertCartCallback);
+			HMODULE module_handle,
+			void* const host_context,
+			path_type configuration_path,
+			const pak_initialization_parameters& parameters);
 
 		LIBCOMMON_EXPORT name_type name() const override;
 		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
 
+		LIBCOMMON_EXPORT void start() override;
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void heartbeat() override;
-		LIBCOMMON_EXPORT void status(char* status) override;
+		LIBCOMMON_EXPORT void status(char* text_buffer, size_t buffer_size) override;
 		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;
 		LIBCOMMON_EXPORT unsigned char read_port(unsigned char port_id) override;
 		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memory_address) override;
 		LIBCOMMON_EXPORT unsigned short sample_audio() override;
 		LIBCOMMON_EXPORT void menu_item_clicked(unsigned char menu_item_id) override;
 
-
-	protected:
-
-		LIBCOMMON_EXPORT void initialize_pak() override;
-
-
 	private:
 
 		const HMODULE handle_;
-		const path_type configurationPath_;
-		const name_type name_;
-		const catalog_id_type catalog_id_;
-
-		// callbacks
-		const AppendCartridgeMenuModuleCallback addMenuItemCallback_;
-		const ReadMemoryByteModuleCallback readDataFunction_;
-		const WriteMemoryByteModuleCallback writeDataFunction_;
-		const AssertInteruptModuleCallback assertCallback_;
-		const AssertCartridgeLineModuleCallback assertCartCallback_;
+		void* const host_context_;
+		const path_type configuration_path_;
+		const pak_initialization_parameters parameters_;
 
 		// imported module functions
-		const ResetModuleFunction reset_;
-		const HeartBeatModuleFunction heartbeat_;
-		const GetStatusModuleFunction status_;
-		const WritePortModuleFunction  write_port_;
-		const ReadPortModuleFunction read_port_;
-		const ReadMemoryByteModuleFunction read_memory_byte_;
-		const SampleAudioModuleFunction sample_audio_;
-		const MenuItemClickedModuleFunction menu_item_clicked_;
+		const PakInitializeModuleFunction initialize_;
+		const PakGetNameModuleFunction get_name_;
+		const PakGetCatalogIdModuleFunction get_catalog_id_;
+		const PakResetModuleFunction reset_;
+		const PakHeartBeatModuleFunction heartbeat_;
+		const PakGetStatusModuleFunction status_;
+		const PakWritePortModuleFunction  write_port_;
+		const PakReadPortModuleFunction read_port_;
+		const PakReadMemoryByteModuleFunction read_memory_byte_;
+		const PakSampleAudioModuleFunction sample_audio_;
+		const PakMenuItemClickedModuleFunction menu_item_clicked_;
 	};
 
 } } }

--- a/libcommon/include/vcc/core/legacy_cartridge_definitions.h
+++ b/libcommon/include/vcc/core/legacy_cartridge_definitions.h
@@ -18,26 +18,41 @@
 #pragma once
 #include <vcc/core/interrupts.h>
 
-// FIXME: this needs to come from the common library but is currently part of the
-// main vcc app. Update this when it is migrated.
-enum MenuItemType;
+extern "C"
+{
 
-using WriteMemoryByteModuleCallback = void (*)(unsigned char value, unsigned short address);
-using ReadMemoryByteModuleCallback = unsigned char (*)(unsigned short address);
-using AssertCartridgeLineModuleCallback = void (*)(bool lineState);
-using AssertInteruptModuleCallback = void (*)(Interrupt interrupt, InterruptSource interrupt_source);
-using AppendCartridgeMenuModuleCallback = void (*)(const char* menu_name, int menu_id, MenuItemType menu_type);
+	// FIXME: this needs to come from the common library but is currently part of the
+	// main vcc app. Update this when it is migrated.
+	enum MenuItemType;
 
-using GetNameModuleFunction = void (*)(char* name_text, char* catalog_id_text, AppendCartridgeMenuModuleCallback addMenuItemCallback);
-using SetDMACallbacksModuleFunction = void (*)(ReadMemoryByteModuleCallback, WriteMemoryByteModuleCallback);
-using SetAssertInterruptCallbackModuleFunction = void (*)(AssertInteruptModuleCallback callback);
-using SetConfigurationPathModuleFunction = void (*)(const char* path);
-using SetAssertCartridgeLineCallbackModuleFunction = void (*)(AssertCartridgeLineModuleCallback callback);
-using ResetModuleFunction = void (*)();
-using HeartBeatModuleFunction = void (*)();
-using GetStatusModuleFunction = void (*)(char* status_text);
-using WritePortModuleFunction = void (*)(unsigned char port, unsigned char value);
-using ReadMemoryByteModuleFunction = unsigned char (*)(unsigned short address);
-using ReadPortModuleFunction = unsigned char (*)(unsigned char port);
-using SampleAudioModuleFunction = unsigned short (*)();
-using MenuItemClickedModuleFunction = void (*)(unsigned char itemId);
+	using PakWriteMemoryByteHostCallback = void (*)(void* host_key, unsigned char value, unsigned short address);
+	using PakReadMemoryByteHostCallback = unsigned char (*)(void* host_key, unsigned short address);
+	using PakAssertCartridgeLineHostCallback = void (*)(void* host_key, bool lineState);
+	using PakAssertInteruptHostCallback = void (*)(void* host_key, Interrupt interrupt, InterruptSource interrupt_source);
+	using PakAppendCartridgeMenuHostCallback = void (*)(void* host_key, const char* menu_name, int menu_id, MenuItemType menu_type);
+
+	struct pak_initialization_parameters
+	{
+		const PakAssertInteruptHostCallback assert_interrupt;
+		const PakAssertCartridgeLineHostCallback assert_cartridge_line;
+		const PakWriteMemoryByteHostCallback write_memory_byte;
+		const PakReadMemoryByteHostCallback read_memory_byte;
+		const PakAppendCartridgeMenuHostCallback add_menu_item;
+	};
+
+	using PakInitializeModuleFunction = void (*)(
+		void* host_key,
+		const char* const configuration_path,
+		const pak_initialization_parameters* const parameters);
+	using PakGetNameModuleFunction = const char* (*)();
+	using PakGetCatalogIdModuleFunction = const char* (*)();
+	using PakResetModuleFunction = void (*)();
+	using PakHeartBeatModuleFunction = void (*)();
+	using PakGetStatusModuleFunction = void (*)(char* text_buffer, size_t buffer_size);
+	using PakWritePortModuleFunction = void (*)(unsigned char port, unsigned char value);
+	using PakReadMemoryByteModuleFunction = unsigned char (*)(unsigned short address);
+	using PakReadPortModuleFunction = unsigned char (*)(unsigned char port);
+	using PakSampleAudioModuleFunction = unsigned short (*)();
+	using PakMenuItemClickedModuleFunction = void (*)(unsigned char itemId);
+
+}

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -57,9 +57,9 @@ namespace vcc { namespace core { namespace cartridges
 		return {};
 	}
 
-	void basic_cartridge::status(char* status_buffer)
+	void basic_cartridge::status(char* text_buffer, size_t buffer_size)
 	{
-		*status_buffer = 0;
+		*text_buffer = 0;
 	}
 
 	unsigned short basic_cartridge::sample_audio()

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -102,9 +102,9 @@ namespace vcc { namespace modules { namespace mpi
 			return cartridge_->read_memory_byte(memory_address);
 		}
 
-		void status(char* status) const
+		void status(char* text_buffer, size_t buffer_size) const
 		{
-			cartridge_->status(status);
+			cartridge_->status(text_buffer, buffer_size);
 		}
 
 		unsigned short sample_audio() const

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -19,11 +19,12 @@
 #include <vcc/core/cartridge_context.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 
-extern "C" __declspec(dllexport) void ModuleName(char*, char*, AppendCartridgeMenuModuleCallback);
-extern "C" __declspec(dllexport) void MemPointers(ReadMemoryByteModuleCallback, WriteMemoryByteModuleCallback);
-extern "C" __declspec(dllexport) void AssertInterupt(AssertInteruptModuleCallback);
-extern "C" __declspec(dllexport) void SetCart(AssertCartridgeLineModuleCallback);
+extern "C" __declspec(dllexport) void PakInitialize(
+	void* const host_key,
+	const char* const configuration_path,
+	const pak_initialization_parameters* const parameters);
 
+// FIXME: this should be unnecessary here. VCC (or the 'host') should provide it
 class host_cartridge_context : public ::vcc::core::cartridge_context
 {
 public:
@@ -34,8 +35,10 @@ public:
 
 public:
 
-	explicit host_cartridge_context(const path_type& configuration_filename)
-		: configuration_filename_(configuration_filename)
+	explicit host_cartridge_context(void* host_key, const path_type& configuration_filename)
+		:
+		host_key_(host_key),
+		configuration_filename_(configuration_filename)
 	{}
 
 	path_type configuration_path() const override
@@ -50,44 +53,45 @@ public:
 
 	void write_memory_byte(unsigned char value, unsigned short address) override
 	{
-		write_memory_byte_(value, address);
+		write_memory_byte_(host_key_, value, address);
 	}
 
 	unsigned char read_memory_byte(unsigned short address) override
 	{
-		return read_memory_byte_(address);
+		return read_memory_byte_(host_key_, address);
 	}
 
 	void assert_cartridge_line(bool line_state) override
 	{
-		assert_cartridge_line_(line_state);
+		assert_cartridge_line_(host_key_, line_state);
 	}
 
 	void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) override
 	{
-		assert_interrupt_(interrupt, interrupt_source);
+		assert_interrupt_(host_key_, interrupt, interrupt_source);
 	}
 
 	void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) override
 	{
-		add_menu_item_(menu_name, menu_id, menu_type);
+		add_menu_item_(host_key_, menu_name, menu_id, menu_type);
 	}
 
 private:
 
-	friend void ModuleName(char*, char*, AppendCartridgeMenuModuleCallback);
-	friend void MemPointers(ReadMemoryByteModuleCallback, WriteMemoryByteModuleCallback);
-	friend void AssertInterupt(AssertInteruptModuleCallback);
-	friend void SetCart(AssertCartridgeLineModuleCallback);
-
+	friend void PakInitialize(
+		void* const host_key,
+		const char* const configuration_path,
+		const pak_initialization_parameters* const parameters);
 	friend class multipak_cartridge;
+
 
 private:
 
+	void* const							host_key_;
 	const path_type&					configuration_filename_;
-	WriteMemoryByteModuleCallback		write_memory_byte_ = [](unsigned char, unsigned short) {};
-	ReadMemoryByteModuleCallback		read_memory_byte_ = [](unsigned short) -> unsigned char { return 0; };
-	AssertCartridgeLineModuleCallback	assert_cartridge_line_ = [](bool) {};
-	AssertInteruptModuleCallback		assert_interrupt_ = [](Interrupt, InterruptSource) {};
-	AppendCartridgeMenuModuleCallback	add_menu_item_ = [](const char*, int, MenuItemType) {};
+	PakWriteMemoryByteHostCallback		write_memory_byte_ = [](void*, unsigned char, unsigned short) {};
+	PakReadMemoryByteHostCallback		read_memory_byte_ = [](void*, unsigned short) -> unsigned char { return 0; };
+	PakAssertCartridgeLineHostCallback	assert_cartridge_line_ = [](void*, bool) {};
+	PakAssertInteruptHostCallback		assert_interrupt_ = [](void*, Interrupt, InterruptSource) {};
+	PakAppendCartridgeMenuHostCallback	add_menu_item_ = [](void*, const char*, int, MenuItemType) {};
 };

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -105,7 +105,7 @@ EXPORT_PUBLIC_API unsigned char PakReadPort(unsigned char port_id)
 	return gMultiPakInterface.read_port(port_id);
 }
 
-EXPORT_PUBLIC_API void HeartBeat()
+EXPORT_PUBLIC_API void PakProcessHorizontalSync()
 {
 	gMultiPakInterface.heartbeat();
 }

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -58,7 +58,7 @@ public:
 	void write_port(unsigned char port_id, unsigned char value) override;
 	unsigned char read_port(unsigned char port_id) override;
 	unsigned char read_memory_byte(unsigned short memory_address) override;
-	void status(char* status) override;
+	void status(char* text_buffer, size_t buffer_size) override;
 	unsigned short sample_audio() override;
 	void menu_item_clicked(unsigned char menu_item_id) override;
 
@@ -84,16 +84,9 @@ public:
 	void append_menu_item(slot_id_type slot, menu_item_type item);
 
 
-
 private:
 
 	void load_configuration();
-
-	template<slot_id_type SlotIndex_, multipak_cartridge& cartridge>
-	friend void assert_cartridge_line_on_slot(bool line_state);
-
-	template<multipak_cartridge::slot_id_type SlotIndex_, multipak_cartridge& cartridge>
-	friend void append_menu_item_on_slot(const char* text, int id, MenuItemType type);
 
 
 private:

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -20,8 +20,8 @@ This file is part of VCC (Virtual Color Computer).
 #include <vcc/core/cartridge_loader.h>
 
 void PakTimer();
-unsigned char PackPortRead (unsigned char);
-void PackPortWrite(unsigned char,unsigned char);
+unsigned char PakReadPort (unsigned char);
+void PakWritePort(unsigned char,unsigned char);
 unsigned char PackMem8Read (unsigned short);
 void GetModuleStatus( SystemState *);
 vcc::core::cartridge_loader_status PakLoadCartridge(const char* filename);


### PR DESCRIPTION
This change-set removes several exported functions from existing cartridges and replaces them with a single initialization call. It also changes the various callback functions to take an additional argument representing a host key (allowing the host to route the calls). It also renames existing functions exported by the cartridge so they use sensible names and have symmetry.

- Update all cartridges to export the `PakInitialize`, `PakGetName`, and `PakGetCatalogId` for the new C interface
- Changes assert interrupt callback to take an additional argument of type `void*` as a host key.
- Changes assert cartridge line callback to take an additional argument of type `void*` as a host key.
- Changes write to system memory callback to take an additional argument of type `void*` as a host key.
- Changes read from system memory callback to take an additional argument of type `void*` as a host key.
- Changes append menu item callback to take an additional argument of type `void*` as a host key.
- Remove `MemPointers` implementations from all cartridges (replaced by `PakInitialize`).
- Remove `AssertInterupt` implementations from all cartridges (replaced by `PakInitialize`).
- Remove `SetIniPath` implementations from all cartridges (replaced by `PakInitialize`).
- Remove `SetCart` implementations from all cartridges (replaced by `PakInitialize`).
- Remove `ModuleName` implementations from all cartridges (replaced by `PakInitialize`, `PakGetName`, and `PakGetCatalogId`).
- Rename `ModuleReset` to `PakReset` in all cartridges that export it.
- Rename `HeartBeat` to `PakProcessHorizontalSync` in all cartridges that export it.
- Rename `ModuleStatus` to `PakGetStatus` in all cartridges that export it.
- Rename `PackPortWrite` to `PakWritePort` in all cartridges that export it.
- Rename `PackPortRead` to `PwkReadPort` in all cartridges that export it.
- Rename `PakMemRead8` to `PakReadMemoryByte` in all cartridges that export it.
- Rename `ModuleAudioSample` to `PakSampleAudio` in all cartridges that export it.
- Rename `ModuleConfig` to `PakMenuItemClicked` in all cartridges that export it.
- Updated `PakGetStatus` signature to take the buffer size as an argument.
