### PR TITLE
FD502 restore floppy becker config items

### DIFF
--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -23,6 +23,9 @@ extern void*const& gHostKey;
 extern PakAssertInteruptHostCallback AssertInt;
 void BuildCartridgeMenu();
 
+// DO NOT REMOVE until becker.dll is retired.  Then FD502 becker becomes permanant.
+#define COMBINE_BECKER
+
 // FIXME: These need to be turned into a scoped enum and the signature of functions
 // that use them updated.
 #define External 0

--- a/FD502/fd502.rc
+++ b/FD502/fd502.rc
@@ -55,6 +55,9 @@ END
 // Dialog
 //
 
+// DO NOT REMOVE until becker.dll is retired.  Then FD502 becker becomes permanant.
+#define COMBINE_BECKER
+
 IDD_CONFIG DIALOGEX 0, 0, 268, 185
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Floppy Configuration"
@@ -198,7 +201,7 @@ STRINGTABLE
 BEGIN
     IDS_MODULE_NAME         "FD-502"
     IDS_VERSION             "3.0.1"
-    IDS_DESCRIPTION         "Turn any Color Computer with Extended BASIC into a disk system. Write your own disk applications or add ready-to-run software. Plugs into the Program Pak port or Multi-Pak Interface."
+    IDS_DESCRIPTION         "Emulate FD502 floppy controller with four floppy drives.  Loads Disk Extended Color Basic (disl11.rom) or user selectable disk rom.  Also includes Becker Port for communicating with Drivewire and a Disto Clock for use with OS-9.  Uses SCS selectable disk ports.  Plugs into the Program Pak port or Multi-Pak Interface."
 #ifdef COMBINE_BECKER
     IDS_CATNUMBER           "+ Becker"
 #else

--- a/FD502/fd502.vcxproj
+++ b/FD502/fd502.vcxproj
@@ -62,7 +62,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;COMBINE_BECKER;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile />
     <Link>
@@ -72,7 +72,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Legacy|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;COMBINE_BECKER;_USRDLL;fd502_EXPORTS;_LEGACY_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_USRDLL;fd502_EXPORTS;_LEGACY_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/arch:SSE</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
@@ -86,7 +86,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;COMBINE_BECKER;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;fd502_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/arch:SSE</AdditionalOptions>
     </ClCompile>
     <ResourceCompile />

--- a/libcommon/include/vcc/core/limits.h
+++ b/libcommon/include/vcc/core/limits.h
@@ -18,4 +18,4 @@
 #pragma once
 
 
-constexpr auto MAX_LOADSTRING = 200u;
+constexpr auto MAX_LOADSTRING = 400u;


### PR DESCRIPTION
COMBINE_BECKER macro affects rc file.  Macro will be removed in the future. Added back to fd502.h and fd502.rc for temporary fix.

Increased value of MAX_LOADSTRING