### PR TITLE
add stop to cartridge and cpak interfaces

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -90,18 +90,12 @@ BOOL WINAPI DllMain(
     DWORD fdwReason,     // reason for calling function
     LPVOID lpReserved )  // reserved
 {
-	if (fdwReason == DLL_PROCESS_DETACH ) //Clean Up
-	{
-        CloseCartDialog(g_hConfDlg);
-		for (unsigned char Drive=0;Drive<=3;Drive++)
-			unmount_disk_image(Drive);
-	}
-	else
+	if (fdwReason == DLL_PROCESS_ATTACH) //Clean Up
 	{
 		gModuleInstance = hinstDLL;
-		RealDisks=InitController();
 	}
-	return 1;
+
+	return TRUE;
 }
 
 extern "C"
@@ -144,8 +138,18 @@ extern "C"
 		AssertInt = context->assert_interrupt;
 		strcpy(IniFile, configuration_path);
 
+		RealDisks = InitController();
 		LoadConfig();
 		BuildCartridgeMenu();
+	}
+
+	__declspec(dllexport) void PakTerminate()
+	{
+		CloseCartDialog(g_hConfDlg);
+		for (unsigned char Drive = 0; Drive <= 3; Drive++)
+		{
+			unmount_disk_image(Drive);
+		}
 	}
 
 }

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -64,14 +64,12 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL,  // handle to DLL module
                      DWORD fdwReason,     // reason for calling function
                      LPVOID lpReserved )  // reserved
 {
-    if (fdwReason == DLL_PROCESS_DETACH ) {
-        CloseCartDialog(hConfDlg);
-        UnmountHD(0);
-        UnmountHD(1);
-    } else {
+    if (fdwReason == DLL_PROCESS_ATTACH)
+	{
 		gModuleInstance = hinstDLL;
     }
-    return 1;
+
+    return TRUE;
 }
 
 void MemWrite(unsigned char Data, unsigned short Address)
@@ -130,6 +128,13 @@ extern "C"
 		SetClockWrite(!ClockReadOnly);
 		VhdReset(); // Selects drive zero
 		BuildCartridgeMenu();
+	}
+
+	__declspec(dllexport) void PakTerminate()
+	{
+		CloseCartDialog(hConfDlg);
+		UnmountHD(0);
+		UnmountHD(1);
 	}
 
 }

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -29,12 +29,12 @@ BOOL WINAPI DllMain(
     DWORD fdwReason,     // reason for calling function
     LPVOID lpReserved )  // reserved
 {
-	if (fdwReason == DLL_PROCESS_DETACH ) //Clean Up 
+	if (fdwReason == DLL_PROCESS_ATTACH) //Clean Up 
 	{
-		return 1;
+		gModuleInstance = hinstDLL;
 	}
-	gModuleInstance = hinstDLL;
-	return 1;
+
+	return TRUE;
 }
 
 extern "C" 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -55,12 +55,12 @@ BOOL WINAPI DllMain(
     DWORD fdwReason,     // reason for calling function
     LPVOID lpReserved )  // reserved
 {
-	if (fdwReason == DLL_PROCESS_DETACH ) //Clean Up 
+	if (fdwReason == DLL_PROCESS_ATTACH) //Clean Up 
 	{
-		if (hConfDlg) DestroyWindow(hConfDlg);
+		gModuleInstance = hinstDLL;
 	}
-	gModuleInstance = hinstDLL;
-	return 1;
+
+	return TRUE;
 }
 
 
@@ -109,6 +109,14 @@ extern "C"
 		BuildCartridgeMenu();		
 	}
 
+	__declspec(dllexport) void PakTerminate()
+	{
+		if (hConfDlg)
+		{
+			CloseCartDialog(hConfDlg);
+			hConfDlg = nullptr;
+		}
+	}
 }
 
 extern "C" 

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -80,15 +80,11 @@ unsigned char LoadExtRom(const char *);
 BOOL APIENTRY
 DllMain(HINSTANCE hinst, DWORD reason, LPVOID foo)
 {
-    if (reason == DLL_PROCESS_ATTACH) {
+    if (reason == DLL_PROCESS_ATTACH)
+	{
 		gModuleInstance = hinst;
-        LoadExtRom("RS232.ROM");
-
-    } else if (reason == DLL_PROCESS_DETACH) {
-        sc6551_close();
-        AciaStat[0]='\0';
-        CloseCartDialog(g_hDlg);
     }
+
     return TRUE;
 }
 
@@ -133,8 +129,16 @@ extern "C"
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();
+		LoadExtRom("RS232.ROM");
 		sc6551_init();
 	}
