### PR TITLE
add descriptions to cartridge implementations

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -125,6 +125,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/FD502/fd502.rc
+++ b/FD502/fd502.rc
@@ -164,7 +164,7 @@ BEGIN
             VALUE "FileDescription", "DiskController"
             VALUE "FileVersion", "2.1.8.1"
             VALUE "InternalName", "DiskController"
-            VALUE "LegalCopyright", "Copyright © 2010"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2010"
             VALUE "OriginalFilename", "fd502.dll"
             VALUE "ProductName", "Vcc Module file"
             VALUE "ProductVersion", "26-3133"
@@ -198,6 +198,7 @@ STRINGTABLE
 BEGIN
     IDS_MODULE_NAME         "FD-502"
     IDS_VERSION             "3.0.1"
+    IDS_DESCRIPTION         "Turn any Color Computer with Extended BASIC into a disk system. Write your own disk applications or add ready-to-run software. Plugs into the Program Pak port or Multi-Pak Interface."
 #ifdef COMBINE_BECKER
     IDS_CATNUMBER           "+ Becker"
 #else

--- a/FD502/resource.h
+++ b/FD502/resource.h
@@ -5,6 +5,7 @@
 #define IDS_MODULE_NAME                 1
 #define IDS_VERSION                     2
 #define IDS_CATNUMBER                   3
+#define IDS_DESCRIPTION                 4
 #define IDD_CONFIG                      101
 #define IDD_NEWDISK                     102
 #define IDC_DRIVE0                      1000

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -1,4 +1,5 @@
 #include "Cartridge.h"
+#include <vcc/core/utils/winapi.h>
 
 
 namespace detail
@@ -11,10 +12,7 @@ namespace detail
 Cartridge* Cartridge::m_Singleton(nullptr);
 
 
