### PR TITLE
separate configuration management from `multipak_cartridge`

### DIFF
--- a/mpi/configuration_dialog.h
+++ b/mpi/configuration_dialog.h
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include "multipak_cartridge.h"
+#include "multipak_configuration.h"
 #include <Windows.h>
 
 
@@ -24,7 +25,9 @@ class configuration_dialog
 {
 public:
 
-	explicit configuration_dialog(multipak_cartridge& mpi);
+	configuration_dialog(
+		multipak_configuration& configuration,
+		multipak_cartridge& mpi);
 
 	configuration_dialog(const configuration_dialog&) = delete;
 	configuration_dialog(configuration_dialog&&) = delete;
@@ -56,6 +59,7 @@ private:
 
 private:
 
+	multipak_configuration& configuration_;
 	multipak_cartridge& mpi_;
 	HWND dialog_handle_ = nullptr;
 	HWND parent_handle_ = nullptr;

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -27,11 +27,12 @@
 #define EXPORT_PUBLIC_API extern "C" __declspec(dllexport)
 
 HINSTANCE gModuleInstance = nullptr;
-std::string gConfigurationFilename;
+static std::string gConfigurationFilename;
 // FIXME: The host context will be provided by VCC once the full implementation is complete
 const std::shared_ptr<host_cartridge_context> gHostContext(std::make_shared<host_cartridge_context>(nullptr, gConfigurationFilename));
-multipak_cartridge gMultiPakInterface(gHostContext);
-configuration_dialog gConfigurationDialog(gMultiPakInterface);
+multipak_configuration gMultiPakConfiguration("MPI");
+multipak_cartridge gMultiPakInterface(gMultiPakConfiguration, gHostContext);
+configuration_dialog gConfigurationDialog(gMultiPakConfiguration, gMultiPakInterface);
 
 
 BOOL WINAPI DllMain(HINSTANCE module_instance, DWORD reason, LPVOID /*reserved*/)
@@ -78,6 +79,7 @@ extern "C"
 		const char* const configuration_path,
 		const pak_initialization_parameters* const parameters)
 	{
+		gMultiPakConfiguration.configuration_path(configuration_path);
 		gConfigurationFilename = configuration_path;
 		gHostContext->add_menu_item_ = parameters->add_menu_item;
 		gHostContext->read_memory_byte_ = parameters->read_memory_byte;

--- a/mpi/mpi.h
+++ b/mpi/mpi.h
@@ -25,4 +25,3 @@ extern const std::shared_ptr<host_cartridge_context> gHostContext;
 extern multipak_cartridge gMultiPakInterface;
 extern configuration_dialog gConfigurationDialog;
 extern std::string gLastAccessedPath;
-extern std::string gConfigurationFilename;

--- a/mpi/mpi.vcxproj
+++ b/mpi/mpi.vcxproj
@@ -97,6 +97,7 @@
     <ClCompile Include="configuration_dialog.cpp" />
     <ClCompile Include="mpi.cpp" />
     <ClCompile Include="multipak_cartridge.cpp" />
+    <ClCompile Include="multipak_configuration.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cartridge_slot.h" />
@@ -105,6 +106,7 @@
     <ClInclude Include="multipak_cartridge.h" />
     <ClInclude Include="configuration_dialog.h" />
     <ClInclude Include="multipak_cartridge_context.h" />
+    <ClInclude Include="multipak_configuration.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/mpi/mpi.vcxproj.filters
+++ b/mpi/mpi.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="multipak_cartridge.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="multipak_configuration.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cartridge_slot.h">
@@ -34,6 +37,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="multipak_cartridge_context.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="multipak_configuration.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -19,7 +19,6 @@
 #include "multipak_cartridge_context.h"
 #include "mpi.h"
 #include "resource.h"
-#include <vcc/core/utils/configuration_serializer.h>
 #include <vcc/core/utils/winapi.h>
 #include <vcc/core/utils/filesystem.h>
 
@@ -68,8 +67,12 @@ namespace
 }
 
 
