### PR TITLE
rename pak_initialization_parameters to cpak_cartridge_context

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -128,11 +128,11 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKeyPtr = host_key;
-		CartMenuCallback = parameters->add_menu_item;
-		AssertInt = parameters->assert_interrupt;
+		CartMenuCallback = context->add_menu_item;
+		AssertInt = context->assert_interrupt;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -54,7 +54,7 @@ private:
 	friend void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters);
+		const cpak_cartridge_context* const context);
 	friend void PakGetStatus(char* text_buffer, size_t buffer_size);
 	friend void PakMenuItemClicked(unsigned char menuId);
 	friend void PakReset();

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -15,11 +15,11 @@ GMC_EXPORT const char* PakCatalogName()
 GMC_EXPORT void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,
-	const pak_initialization_parameters* const parameters)
+	const cpak_cartridge_context* const context)
 {
 	Cartridge::m_Singleton->SetHostKey(host_key);
-	Cartridge::m_Singleton->SetMenuBuilderCallback(parameters->add_menu_item);
-	Cartridge::m_Singleton->SetCartLineAssertCallback(parameters->assert_cartridge_line);
+	Cartridge::m_Singleton->SetMenuBuilderCallback(context->add_menu_item);
+	Cartridge::m_Singleton->SetCartLineAssertCallback(context->assert_cartridge_line);
 	Cartridge::m_Singleton->SetConfigurationPath(configuration_path);
 }
 

--- a/GMC/CartridgeTrampolines.h
+++ b/GMC/CartridgeTrampolines.h
@@ -6,7 +6,7 @@ GMC_EXPORT const char* PakCatalogName();
 GMC_EXPORT void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,
-	const pak_initialization_parameters* const parameters);
+	const cpak_cartridge_context* const context);
 
 GMC_EXPORT void PakGetStatus(char* text_buffer, size_t buffer_size);
 GMC_EXPORT void PakMenuItemClicked(unsigned char /*menuId*/);

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -109,12 +109,12 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKey = host_key;
-		CartMenuCallback = parameters->add_menu_item;
-		MemRead8 = parameters->read_memory_byte;
-		MemWrite8 = parameters->write_memory_byte;
+		CartMenuCallback = context->add_menu_item;
+		MemRead8 = context->read_memory_byte;
+		MemWrite8 = context->write_memory_byte;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -61,7 +61,7 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const /*host_key*/,
 		const char* const /*configuration_path*/,
-		const pak_initialization_parameters* const /*parameters*/)
+		const cpak_cartridge_context* const /*context*/)
 	{
 		InitMemBoard();
 	}

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -88,10 +88,10 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKeyPtr = host_key;
-		CartMenuCallback = parameters->add_menu_item;
+		CartMenuCallback = context->add_menu_item;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -116,11 +116,11 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKeyPtr = host_key;
-		CartMenuCallback = parameters->add_menu_item;
-		AssertInt = parameters->assert_interrupt;
+		CartMenuCallback = context->add_menu_item;
+		AssertInt = context->assert_interrupt;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -410,11 +410,11 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKey = host_key;
-		CartMenuCallback = parameters->add_menu_item;
-		PakSetCart = parameters->assert_cartridge_line;
+		CartMenuCallback = context->add_menu_item;
+		PakSetCart = context->assert_cartridge_line;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/libcommon/include/vcc/core/cartridge_loader.h
+++ b/libcommon/include/vcc/core/cartridge_loader.h
@@ -79,13 +79,13 @@ namespace vcc { namespace core
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const pak_initialization_parameters& pak_parameters);
+		const cpak_cartridge_context& cpak_context);
 
 	LIBCOMMON_EXPORT cartridge_loader_result load_cartridge(
 		const std::string& filename,
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const pak_initialization_parameters& pak_parameters);
+		const cpak_cartridge_context& cpak_context);
 
 } }

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -38,7 +38,7 @@ namespace vcc { namespace core { namespace cartridges
 			HMODULE module_handle,
 			void* const host_context,
 			path_type configuration_path,
-			const pak_initialization_parameters& parameters);
+			const cpak_cartridge_context& cpak_context);
 
 		LIBCOMMON_EXPORT name_type name() const override;
 		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
