### PR TITLE
rename `heartbeat` to `process_horizontal_sync`

### DIFF
--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -46,7 +46,7 @@ namespace vcc { namespace core
 
 		virtual void start() = 0;
 		virtual void reset() = 0;
-		virtual void heartbeat() = 0;
+		virtual void process_horizontal_sync() = 0;
 		virtual void write_port(unsigned char port_id, unsigned char value) = 0;
 		virtual unsigned char read_port(unsigned char port_id) = 0;
 		virtual unsigned char read_memory_byte(unsigned short memory_address) = 0;

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -40,7 +40,7 @@ namespace vcc { namespace core { namespace cartridges
 
 		void start() override;
 		void reset() override;
-		void heartbeat() override;
+		void process_horizontal_sync() override;
 		void write_port(unsigned char port_id, unsigned char value) override;
 		unsigned char read_port(unsigned char port_id) override;
 		unsigned char read_memory_byte(unsigned short memory_address) override;

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -46,7 +46,7 @@ namespace vcc { namespace core { namespace cartridges
 
 		LIBCOMMON_EXPORT void start() override;
 		LIBCOMMON_EXPORT void reset() override;
-		LIBCOMMON_EXPORT void heartbeat() override;
+		LIBCOMMON_EXPORT void process_horizontal_sync() override;
 		LIBCOMMON_EXPORT void status(char* text_buffer, size_t buffer_size) override;
 		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;
 		LIBCOMMON_EXPORT unsigned char read_port(unsigned char port_id) override;

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -46,7 +46,7 @@ namespace vcc { namespace core { namespace cartridges
 	void basic_cartridge::reset()
 	{}
 
-	void basic_cartridge::heartbeat()
+	void basic_cartridge::process_horizontal_sync()
 	{}
 
 	void basic_cartridge::write_port(unsigned char port_id, unsigned char value)

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -128,7 +128,7 @@ namespace vcc { namespace core { namespace cartridges
 		reset_();
 	}
 
-	void legacy_cartridge::heartbeat()
+	void legacy_cartridge::process_horizontal_sync()
 	{
 		heartbeat_();
 	}

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -88,9 +88,9 @@ namespace vcc { namespace modules { namespace mpi
 			cartridge_->reset();
 		}
 
-		void heartbeat() const
+		void process_horizontal_sync() const
 		{
-			cartridge_->heartbeat();
+			cartridge_->process_horizontal_sync();
 		}
 
 		void write_port(unsigned char port_id, unsigned char value) const

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -107,7 +107,7 @@ EXPORT_PUBLIC_API unsigned char PakReadPort(unsigned char port_id)
 
 EXPORT_PUBLIC_API void PakProcessHorizontalSync()
 {
-	gMultiPakInterface.heartbeat();
+	gMultiPakInterface.process_horizontal_sync();
 }
 
 EXPORT_PUBLIC_API unsigned char PakReadMemoryByte(unsigned short memory_address)

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -107,13 +107,13 @@ void multipak_cartridge::reset()
 	context_->assert_cartridge_line(slots_[cached_scs_slot_].line_state());
 }
 
-void multipak_cartridge::heartbeat()
+void multipak_cartridge::process_horizontal_sync()
 {
 	vcc::core::utils::section_locker lock(mutex_);
 
 	for(const auto& cartridge_slot : slots_)
 	{
-		cartridge_slot.heartbeat();
+		cartridge_slot.process_horizontal_sync();
 	}
 }
 

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -55,7 +55,7 @@ public:
 
 	void start() override;
 	void reset() override;
-	void heartbeat() override;
+	void process_horizontal_sync() override;
 	void write_port(unsigned char port_id, unsigned char value) override;
 	unsigned char read_port(unsigned char port_id) override;
 	unsigned char read_memory_byte(unsigned short memory_address) override;

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -127,7 +127,7 @@ void PakTimer()
 {
 	vcc::core::utils::section_locker lock(gPakMutex);
 
-	gActiveCartrige->heartbeat();
+	gActiveCartrige->process_horizontal_sync();
 }
 
 void ResetBus()


### PR DESCRIPTION
Renames `heartbeat` to `process_horizontal_sync` in `cartridge` and derived types.