-Cartridge::Cartridge(std::string name, std::string catalogId)
-	:
-	m_Name(move(name)),
-	m_CatalogId(move(catalogId))
+Cartridge::Cartridge()
 {
 	if (m_Singleton)
 	{
@@ -42,21 +40,6 @@ void Cartridge::LoadConfiguration(const std::string& /*filename*/)
 void Cartridge::LoadMenuItems()
 {
 }
-
-
-
-
-std::string Cartridge::GetName() const
-{
-	return m_Name;
-}
-
-
-std::string Cartridge::GetCatalogId() const
-{
-	return m_CatalogId;
-}
-
 
 
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -7,15 +7,13 @@ class Cartridge
 {
 protected:
 
-	explicit Cartridge(std::string name, std::string catalogId = std::string());
+	Cartridge();
 
 
 public:
 
 	virtual ~Cartridge();
 
-	virtual std::string GetName() const;
-	virtual std::string GetCatalogId() const;
 
 	virtual void SetHostKey(void* key);
 	virtual void SetCartLineAssertCallback(PakAssertCartridgeLineHostCallback callback);

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -1,16 +1,36 @@
 #include "CartridgeTrampolines.h"
 #include "Cartridge.h"
+#include "resource.h"
+#include <vcc/core/limits.h>
 
 
 GMC_EXPORT const char* PakGetName()
 {
-	return Cartridge::m_Singleton->GetName().c_str();
+	static char string_buffer[MAX_LOADSTRING];
+
+	LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
+
+	return string_buffer;
 }
 
 GMC_EXPORT const char* PakCatalogName()
 {
-	return Cartridge::m_Singleton->GetCatalogId().c_str();
+	static char string_buffer[MAX_LOADSTRING];
+
+	LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
+
+	return string_buffer;
 }
+
+GMC_EXPORT const char* PakGetDescription()
+{
+	static char string_buffer[MAX_LOADSTRING];
+
+	LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+	return string_buffer;
+}
+
 
 GMC_EXPORT void PakInitialize(
 	void* const host_key,

--- a/GMC/GMC.h
+++ b/GMC/GMC.h
@@ -9,6 +9,7 @@
 #define GMC_EXPORT
 #endif
 
+extern HINSTANCE gModuleInstance;
 std::string SelectROMFile();
 std::string ExtractFilename(std::string path);
 

--- a/GMC/GMC.rc
+++ b/GMC/GMC.rc
@@ -71,7 +71,7 @@ BEGIN
             VALUE "FileDescription", "GMC"
             VALUE "FileVersion", "2.1.8.1"
             VALUE "InternalName", "orch90"
-            VALUE "LegalCopyright", "Copyright © 2019"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2019"
             VALUE "OriginalFilename", "gmc.dll"
             VALUE "ProductName", "Game Master Cartridge (SN76489)"
             VALUE "ProductVersion", "26-XXXX"
@@ -82,6 +82,20 @@ BEGIN
     BEGIN
         VALUE "Translation", 0x409, 1200
     END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_MODULE_NAME         "Game Master Catridge"
+    IDS_CATNUMBER           "26-XXXX"
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
+    IDS_VERSION             "1.0"
 END
 
 #endif    // English (United States) resources

--- a/GMC/GMCCartridge.cpp
+++ b/GMC/GMCCartridge.cpp
@@ -2,11 +2,6 @@
 #include <Windows.h>
 
 
-GMCCartridge::GMCCartridge()
-	: Cartridge("Game Master Catridge", "SN76489")
-{}
-
-
 void GMCCartridge::LoadConfiguration(const std::string& filename)
 {
 	Cartridge::LoadConfiguration(filename);

--- a/GMC/GMCCartridge.h
+++ b/GMC/GMCCartridge.h
@@ -9,8 +9,6 @@ class GMCCartridge : public Cartridge
 {
 public:
 
-	GMCCartridge();
-
 	void LoadConfiguration(const std::string& filename) override;
 
 	std::string GetStatusMessage() const override;

--- a/GMC/main.cpp
+++ b/GMC/main.cpp
@@ -2,6 +2,7 @@
 #include "GMCCartridge.h"
 #include <vcc/common/DialogOps.h>
 
+HINSTANCE gModuleInstance = nullptr;
 GMCCartridge theCart;
 
 std::string ExtractFilename(std::string path)
@@ -37,8 +38,13 @@ std::string SelectROMFile()
 }
 
 
-BOOL WINAPI DllMain(HINSTANCE /*hinstDLL*/, DWORD /*fdwReason*/, LPVOID /*lpReserved*/)
+BOOL APIENTRY DllMain(HINSTANCE hinst, DWORD reason, LPVOID foo)
 {
+	if (reason == DLL_PROCESS_ATTACH)
+	{
+		gModuleInstance = hinst;
+	}
+
 	return TRUE;
 }
 

--- a/GMC/resource.h
+++ b/GMC/resource.h
@@ -2,12 +2,16 @@
 // Microsoft Visual C++ generated include file.
 // Used by GMC.rc
 //
+#define IDS_MODULE_NAME                 1
+#define IDS_CATNUMBER                   2
+#define IDS_DESCRIPTION                 3
+#define IDS_VERSION                     4
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_RESOURCE_VALUE        102
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1000
 #define _APS_NEXT_SYMED_VALUE           101

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -106,6 +106,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/HardDisk/harddisk.rc
+++ b/HardDisk/harddisk.rc
@@ -75,7 +75,7 @@ BEGIN
             VALUE "FileDescription", "Hard Disk\0"
             VALUE "FileVersion", "2.1.8.3\0"
             VALUE "InternalName", "Hard Disk\0"
-            VALUE "LegalCopyright", "Copyright © 2010\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2010\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "harddisk.dll\0"
             VALUE "PrivateBuild", "\0"
@@ -155,6 +155,7 @@ BEGIN
     IDS_MODULE_NAME         "Hard Drive"
     IDS_VERSION             "2.0.2"
     IDS_CATNUMBER           "+ Cloud9 RTC"
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
 END
 
 #endif    // English (U.S.) resources

--- a/HardDisk/resource.h
+++ b/HardDisk/resource.h
@@ -22,6 +22,7 @@ This file is part of VCC (Virtual Color Computer).
 #define IDS_MODULE_NAME                 1
 #define IDS_VERSION                     2
 #define IDS_CATNUMBER                   3
+#define IDS_DESCRIPTION                 4
 #define IDD_CONFIG                      101
 #define IDD_NEWDISK                     102
 #define IDC_CLOCK                       1001

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -58,6 +58,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const /*host_key*/,
 		const char* const /*configuration_path*/,

--- a/Ramdisk/Ramdisk.rc
+++ b/Ramdisk/Ramdisk.rc
@@ -75,7 +75,7 @@ BEGIN
             VALUE "FileDescription", "Ramdisk\0"
             VALUE "FileVersion", "1, 0, 0, 1\0"
             VALUE "InternalName", "Ramdisk\0"
-            VALUE "LegalCopyright", "Copyright © 2007\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2007\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "Ramdisk.dll\0"
             VALUE "PrivateBuild", "\0"
@@ -102,6 +102,7 @@ STRINGTABLE DISCARDABLE
 BEGIN
     IDS_MODULE_NAME         "RamDisk"
     IDS_CATNUMBER           "00-0000"
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
 END
 
 #endif    // English (U.S.) resources

--- a/Ramdisk/Ramdisk.vcxproj
+++ b/Ramdisk/Ramdisk.vcxproj
@@ -99,6 +99,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="memboard.h" />
+    <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Ramdisk.rc" />

--- a/Ramdisk/resource.h
+++ b/Ramdisk/resource.h
@@ -4,6 +4,7 @@
 //
 #define IDS_MODULE_NAME                 1
 #define IDS_CATNUMBER                   2
+#define IDS_DESCRIPTION                 3
 
 // Next default values for new objects
 // 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -85,6 +85,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/SuperIDE/SuperIDE.rc
+++ b/SuperIDE/SuperIDE.rc
@@ -74,7 +74,7 @@ BEGIN
             VALUE "FileDescription", "SuperIDE\0"
             VALUE "FileVersion", "2.1.8.3\0"
             VALUE "InternalName", "SuperIDE\0"
-            VALUE "LegalCopyright", "Copyright © 2010\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2010\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "SuperIDE.dll\0"
             VALUE "PrivateBuild", "\0"
@@ -142,6 +142,7 @@ STRINGTABLE DISCARDABLE
 BEGIN
     IDS_MODULE_NAME         "Glenside-IDE /w Clock"
     IDS_CATNUMBER           "000"
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
 END
 
 #endif    // English (U.S.) resources

--- a/SuperIDE/SuperIDE.vcxproj
+++ b/SuperIDE/SuperIDE.vcxproj
@@ -101,6 +101,7 @@
   <ItemGroup>
     <ClInclude Include="cloud9.h" />
     <ClInclude Include="IdeBus.h" />
+    <ClInclude Include="resource.h" />
     <ClInclude Include="SuperIDE.h" />
   </ItemGroup>
   <ItemGroup>

--- a/SuperIDE/resource.h
+++ b/SuperIDE/resource.h
@@ -4,6 +4,7 @@
 //
 #define IDS_MODULE_NAME                 1
 #define IDS_CATNUMBER                   2
+#define IDS_DESCRIPTION                 3
 #define IDD_DIALOG1                     101
 #define IDD_CONFIG                      101
 #define IDC_BASEADDR                    1000

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -113,6 +113,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/acia/acia.rc
+++ b/acia/acia.rc
@@ -133,7 +133,7 @@ BEGIN
             VALUE "FileDescription", "acia"
             VALUE "FileVersion", "2.1.9.3"
             VALUE "InternalName", "SC6551 Interface"
-            VALUE "LegalCopyright", "Copyright © 2023"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2023"
             VALUE "OriginalFilename", "acia.dll"
             VALUE "ProductName", "acia"
             VALUE "ProductVersion", "26-3124"
@@ -164,9 +164,10 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_MODULE_NAME         "ACIA Interface"
+    IDS_MODULE_NAME         "Tandy Deluxe RS232 Pak (Beta)"
+    IDS_CATNUMBER           "26-2226"
+	IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
     IDS_VERSION             "1.00"
-    IDS_CATNUMBER           "Beta"
 END
 
 #endif    // English (United States) resources

--- a/acia/resource.h
+++ b/acia/resource.h
@@ -5,6 +5,7 @@
 #define IDS_MODULE_NAME                 1
 #define IDS_VERSION                     2
 #define IDS_CATNUMBER                   3
+#define IDS_DESCRIPTION                 4
 #define IDD_PROPPAGE                    102
 
 #define IDC_PORT                        1010

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -407,6 +407,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/becker/becker.rc
+++ b/becker/becker.rc
@@ -92,7 +92,7 @@ BEGIN
             VALUE "FileDescription", "becker"
             VALUE "FileVersion", "2.1.8.1"
             VALUE "InternalName", "Becker Port Interface"
-            VALUE "LegalCopyright", "Copyright © 2007"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2007"
             VALUE "OriginalFilename", "becker.dll"
             VALUE "ProductName", "becker"
             VALUE "ProductVersion", "26-3124"
@@ -134,6 +134,7 @@ BEGIN
     IDS_MODULE_NAME         "HDBDOS/DW/Becker"
     IDS_VERSION             "1.00"
     IDS_CATNUMBER           "00-0000"
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
 END
 
 #endif    // English (U.S.) resources

--- a/becker/resource.h
+++ b/becker/resource.h
@@ -5,6 +5,7 @@
 #define IDS_MODULE_NAME                 1
 #define IDS_VERSION                     2
 #define IDS_CATNUMBER                   3
+#define IDS_DESCRIPTION                 4
 #define IDD_PROPPAGE                    102
 #define IDC_TCPPORT                     1004
 #define IDC_TCPHOST                     1005

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -27,8 +27,9 @@ namespace vcc { namespace core
 	{
 	public:
 
-		using name_type = std::string;
-		using catalog_id_type = std::string;
+		using name_type = ::std::string;
+		using catalog_id_type = ::std::string;
+		using description_type = ::std::string;
 
 
 	public:
@@ -41,6 +42,7 @@ namespace vcc { namespace core
 
 		virtual name_type name() const = 0;
 		virtual catalog_id_type catalog_id() const = 0;
+		virtual description_type description() const = 0;
 
 		virtual void start() = 0;
 		virtual void reset() = 0;

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -36,6 +36,7 @@ namespace vcc { namespace core { namespace cartridges
 
 		name_type name() const override;
 		catalog_id_type catalog_id() const override;
+		description_type description() const override;
 
 		void start() override;
 		void reset() override;

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -42,6 +42,7 @@ namespace vcc { namespace core { namespace cartridges
 
 		LIBCOMMON_EXPORT name_type name() const override;
 		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
+		LIBCOMMON_EXPORT description_type description() const override;
 
 		LIBCOMMON_EXPORT void start() override;
 		LIBCOMMON_EXPORT void reset() override;
@@ -64,6 +65,7 @@ namespace vcc { namespace core { namespace cartridges
 		const PakInitializeModuleFunction initialize_;
 		const PakGetNameModuleFunction get_name_;
 		const PakGetCatalogIdModuleFunction get_catalog_id_;
+		const PakGetDescriptionModuleFunction get_description_;
 		const PakResetModuleFunction reset_;
 		const PakHeartBeatModuleFunction heartbeat_;
 		const PakGetStatusModuleFunction status_;

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -48,6 +48,7 @@ namespace vcc { namespace core { namespace cartridges
 		
 		LIBCOMMON_EXPORT name_type name() const override;
 		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
+		LIBCOMMON_EXPORT description_type description() const override;
 
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;

--- a/libcommon/include/vcc/core/legacy_cartridge_definitions.h
+++ b/libcommon/include/vcc/core/legacy_cartridge_definitions.h
@@ -46,6 +46,7 @@ extern "C"
 		const pak_initialization_parameters* const parameters);
 	using PakGetNameModuleFunction = const char* (*)();
 	using PakGetCatalogIdModuleFunction = const char* (*)();
+	using PakGetDescriptionModuleFunction = const char* (*)();
 	using PakResetModuleFunction = void (*)();
 	using PakHeartBeatModuleFunction = void (*)();
 	using PakGetStatusModuleFunction = void (*)(char* text_buffer, size_t buffer_size);

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -31,6 +31,11 @@ namespace vcc { namespace core { namespace cartridges
 		return {};
 	}
 
+	basic_cartridge::description_type basic_cartridge:: description() const
+	{
+		return {};
+	}
+
 
 	void basic_cartridge::start()
 	{

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -65,15 +65,11 @@ namespace vcc { namespace core { namespace cartridges
 		void default_reset()
 		{}
 
-		const char* default_get_name()
+		const char* default_get_empty_string()
 		{
 			return "";
 		}
 
-		const char* default_get_catalog_id()
-		{
-			return "";
-		}
 	}
 
 
@@ -88,8 +84,9 @@ namespace vcc { namespace core { namespace cartridges
 		configuration_path_(move(configuration_path)),
 		parameters_(parameters),
 		initialize_(GetImportedProcAddress<PakInitializeModuleFunction>(module_handle, "PakInitialize", nullptr)),
-		get_name_(GetImportedProcAddress(module_handle, "PakGetName", default_get_name)),
-		get_catalog_id_(GetImportedProcAddress(module_handle, "PakGetCatalogId", default_get_catalog_id)),
+		get_name_(GetImportedProcAddress(module_handle, "PakGetName", default_get_empty_string)),
+		get_catalog_id_(GetImportedProcAddress(module_handle, "PakGetCatalogId", default_get_empty_string)),
+		get_description_(GetImportedProcAddress(module_handle, "PakGetDescription", default_get_empty_string)),
 		reset_(GetImportedProcAddress(module_handle, "PakReset", default_reset)),
 		heartbeat_(GetImportedProcAddress(module_handle, "PakProcessHorizontalSync", default_heartbeat)),
 		status_(GetImportedProcAddress(module_handle, "PakGetStatus", default_status)),
@@ -113,6 +110,11 @@ namespace vcc { namespace core { namespace cartridges
 	legacy_cartridge::catalog_id_type legacy_cartridge::catalog_id() const
 	{
 		return get_catalog_id_();
+	}
+
+	legacy_cartridge::description_type legacy_cartridge:: description() const
+	{
+		return get_description_();
 	}
 
 

--- a/libcommon/src/core/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/core/cartridges/rom_cartridge.cpp
@@ -47,6 +47,11 @@ namespace vcc { namespace core { namespace cartridges
 		return catalog_id_;
 	}
 
+	rom_cartridge::description_type rom_cartridge:: description() const
+	{
+		return {};
+	}
+
 
 	void rom_cartridge::reset()
 	{

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -31,6 +31,7 @@ namespace vcc { namespace modules { namespace mpi
 
 		using name_type = ::vcc::core::cartridge::name_type;
 		using catalog_id_type = ::vcc::core::cartridge::catalog_id_type;
+		using description_type = ::vcc::core::cartridge::description_type;
 		using path_type = ::std::string;
 		using label_type = ::std::string;
 		using handle_type = ::vcc::core::cartridge_loader_result::handle_type;
@@ -68,6 +69,11 @@ namespace vcc { namespace modules { namespace mpi
 		catalog_id_type catalog_id() const
 		{
 			return cartridge_->catalog_id();
+		}
+
+		description_type description() const
+		{
+			return cartridge_->description();
 		}
 
 		label_type label() const;

--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -110,7 +110,7 @@ void configuration_dialog::set_selected_slot(size_t slot)
 		IDC_MODINFO,
 		WM_SETTEXT,
 		0,
-		(LPARAM)mpi_.slot_description(slot).c_str());
+		reinterpret_cast<LPARAM>(mpi_.slot_description(slot).c_str()));
 
 	for (auto ndx(0u); ndx < gSlotUiElementIds.size(); ndx++)
 	{

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -82,6 +82,12 @@ multipak_cartridge::catalog_id_type multipak_cartridge::catalog_id() const
 	return ::vcc::core::utils::load_string(gModuleInstance, IDS_CATNUMBER);
 }
 
+multipak_cartridge::description_type multipak_cartridge:: description() const
+{
+	return ::vcc::core::utils::load_string(gModuleInstance, IDS_CATNUMBER);
+}
+
+
 void multipak_cartridge::start()
 {
 	load_configuration();
@@ -253,7 +259,7 @@ multipak_cartridge::description_type multipak_cartridge::slot_description(slot_i
 {
 	vcc::core::utils::section_locker lock(mutex_);
 
-	return "Module Name: " + slots_[slot].name();
+	return slots_[slot].description();
 }
 
 bool multipak_cartridge::empty(slot_id_type slot) const

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -51,6 +51,7 @@ public:
 	//	Cartridge implementation
 	name_type name() const override;
 	catalog_id_type catalog_id() const override;
+	description_type description() const override;
 
 	void start() override;
 	void reset() override;

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -65,6 +65,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const /*configuration_path*/,

--- a/orch90/orch90.rc
+++ b/orch90/orch90.rc
@@ -75,7 +75,7 @@ BEGIN
             VALUE "FileDescription", "Orchestra 90-CC \0"
             VALUE "FileVersion", "2.1.8.1\0"
             VALUE "InternalName", "orch90\0"
-            VALUE "LegalCopyright", "Copyright © 2006\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2006\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "orch90.dll\0"
             VALUE "PrivateBuild", "\0"
@@ -103,6 +103,7 @@ BEGIN
     IDS_MODULE_NAME         "Orchestra-90"
     IDS_CATNUMBER           "26-3143"
     IDS_VERSION             "1.30"
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
 END
 
 #endif    // English (U.S.) resources

--- a/orch90/orch90.vcxproj
+++ b/orch90/orch90.vcxproj
@@ -97,6 +97,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="orch90.h" />
+    <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="orch90.rc" />

--- a/orch90/resource.h
+++ b/orch90/resource.h
@@ -5,6 +5,7 @@
 #define IDS_MODULE_NAME                 1
 #define IDS_CATNUMBER                   2
 #define IDS_VERSION                     3
+#define IDS_DESCRIPTION                 4
 
 // Next default values for new objects
 // 

--- a/sdc/resource.h
+++ b/sdc/resource.h
@@ -22,7 +22,7 @@
 #define IDS_MODULE_NAME      1
 #define IDS_VERSION          2
 #define IDS_CATNUMBER        3
-
+#define IDS_DESCRIPTION      4
 #define IDD_CONTROL          101
 #define IDD_CONFIG           102
 
@@ -58,7 +58,7 @@
 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        103
+#define _APS_NEXT_RESOURCE_VALUE        105
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1005
 #define _APS_NEXT_SYMED_VALUE           101

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -370,6 +370,15 @@ extern "C"
 		return string_buffer;
 	}
 
+	__declspec(dllexport) const char* PakGetDescription()
+	{
+		static char string_buffer[MAX_LOADSTRING];
+
+		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
+
+		return string_buffer;
+	}
+
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/sdc/sdc.rc
+++ b/sdc/sdc.rc
@@ -1,4 +1,4 @@
-//Microsoft Developer Studio generated resource script.
+// Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
 
@@ -13,13 +13,11 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -27,18 +25,18 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // TEXTINCLUDE
 //
 
-1 TEXTINCLUDE DISCARDABLE
+1 TEXTINCLUDE 
 BEGIN
     "resource.h\0"
 END
 
-2 TEXTINCLUDE DISCARDABLE
+2 TEXTINCLUDE 
 BEGIN
     "#include ""winres.h""\r\n"
     "\0"
 END
 
-3 TEXTINCLUDE DISCARDABLE
+3 TEXTINCLUDE 
 BEGIN
     "\r\n"
     "\0"
@@ -46,7 +44,7 @@ END
 
 #endif    // APSTUDIO_INVOKED
 
-#ifndef _MAC
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Version
@@ -69,18 +67,16 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", "Simulation of SDC floppy emulator\0"
-            VALUE "CompanyName", "BitRot Software.\0"
-            VALUE "FileDescription", "SDC Simulator\0"
-            VALUE "FileVersion", "2.1.9.3\0"
-            VALUE "InternalName", "SDC\0"
-            VALUE "LegalCopyright", "Copyright © 2010\0"
-            VALUE "LegalTrademarks", "\0"
-            VALUE "OriginalFilename", "sdc.dll\0"
-            VALUE "PrivateBuild", "\0"
-            VALUE "ProductName", "Vcc Module file\0"
-            VALUE "ProductVersion", "2.1.9.3\0"
-            VALUE "SpecialBuild", "SDC Simulator\0"
+            VALUE "Comments", "Simulation of SDC floppy emulator"
+            VALUE "CompanyName", "BitRot Software."
+            VALUE "FileDescription", "SDC Simulator"
+            VALUE "FileVersion", "2.1.9.3"
+            VALUE "InternalName", "SDC"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2010"
+            VALUE "OriginalFilename", "sdc.dll"
+            VALUE "ProductName", "Vcc Module file"
+            VALUE "ProductVersion", "2.1.9.3"
+            VALUE "SpecialBuild", "SDC Simulator"
         END
     END
     BLOCK "VarFileInfo"
@@ -89,70 +85,58 @@ BEGIN
     END
 END
 
-#endif
 
 /////////////////////////////////////////////////////////////////////////////
 //
-// Dialogs
+// Dialog
 //
 
 IDD_CONTROL DIALOGEX 0, 0, 95, 40
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "SDC Disk 0"
-FONT 8, "MS Sans Serif"
+FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
-    EDITTEXT      ID_DISK0, 8,3,80,14,ES_AUTOHSCROLL,ES_READONLY
-    DEFPUSHBUTTON "Next Disk", ID_NEXT,22,21,50,14,BS_DEFPUSHBUTTON
+    EDITTEXT        ID_DISK0,8,3,80,14,ES_AUTOHSCROLL,0x800L
+    DEFPUSHBUTTON   "Next Disk",ID_NEXT,22,21,50,14
 END
 
 IDD_CONFIG DIALOGEX 0, 0, 200, 180
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "SDC Config"
-FONT 8, "MS Sans Serif"
+FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
-    LTEXT       "SD Card Path (Directory)",IDC_STATIC, 7+10, 7, 155, 14
-    EDITTEXT    ID_SD_BOX,         7+10,19,155,14,ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_SD_SELECT,166+10,19,14,11
-
-    LTEXT       "Flash Banks",  IDC_STATIC,   7+10, 37, 60, 14
-    LTEXT       "Startup Bank:",IDC_STATIC, 120+10, 37, 60, 12
-    EDITTEXT    ID_STARTUP_BANK,            167+10, 37, 10, 10, ES_NUMBER
-
-    LTEXT       "0",IDC_STATIC,   0+10, 36  +15,   8, 10
-    EDITTEXT    ID_TEXT0,         7+10, 36  +13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE0, 166+10, 36  +14,  14, 11
-
-    LTEXT       "1",IDC_STATIC,   0+10, 36+12+15,   8, 10
-    EDITTEXT    ID_TEXT1,         7+10, 36+12+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE1, 166+10, 36+12+14,  14, 11
-
-    LTEXT       "2",IDC_STATIC,   0+10, 36+24+15,   8, 10
-    EDITTEXT    ID_TEXT2,         7+10, 36+24+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE2, 166+10, 36+24+14,  14, 11
-
-    LTEXT       "3",IDC_STATIC,   0+10, 36+36+15,   8, 10
-    EDITTEXT    ID_TEXT3,         7+10, 36+36+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE3, 166+10, 36+36+14,  14, 11
-
-    LTEXT       "4",IDC_STATIC,   0+10, 36+48+15,   8, 10
-    EDITTEXT    ID_TEXT4,         7+10, 36+48+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE4, 166+10, 36+48+14,  14, 11
-
-    LTEXT       "5",IDC_STATIC,   0+10, 36+60+15,   8, 10
-    EDITTEXT    ID_TEXT5,         7+10, 36+60+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE5, 166+10, 36+60+14,  14, 11
-
-    LTEXT       "6",IDC_STATIC,   0+10, 36+72+15,   8, 10
-    EDITTEXT    ID_TEXT6,         7+10, 36+72+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE6, 166+10, 36+72+14,  14, 11
-
-    LTEXT       "7",IDC_STATIC,   0+10, 36+84+15,   8, 10
-    EDITTEXT    ID_TEXT7,         7+10, 36+84+13, 155, 12, ES_AUTOHSCROLL
-    PUSHBUTTON  ">",ID_UPDATE7, 166+10, 36+84+14,  14, 11
-
-    CONTROL "Enable Cloud9 clock ($FF70)",IDC_CLOCK,"Button",BS_AUTOCHECKBOX,7+10,158,140,10
-
-    PUSHBUTTON     "OK",IDOK,    128+10, 155, 53, 18
+    LTEXT           "SD Card Path (Directory)",IDC_STATIC,17,7,155,14
+    EDITTEXT        ID_SD_BOX,17,19,155,14,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_SD_SELECT,176,19,14,11
+    LTEXT           "Flash Banks",IDC_STATIC,17,37,60,14
+    LTEXT           "Startup Bank:",IDC_STATIC,130,37,60,12
+    EDITTEXT        ID_STARTUP_BANK,177,37,10,10,ES_NUMBER
+    LTEXT           "0",IDC_STATIC,10,51,8,10
+    EDITTEXT        ID_TEXT0,17,49,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE0,176,50,14,11
+    LTEXT           "1",IDC_STATIC,10,63,8,10
+    EDITTEXT        ID_TEXT1,17,61,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE1,176,62,14,11
+    LTEXT           "2",IDC_STATIC,10,75,8,10
+    EDITTEXT        ID_TEXT2,17,73,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE2,176,74,14,11
+    LTEXT           "3",IDC_STATIC,10,87,8,10
+    EDITTEXT        ID_TEXT3,17,85,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE3,176,86,14,11
+    LTEXT           "4",IDC_STATIC,10,99,8,10
+    EDITTEXT        ID_TEXT4,17,97,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE4,176,98,14,11
+    LTEXT           "5",IDC_STATIC,10,111,8,10
+    EDITTEXT        ID_TEXT5,17,109,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE5,176,110,14,11
+    LTEXT           "6",IDC_STATIC,10,123,8,10
+    EDITTEXT        ID_TEXT6,17,121,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE6,176,122,14,11
+    LTEXT           "7",IDC_STATIC,10,135,8,10
+    EDITTEXT        ID_TEXT7,17,133,155,12,ES_AUTOHSCROLL
+    PUSHBUTTON      ">",ID_UPDATE7,176,134,14,11
+    CONTROL         "Enable Cloud9 clock ($FF70)",IDC_CLOCK,"Button",BS_AUTOCHECKBOX,17,158,140,10
+    PUSHBUTTON      "OK",IDOK,138,155,53,18
 END
 
 
@@ -162,7 +146,7 @@ END
 //
 
 #ifdef APSTUDIO_INVOKED
-GUIDELINES DESIGNINFO DISCARDABLE
+GUIDELINES DESIGNINFO
 BEGIN
     IDD_CONFIG, DIALOG
     BEGIN
@@ -174,20 +158,23 @@ BEGIN
 END
 #endif    // APSTUDIO_INVOKED
 
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // String Table
 //
 
-STRINGTABLE DISCARDABLE
+STRINGTABLE
 BEGIN
     IDS_MODULE_NAME         "SDC simulator"
     IDS_VERSION             "1.0"
-    IDS_CATNUMBER           ""
+    IDS_DESCRIPTION         "[TODO: DESCRIPTION]"
 END
 
-#endif    // English (U.S.) resources
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
+
+
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change-set adds a description property function and exported C function allowing cartridges to provide a description. The description is pulled from the string table of the DLL's resources. Note that most descriptions are TODO as they will require some research and time to determine what information should be included (i.e. port addresses, product description, additional hardware like RTC's).

- add `PakGetDescription` to each cartridge
- add cartridge description to the string table of each pak
- update `cartridge` to export description as a property function
- update `legacy_cartridge` to support PakGetDescription