### PR TITLE
Fixes return type of PakReset exports

### DIFF
--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -464,7 +464,7 @@ extern "C" __declspec(dllexport) unsigned char PakReadPort(unsigned char Port)
 	}
 
 /*
-	__declspec(dllexport) unsigned char PakReset()
+	__declspec(dllexport) void PakReset()
 	{
 		if (PakSetCart!=NULL)
 			PakSetCart(1);

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -116,7 +116,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char PakReset()
+	__declspec(dllexport) void PakReset()
 	{
 		char RomPath[MAX_PATH];
 
@@ -127,8 +127,6 @@ extern "C"
 		
 		if (LoadExtRom(RomPath))	//If we can load the rom them assert cart 
 			PakSetCart(gHostKey, 1);
-
-		return 0;
 	}
 }
 

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -425,11 +425,10 @@ extern "C"
     }
 
     // Reset module
-    __declspec(dllexport) unsigned char PakReset()
+    __declspec(dllexport) void PakReset()
     {
         DLOG_C("PakReset\n");
         SDCInit();
-        return 0;
     }
 
     //  Dll export run config dialog


### PR DESCRIPTION
gixes return type of `PakReset` exports in the following cartridges

- Becker.
- Orchestra-90cc.
- SDC.

The MPI is not updated as the `PakReset` function is removed in pending merge.