-multipak_cartridge::multipak_cartridge(std::shared_ptr<context_type> context)
-	: context_(move(context))
+multipak_cartridge::multipak_cartridge(
+	multipak_configuration& configuration,
+	std::shared_ptr<context_type> context)
+	:
+	configuration_(configuration),
+	context_(move(context))
 { }
 
 multipak_cartridge::name_type multipak_cartridge::name() const
@@ -84,7 +87,23 @@ multipak_cartridge::catalog_id_type multipak_cartridge::catalog_id() const
 
 void multipak_cartridge::start()
 {
-	load_configuration();
+	// Get the startup slot and set Chip select and SCS slots from ini file
+	switch_slot_ = configuration_.selected_slot();
+	cached_cts_slot_ = switch_slot_;
+	cached_scs_slot_ = switch_slot_;
+
+	// Mount them
+	for (auto slot(0u); slot < slots_.size(); slot++)
+	{
+		const auto path(vcc::core::utils::find_pak_module_path(configuration_.slot_cartridge_path(slot)));
+		if (!path.empty())
+		{
+			mount_cartridge(slot, path);
+		}
+	}
+
+	// Build the dynamic menu
+	build_menu();
 }
 
 void multipak_cartridge::reset()
@@ -385,47 +404,6 @@ void multipak_cartridge::build_menu()
 	context_->add_menu_item("", MID_FINISH, MIT_Head);  // Finish draws the entire menu
 }
 