@@ -58,7 +58,7 @@ namespace vcc { namespace core { namespace cartridges
 		const HMODULE handle_;
 		void* const host_context_;
 		const path_type configuration_path_;
-		const pak_initialization_parameters parameters_;
+		const cpak_cartridge_context cpak_context_;
 
 		// imported module functions
 		const PakInitializeModuleFunction initialize_;

--- a/libcommon/include/vcc/core/legacy_cartridge_definitions.h
+++ b/libcommon/include/vcc/core/legacy_cartridge_definitions.h
@@ -31,8 +31,9 @@ extern "C"
 	using PakAssertInteruptHostCallback = void (*)(void* host_key, Interrupt interrupt, InterruptSource interrupt_source);
 	using PakAppendCartridgeMenuHostCallback = void (*)(void* host_key, const char* menu_name, int menu_id, MenuItemType menu_type);
 
-	struct pak_initialization_parameters
+	struct cpak_cartridge_context
 	{
+		// FIXME-CHET: This needs a reset callback
 		const PakAssertInteruptHostCallback assert_interrupt;
 		const PakAssertCartridgeLineHostCallback assert_cartridge_line;
 		const PakWriteMemoryByteHostCallback write_memory_byte;
@@ -43,7 +44,7 @@ extern "C"
 	using PakInitializeModuleFunction = void (*)(
 		void* host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters);
+		const cpak_cartridge_context* const context);
 	using PakGetNameModuleFunction = const char* (*)();
 	using PakGetCatalogIdModuleFunction = const char* (*)();
 	using PakResetModuleFunction = void (*)();

--- a/libcommon/src/core/cartridge_loader.cpp
+++ b/libcommon/src/core/cartridge_loader.cpp
@@ -111,7 +111,7 @@ namespace vcc { namespace core
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const pak_initialization_parameters& pak_parameters)
+		const cpak_cartridge_context& cpak_context)
 	{
 		if (GetModuleHandle(filename.c_str()) != nullptr)
 		{
@@ -143,7 +143,7 @@ namespace vcc { namespace core
 				details.handle.get(),
 				host_context,
 				iniPath,
-				pak_parameters);
+				cpak_context);
 			details.load_result = cartridge_loader_status::success;
 
 			return details;
@@ -157,7 +157,7 @@ namespace vcc { namespace core
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const pak_initialization_parameters& pak_parameters)
+		const cpak_cartridge_context& cpak_context)
 	{
 		switch (vcc::core::determine_cartridge_type(filename))
 		{
@@ -174,7 +174,7 @@ namespace vcc { namespace core
 				move(cartridge_context),
 				host_context,
 				iniPath,
-				pak_parameters);
+				cpak_context);
 		}
 	}
 

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -81,12 +81,12 @@ namespace vcc { namespace core { namespace cartridges
 		HMODULE module_handle,
 		void* const host_context,
 		path_type configuration_path,
-		const pak_initialization_parameters& parameters)
+		const cpak_cartridge_context& cpak_context)
 		:
 		handle_(module_handle),
 		host_context_(host_context),
 		configuration_path_(move(configuration_path)),
-		parameters_(parameters),
+		cpak_context_(cpak_context),
 		initialize_(GetImportedProcAddress<PakInitializeModuleFunction>(module_handle, "PakInitialize", nullptr)),
 		get_name_(GetImportedProcAddress(module_handle, "PakGetName", default_get_name)),
 		get_catalog_id_(GetImportedProcAddress(module_handle, "PakGetCatalogId", default_get_catalog_id)),
@@ -118,7 +118,7 @@ namespace vcc { namespace core { namespace cartridges
 
 	void legacy_cartridge::start()
 	{
-		initialize_(host_context_, configuration_path_.c_str(), & parameters_);
+		initialize_(host_context_, configuration_path_.c_str(), &cpak_context_);
 	}
 
 	void legacy_cartridge::reset()

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -22,7 +22,7 @@
 extern "C" __declspec(dllexport) void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,
-	const pak_initialization_parameters* const parameters);
+	const cpak_cartridge_context* const context);
 
 // FIXME: this should be unnecessary here. VCC (or the 'host') should provide it
 class host_cartridge_context : public ::vcc::core::cartridge_context
@@ -81,7 +81,7 @@ private:
 	friend void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters);
+		const cpak_cartridge_context* const context);
 	friend class multipak_cartridge;
 
 

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -76,14 +76,14 @@ extern "C"
 	EXPORT_PUBLIC_API void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gConfigurationFilename = configuration_path;
-		gHostContext->add_menu_item_ = parameters->add_menu_item;
-		gHostContext->read_memory_byte_ = parameters->read_memory_byte;
-		gHostContext->write_memory_byte_ = parameters->write_memory_byte;
-		gHostContext->assert_interrupt_ = parameters->assert_interrupt;
-		gHostContext->assert_cartridge_line_ = parameters->assert_cartridge_line;
+		gHostContext->add_menu_item_ = context->add_menu_item;
+		gHostContext->read_memory_byte_ = context->read_memory_byte;
+		gHostContext->write_memory_byte_ = context->write_memory_byte;
+		gHostContext->assert_interrupt_ = context->assert_interrupt;
+		gHostContext->assert_cartridge_line_ = context->assert_cartridge_line;
 
 		gMultiPakInterface.start();
 	}

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -68,10 +68,10 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const /*configuration_path*/,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKey = host_key;
-		PakSetCart = parameters->assert_cartridge_line;
+		PakSetCart = context->assert_cartridge_line;
 	}
 
 }

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -373,13 +373,13 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const pak_initialization_parameters* const parameters)
+		const cpak_cartridge_context* const context)
 	{
 		gHostKey = host_key;
-		CartMenuCallback = parameters->add_menu_item;
-		MemRead8 = parameters->read_memory_byte;
-		MemWrite8 = parameters->write_memory_byte;
-		AssertInt = parameters->assert_interrupt;
+		CartMenuCallback = context->add_menu_item;
+		MemRead8 = context->read_memory_byte;
+		MemWrite8 = context->write_memory_byte;
+		AssertInt = context->assert_interrupt;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();


### PR DESCRIPTION
Renames `pak_initialization_parameters` to `cpak_cartridge_context`