### PR TITLE
rename to `PakCatalogName` to `PakGetCatalogId`

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -116,7 +116,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -48,7 +48,7 @@ protected:
 private:
 
 	friend const char* PakGetName();
-	friend const char* PakCatalogName();
+	friend const char* PakGetCatalogId();
 	friend void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -13,7 +13,7 @@ GMC_EXPORT const char* PakGetName()
 	return string_buffer;
 }
 
-GMC_EXPORT const char* PakCatalogName()
+GMC_EXPORT const char* PakGetCatalogId()
 {
 	static char string_buffer[MAX_LOADSTRING];
 

--- a/GMC/CartridgeTrampolines.h
+++ b/GMC/CartridgeTrampolines.h
@@ -2,7 +2,7 @@
 #include "GMC.h"
 
 GMC_EXPORT const char* PakGetName();
-GMC_EXPORT const char* PakCatalogName();
+GMC_EXPORT const char* PakGetCatalogId();
 GMC_EXPORT void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -97,7 +97,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -49,7 +49,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -76,7 +76,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -104,7 +104,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -398,7 +398,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -64,7 +64,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	EXPORT_PUBLIC_API const char* PakCatalogName()
+	EXPORT_PUBLIC_API const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -56,7 +56,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -361,7 +361,7 @@ extern "C"
 		return string_buffer;
 	}
 
-	__declspec(dllexport) const char* PakCatalogName()
+	__declspec(dllexport) const char* PakGetCatalogId()
 	{
 		static char string_buffer[MAX_LOADSTRING];
 


### PR DESCRIPTION
rename to `PakCatalogName` to `PakGetCatalogId` in all cartridge implementations exporting the C api