+	__declspec(dllexport) void PakTerminate()
+	{
+		CloseCartDialog(g_hDlg);
+		sc6551_close();
+		AciaStat[0]='\0';
+	}
+	
 
 }
 

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -78,14 +78,10 @@ BOOL APIENTRY DllMain( HINSTANCE  hinstDLL,
 		case DLL_PROCESS_ATTACH:
 			// init
 			gModuleInstance = hinstDLL;
-			LastStats = GetTickCount();
-			SetDWTCPConnectionEnable(1);
-
 			break;
+
 		case DLL_PROCESS_DETACH:
 			// shutdown
-
-		
 			break;
 
 		// not used by Vcc
@@ -426,10 +422,11 @@ extern "C"
 		PakSetCart = context->assert_cartridge_line;
 		strcpy(IniFile, configuration_path);
 
+		LastStats = GetTickCount();
 		LoadConfig();
+		SetDWTCPConnectionEnable(1);
 		BuildCartridgeMenu();
 	}
-
 }
 
 

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -45,6 +45,8 @@ namespace vcc { namespace core
 		virtual description_type description() const = 0;
 
 		virtual void start() = 0;
+		virtual void stop() = 0;
+
 		virtual void reset() = 0;
 		virtual void heartbeat() = 0;
 		virtual void write_port(unsigned char port_id, unsigned char value) = 0;

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -39,6 +39,8 @@ namespace vcc { namespace core { namespace cartridges
 		description_type description() const override;
 
 		void start() override;
+		void stop() override;
+
 		void reset() override;
 		void heartbeat() override;
 		void write_port(unsigned char port_id, unsigned char value) override;

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -45,6 +45,8 @@ namespace vcc { namespace core { namespace cartridges
 		LIBCOMMON_EXPORT description_type description() const override;
 
 		LIBCOMMON_EXPORT void start() override;
+		LIBCOMMON_EXPORT void stop() override;
+
 		LIBCOMMON_EXPORT void reset() override;
 		LIBCOMMON_EXPORT void heartbeat() override;
 		LIBCOMMON_EXPORT void status(char* text_buffer, size_t buffer_size) override;
@@ -53,6 +55,7 @@ namespace vcc { namespace core { namespace cartridges
 		LIBCOMMON_EXPORT unsigned char read_memory_byte(unsigned short memory_address) override;
 		LIBCOMMON_EXPORT unsigned short sample_audio() override;
 		LIBCOMMON_EXPORT void menu_item_clicked(unsigned char menu_item_id) override;
+
 
 	private:
 
@@ -63,6 +66,7 @@ namespace vcc { namespace core { namespace cartridges
 
 		// imported module functions
 		const PakInitializeModuleFunction initialize_;
+		const PakTerminateModuleFunction terminate_;
 		const PakGetNameModuleFunction get_name_;
 		const PakGetCatalogIdModuleFunction get_catalog_id_;
 		const PakGetDescriptionModuleFunction get_description_;

--- a/libcommon/include/vcc/core/legacy_cartridge_definitions.h
+++ b/libcommon/include/vcc/core/legacy_cartridge_definitions.h
@@ -45,6 +45,7 @@ extern "C"
 		void* host_key,
 		const char* const configuration_path,
 		const cpak_cartridge_context* const context);
+	using PakTerminateModuleFunction = void (*)();
 	using PakGetNameModuleFunction = const char* (*)();
 	using PakGetCatalogIdModuleFunction = const char* (*)();
 	using PakGetDescriptionModuleFunction = const char* (*)();

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -43,6 +43,9 @@ namespace vcc { namespace core { namespace cartridges
 		initialize_bus();
 	}
 
+	void basic_cartridge::stop()
+	{}
+
 	void basic_cartridge::reset()
 	{}
 

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -32,6 +32,8 @@ namespace vcc { namespace core { namespace cartridges
 			return importedFunction ? importedFunction : defaultFunction;
 		}
 
+		void default_stop()
+		{}
 
 		void default_menu_item_clicked(unsigned char)
 		{}
@@ -84,6 +86,7 @@ namespace vcc { namespace core { namespace cartridges
 		configuration_path_(move(configuration_path)),
 		cpak_context_(cpak_context),
 		initialize_(GetImportedProcAddress<PakInitializeModuleFunction>(module_handle, "PakInitialize", nullptr)),
+		terminate_(GetImportedProcAddress(module_handle, "PakTerminate", default_stop)),
 		get_name_(GetImportedProcAddress(module_handle, "PakGetName", default_get_empty_string)),
 		get_catalog_id_(GetImportedProcAddress(module_handle, "PakGetCatalogId", default_get_empty_string)),
 		get_description_(GetImportedProcAddress(module_handle, "PakGetDescription", default_get_empty_string)),
@@ -121,6 +124,11 @@ namespace vcc { namespace core { namespace cartridges
 	void legacy_cartridge::start()
 	{
 		initialize_(host_context_, configuration_path_.c_str(), &cpak_context_);
+	}
+
+	void legacy_cartridge::stop()
+	{
+		terminate_();
 	}
 
 	void legacy_cartridge::reset()

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -83,6 +83,11 @@ namespace vcc { namespace modules { namespace mpi
 			cartridge_->start();
 		}
 
+		void stop() const
+		{
+			cartridge_->stop();
+		}
+
 		void reset() const
 		{
 			cartridge_->reset();

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -43,8 +43,6 @@ BOOL WINAPI DllMain(HINSTANCE module_instance, DWORD reason, LPVOID /*reserved*/
 		break;
 
 	case DLL_PROCESS_DETACH:
-		gConfigurationDialog.close();
-		gMultiPakInterface.eject_all();
 		break;
 	}
 
@@ -86,6 +84,12 @@ extern "C"
 		gHostContext->assert_cartridge_line_ = context->assert_cartridge_line;
 
 		gMultiPakInterface.start();
+	}
+
+	__declspec(dllexport) void PakTerminate()
+	{
+		gConfigurationDialog.close();
+		gMultiPakInterface.stop();
 	}
 
 }

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -93,6 +93,17 @@ void multipak_cartridge::start()
 	load_configuration();
 }
 
+
+void multipak_cartridge::stop()
+{
+	gConfigurationDialog.close();
+
+	for (auto slot(0u); slot < slots_.size(); slot++)
+	{
+		eject_cartridge(slot);
+	}
+}
+
 void multipak_cartridge::reset()
 {
 	vcc::core::utils::section_locker lock(mutex_);
@@ -269,18 +280,11 @@ bool multipak_cartridge::empty(slot_id_type slot) const
 	return slots_[slot].empty();
 }
 
-// FIXME: refactor this into a stop that also shuts down the configuration dialog
-void multipak_cartridge::eject_all()
-{
-	for (auto slot(0u); slot < slots_.size(); slot++)
-	{
-		eject_cartridge(slot);
-	}
-}
-
 void multipak_cartridge::eject_cartridge(slot_id_type slot)
 {
 	vcc::core::utils::section_locker lock(mutex_);
+
+	slots_[slot].stop();
 
 	slots_[slot] = {};
 }

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -54,6 +54,8 @@ public:
 	description_type description() const override;
 
 	void start() override;
+	void stop() override;
+
 	void reset() override;
 	void heartbeat() override;
 	void write_port(unsigned char port_id, unsigned char value) override;
@@ -69,7 +71,6 @@ public:
 
 	bool empty(slot_id_type slot) const;
 
-	void eject_all();
 	void eject_cartridge(slot_id_type slot);
 	mount_status_type mount_cartridge(slot_id_type slot, const path_type& filename);
 

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -28,18 +28,19 @@ static PakAssertCartridgeLineHostCallback PakSetCart = nullptr;
 static unsigned char LeftChannel=0,RightChannel=0;
 unsigned char LoadExtRom(const char *);
 static unsigned char Rom[8192];
+
+
 BOOL WINAPI DllMain(
     HINSTANCE hinstDLL,  // handle to DLL module
     DWORD fdwReason,     // reason for calling function
     LPVOID lpReserved )  // reserved
 {
-	if (fdwReason == DLL_PROCESS_DETACH ) //Clean Up 
+	if (fdwReason == DLL_PROCESS_ATTACH) //Clean Up 
 	{
-		//Put shutdown procs here
-		return 1;
+		gModuleInstance = hinstDLL;
 	}
-	gModuleInstance = hinstDLL;
-	return 1;
+
+	return TRUE;
 }
 
 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -306,6 +306,8 @@ void UnloadDll()
 {
 	vcc::core::utils::section_locker lock(gPakMutex);
 
+	gActiveCartrige->stop();
+
 	gActiveCartrige = std::make_unique<vcc::core::cartridges::null_cartridge>();
 	gActiveModule.reset();
 

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -395,6 +395,16 @@ extern "C"
 		BuildCartridgeMenu();
 	}
 
+	__declspec(dllexport) void PakTerminate()
+	{
+		CloseCartDialog(hControlDlg);
+		CloseCartDialog(hConfigureDlg);
+		hControlDlg = nullptr;
+		hConfigureDlg = nullptr;
+		CloseDrive(0);
+		CloseDrive(1);
+	}
+
     // Write to port
     __declspec(dllexport) void PakWritePort(unsigned char Port,unsigned char Data)
     {
@@ -477,17 +487,11 @@ extern "C"
 
 BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID rsvd)
 {
-    if (reason == DLL_PROCESS_ATTACH) {
+    if (reason == DLL_PROCESS_ATTACH)
+	{
 		gModuleInstance = hinst;
-
-    } else if (reason == DLL_PROCESS_DETACH) {
-        CloseCartDialog(hControlDlg);
-        CloseCartDialog(hConfigureDlg);
-        hControlDlg = nullptr;
-        hConfigureDlg = nullptr;
-        CloseDrive(0);
-        CloseDrive(1);
     }
+
     return TRUE;
 }
 


### PR DESCRIPTION
Adds a `stop` member to the `cartridge` interface and `PakTerminate` export to cpak (C based) interface.

- Update cartridge implementations derived from `cartridge` to implement `stop`.
- Updates legacy cartridge to support the `PakTerminate`  export.
- Updated pakinterface in VCC to invoke `stop` when ejecting a cartridge.
- Update MPI to invoke `stop` when ejecting a cartridge.
- Updated all cartridge implementations to move shutdown code from `DllMain` to `PakTerminate` where necessary.