-
-void multipak_cartridge::load_configuration()
-{
-	const auto& section(name());
-	::vcc::core::configuration_serializer serializer(context_->configuration_path());
-
-	// Get the startup slot and set Chip select and SCS slots from ini file
-	switch_slot_ = serializer.read(section, "SWPOSITION", 3);
-	cached_cts_slot_ = switch_slot_;
-	cached_scs_slot_ = switch_slot_;
-
-	// Mount them
-	for (auto slot(0u); slot < slots_.size(); slot++)
-	{
-		const auto path(vcc::core::utils::find_pak_module_path(serializer.read(section, "SLOT" + std::to_string(slot + 1))));
-		if (!path.empty())
-		{
-			mount_cartridge(slot, path);
-		}
-	}
-
-	// Build the dynamic menu
-	build_menu();
-}
-
-void multipak_cartridge::save_configuration() const
-{
-	vcc::core::utils::section_locker lock(mutex_);
-
-	const auto& section(name());
-	::vcc::core::configuration_serializer serializer(context_->configuration_path());
-
-	serializer.write(section, "SWPOSITION", switch_slot_);
-	for (auto slot(0u); slot < slots_.size(); slot++)
-	{
-		serializer.write(
-			section,
-			"SLOT" + ::std::to_string(slot + 1),
-			vcc::core::utils::strip_application_path(slots_[slot].path()));
-	}
-}
 
 void multipak_cartridge::assert_cartridge_line(slot_id_type slot, bool line_state)
 {

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include "cartridge_slot.h"
+#include "multipak_configuration.h"
 #include <vcc/core/cartridges/basic_cartridge.h>
 #include <vcc/core/cartridge_loader.h>
 #include <vcc/core/utils/critical_section.h>
@@ -41,7 +42,9 @@ public:
 
 public:
 
-	explicit multipak_cartridge(std::shared_ptr<context_type> context);
+	multipak_cartridge(
+		multipak_configuration& configuration,
+		std::shared_ptr<context_type> context);
 	multipak_cartridge(const multipak_cartridge&) = delete;
 	multipak_cartridge(multipak_cartridge&&) = delete;
 
@@ -79,14 +82,8 @@ public:
 	void build_menu();
 
 	// Make automatic when mounting, ejecting, selecting slot, etc.
-	void save_configuration() const;
 	void assert_cartridge_line(slot_id_type slot, bool line_state);
 	void append_menu_item(slot_id_type slot, menu_item_type item);
-
-
-private:
-
-	void load_configuration();
 
 
 private:
@@ -96,6 +93,7 @@ private:
 	static const size_t default_slot_register_value = 0xff;
 
 	vcc::core::utils::critical_section mutex_;
+	multipak_configuration& configuration_;
 	std::shared_ptr<context_type> context_;
 	std::array<vcc::modules::mpi::cartridge_slot, NUMSLOTS> slots_;
 	unsigned char slot_register_ = default_slot_register_value;

--- a/mpi/multipak_configuration.cpp
+++ b/mpi/multipak_configuration.cpp
@@ -1,0 +1,60 @@
+#include "multipak_configuration.h"
+#include <vcc/core/utils/configuration_serializer.h>
+
+
+using serializer = ::vcc::core::configuration_serializer;
+
+
+multipak_configuration::multipak_configuration(string_type section)
+	: section_(move(section))
+{}
+
+
+void multipak_configuration::configuration_path(path_type path)
+{
+	configuration_path_ = move(path);
+}
+
+multipak_configuration::path_type multipak_configuration::configuration_path() const
+{
+	return configuration_path_;
+}
+
+
+multipak_configuration::path_type multipak_configuration::last_accessed_module_path() const
+{
+	return serializer(configuration_path()).read("DefaultPaths", "MPIPath");
+}
+
+void multipak_configuration::last_accessed_module_path(const path_type& path) const
+{
+	serializer(configuration_path()).write("DefaultPaths", "MPIPath", path);
+}
+
+
+void multipak_configuration::selected_slot(slot_id_type slot) const
+{
+	serializer(configuration_path()).write(section_, "SWPOSITION", slot);
+}
+
+multipak_configuration::slot_id_type multipak_configuration::selected_slot() const
+{
+	return serializer(configuration_path()).read(section_, "SWPOSITION", 3);
+}
+
+
+void multipak_configuration::slot_cartridge_path(slot_id_type slot, const path_type& path) const
+{
+	serializer(configuration_path()).write(section_, get_slot_path_key(slot), path);
+}
+
+multipak_configuration::path_type multipak_configuration::slot_cartridge_path(slot_id_type slot) const
+{
+	return serializer(configuration_path()).read(section_, get_slot_path_key(slot));
+}
+
+
+multipak_configuration::string_type multipak_configuration::get_slot_path_key(slot_id_type slot) const
+{
+	return "SLOT" + ::std::to_string(slot + 1);
+}

--- a/mpi/multipak_configuration.h
+++ b/mpi/multipak_configuration.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <string>
+
+
+class multipak_configuration
+{
+public:
+
+	using slot_id_type = ::std::size_t;
+	using path_type = ::std::string;
+	using string_type = ::std::string;
+
+
+public:
+
+	explicit multipak_configuration(string_type section);
+
+	// in configuration
+	void configuration_path(path_type path);	//	FIXME: maybe make private with a friend setter
+	path_type configuration_path() const;
+
+	void last_accessed_module_path(const path_type& path) const;
+	path_type last_accessed_module_path() const;
+
+	void selected_slot(slot_id_type slot) const;
+	slot_id_type selected_slot() const;
+
+	void slot_cartridge_path(slot_id_type slot, const path_type& path) const;
+	path_type slot_cartridge_path(slot_id_type slot) const;
+
+
+private:
+
+	string_type get_slot_path_key(slot_id_type slot) const;
+
+
+private:
+
+	const string_type section_;
+	path_type configuration_path_;
+};


### PR DESCRIPTION
Separate configuration management from `multipak_cartridge` and places the responsibility of saving the configuration details on the UI settings.

- Adds `multipak_configuration` class.
- Updates configuration dialog to get/set settings using the multipak configuration.
- Updates multipak cartridge to get settings from the multipak configuration.
- Updates multipak configuration dialog to save the selected slot and cartridge paths to the configuration.
- Remove `save_configuration` from `multipak_cartridge`.
- Removes `load_Configuration` from `multipak_cartridge` and move functionality into `start`.