### PR TITLE
Reorganize libcommon

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -30,7 +30,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::Reset()
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		ExecutionMode_ = ExecutionMode::Run;
 		PendingCommand_ = ExecutionMode::Halt;
@@ -50,7 +50,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::RegisterClient(HWND window, std::unique_ptr<Client> client)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		if (!client)
 		{
@@ -68,7 +68,7 @@ namespace VCC { namespace Debugger
 	
 	void Debugger::RemoveClient(HWND window)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		if (RegisteredClients_.find(window) == RegisteredClients_.end())
 		{
@@ -99,7 +99,7 @@ namespace VCC { namespace Debugger
 		}
 
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			vcc::utils::section_locker lock(Section_);
 			returnPc = ProcessorState_.PC;
 		}
 
@@ -116,7 +116,7 @@ namespace VCC { namespace Debugger
 
 	CPUState Debugger::GetProcessorStateCopy() const
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		return ProcessorState_;
 	}
@@ -142,7 +142,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetBreakpoints(breakpointsbuffer_type breakpoints)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		Breakpoints_ = move(breakpoints);
 		BreakpointsChanged_ = true;
@@ -279,14 +279,14 @@ namespace VCC { namespace Debugger
 		TraceEnabled_ = false;
 		TraceRunning_ = false;
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			vcc::utils::section_locker lock(Section_);
 			Decoder_->Reset(TraceMaxSamples_);
 		}
 	}
 
 	void Debugger::SetTraceMaxSamples(long samples)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		TraceMaxSamples_ = samples;
 		Decoder_->Reset(TraceMaxSamples_);
@@ -294,7 +294,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceStartTriggers(triggerbuffer_type startTriggers)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		TraceStartTriggers_ = move(startTriggers);
 		TraceTriggerChanged_ = true;
@@ -302,7 +302,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceStopTriggers(triggerbuffer_type stopTriggers)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		TraceStopTriggers_ = move(stopTriggers);
 		TraceTriggerChanged_ = true;
@@ -310,7 +310,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceOptions(bool screen, bool emulation)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		TraceScreen_ = screen;
 		TraceEmulation_ = emulation;
@@ -318,7 +318,7 @@ namespace VCC { namespace Debugger
 
 	long Debugger::GetTraceSamples() const
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		return Decoder_->GetSampleCount();
 	}
@@ -330,7 +330,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::SetTraceMark(int mark, long sample)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		TraceMarks_[mark] = sample;
 	}
@@ -338,14 +338,14 @@ namespace VCC { namespace Debugger
 
 	void Debugger::ClearTraceMarks()
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		TraceMarks_.clear();
 	}
 
 	void Debugger::GetTraceMarkSamples(tracebuffer_type &result) const
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		result.clear();
 
@@ -360,7 +360,7 @@ namespace VCC { namespace Debugger
 	void Debugger::QueueRun()
 	{
 		ApplyHaltpoints(true);
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Run;
 		HasPendingCommand_ = true;
@@ -368,7 +368,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::QueueStep()
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Step;
 		HasPendingCommand_ = true;
@@ -377,7 +377,7 @@ namespace VCC { namespace Debugger
 	void Debugger::QueueHalt()
 	{
 		ApplyHaltpoints(false);
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Halt;
 		HasPendingCommand_ = true;
@@ -397,7 +397,7 @@ namespace VCC { namespace Debugger
 	void Debugger::Update()
 	{
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			vcc::utils::section_locker lock(Section_);
 
 			ProcessorState_ = CPUGetState();
 
@@ -457,7 +457,7 @@ namespace VCC { namespace Debugger
 
 	void Debugger::QueueWrite(unsigned short addr, unsigned char value)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		vcc::utils::section_locker lock(Section_);
 
 		PendingWrite_ = PendingWrite(addr, value);
 		HasPendingWrite_ = true;

--- a/Debugger.h
+++ b/Debugger.h
@@ -19,7 +19,7 @@
 #pragma once
 #include "DebuggerUtils.h"
 #include "MachineDefs.h"
-#include <vcc/core/utils/critical_section.h>
+#include <vcc/utils/critical_section.h>
 #include <string>
 #include <vector>
 #include <functional>
@@ -146,7 +146,7 @@ namespace VCC { namespace Debugger
 
 	private:
 
-		mutable vcc::core::utils::critical_section	Section_;
+		mutable vcc::utils::critical_section	Section_;
 		bool							HasPendingCommand_ = false;
 		ExecutionMode					PendingCommand_ = ExecutionMode::Halt;
 		breakpointsbuffer_type			Breakpoints_;

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -114,7 +114,7 @@ std::string FmtLine(
 /*            Static Variables                    */
 /**************************************************/
 
-vcc::core::utils::critical_section Section_;
+vcc::utils::critical_section Section_;
 
 HINSTANCE hVccInst;
 
@@ -790,7 +790,7 @@ void UnHilitePC()
 /***************************************************/
 void ApplyHaltPoint(Haltpoint &hp,bool flag)
 {
-	vcc::core::utils::section_locker lock(Section_);
+	vcc::utils::section_locker lock(Section_);
     if (flag) {
         if (!hp.placed) {
             // Be sure really not placed

--- a/GMC/gmc_cartridge.cpp
+++ b/GMC/gmc_cartridge.cpp
@@ -1,11 +1,11 @@
 #include "gmc_cartridge.h"
 #include "resource.h"
 #include <vcc/common/DialogOps.h>
-#include <vcc/core/utils/winapi.h>
-#include <vcc/core/utils/filesystem.h>
-#include <Windows.h>
+#include <vcc/utils/configuration_serializer.h>
+#include <vcc/utils/winapi.h>
+#include <vcc/utils/filesystem.h>
 #include "../CartridgeMenu.h"
-#include <vcc/core/utils/configuration_serializer.h>
+#include <Windows.h>
 
 namespace
 {
@@ -39,22 +39,22 @@ gmc_cartridge::gmc_cartridge(std::unique_ptr<context_type> context, HINSTANCE mo
 
 gmc_cartridge::name_type gmc_cartridge::name() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_MODULE_NAME);
+	return ::vcc::utils::load_string(module_instance_, IDS_MODULE_NAME);
 }
 
 gmc_cartridge::catalog_id_type gmc_cartridge::catalog_id() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_CATNUMBER);
+	return ::vcc::utils::load_string(module_instance_, IDS_CATNUMBER);
 }
 
 gmc_cartridge::description_type gmc_cartridge::description() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_DESCRIPTION);
+	return ::vcc::utils::load_string(module_instance_, IDS_DESCRIPTION);
 }
 
 void gmc_cartridge::start()
 {
-	::vcc::core::configuration_serializer serializer(context_->configuration_path());
+	::vcc::utils::configuration_serializer serializer(context_->configuration_path());
 	const auto selected_file(serializer.read(configuration_section_id_, configuration_rom_key_id_));
 
 	load_rom(selected_file, false);
@@ -107,7 +107,7 @@ void gmc_cartridge::status(char* status, size_t buffer_size)
 {
 	std::string message("GMC Active");
 
-	const auto activeRom(::vcc::core::utils::get_filename(rom_image_.filename()));
+	const auto activeRom(::vcc::utils::get_filename(rom_image_.filename()));
 	if (!rom_image_.empty())
 	{
 		message += " (" + activeRom + " Loaded)";
@@ -143,7 +143,7 @@ void gmc_cartridge::menu_item_clicked(unsigned char menuId)
 			return;
 		}
 
-		::vcc::core::configuration_serializer serializer(context_->configuration_path());
+		::vcc::utils::configuration_serializer serializer(context_->configuration_path());
 		serializer.write(
 			configuration_section_id_,
 			configuration_rom_key_id_,

--- a/GMC/gmc_cartridge.h
+++ b/GMC/gmc_cartridge.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "sn76496.h"
+#include <vcc/devices/rom/banked_rom_image.h>
 #include <vcc/core/cartridge.h>
 #include <vcc/core/cartridge_context.h>
-#include <vcc/core/banked_rom_image.h>
 #include <memory>
 #include <Windows.h>
 
@@ -13,7 +13,7 @@ public:
 
 	using context_type = ::vcc::core::cartridge_context;
 	using path_type = ::std::string;
-	using rom_image_type = ::vcc::core::banked_rom_image;
+	using rom_image_type = ::vcc::devices::rom::banked_rom_image;
 
 
 public:

--- a/MMUMonitor.cpp
+++ b/MMUMonitor.cpp
@@ -31,7 +31,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 	const COLORREF rgbViolet = RGB(100,   0, 170);
 	const COLORREF rgbGray   = RGB(120, 120, 120);
 
-	vcc::core::utils::critical_section Section_;
+	vcc::utils::critical_section Section_;
 	MMUState MMUState_;
 
 	HWND MMUMonitorWindow = nullptr;
@@ -44,7 +44,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		void OnReset() override {
 		}
 		void OnUpdate() override {
-			vcc::core::utils::section_locker lock(Section_);
+			vcc::utils::section_locker lock(Section_);
 			MMUState_ = GetMMUState();
 		}
 	};
@@ -107,7 +107,7 @@ namespace VCC { namespace Debugger { namespace UI { namespace
 		// Quick pull out MMU state
 		MMUState regs;
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			vcc::utils::section_locker lock(Section_);
 			regs = MMUState_;
 		}
 

--- a/Ramdisk/ramdisk_cartridge.cpp
+++ b/Ramdisk/ramdisk_cartridge.cpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "ramdisk_cartridge.h"
 #include "resource.h"
-#include <vcc/core/utils/winapi.h>
+#include <vcc/utils/winapi.h>
 
 
 extern HINSTANCE gModuleInstance;
@@ -25,12 +25,12 @@ extern HINSTANCE gModuleInstance;
 
 ramdisk_cartridge::name_type ramdisk_cartridge::name() const
 {
-	return ::vcc::core::utils::load_string(gModuleInstance, IDS_MODULE_NAME);
+	return ::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME);
 }
 
 ramdisk_cartridge::catalog_id_type ramdisk_cartridge::catalog_id() const
 {
-	return ::vcc::core::utils::load_string(gModuleInstance, IDS_CATNUMBER);
+	return ::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER);
 }
 
 void ramdisk_cartridge::start()

--- a/Ramdisk/ramdisk_cartridge.h
+++ b/Ramdisk/ramdisk_cartridge.h
@@ -16,13 +16,13 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridges/basic_cartridge.h>
+#include <vcc/cartridges/basic_cartridge.h>
 #include <vcc/core/cartridge_context.h>
 #include <memory>
 #include <array>
 
 
-class ramdisk_cartridge : public ::vcc::core::cartridges::basic_cartridge
+class ramdisk_cartridge : public ::vcc::cartridges::basic_cartridge
 {
 public:
 

--- a/libcommon/include/vcc/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/cartridges/basic_cartridge.h
@@ -16,61 +16,45 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/detail/exports.h>
-#include <string>
-#include <vector>
+#include <vcc/core/cartridge.h>
 
-namespace vcc { namespace core
+
+namespace vcc::cartridges
 {
 
-	class rom_image
+	struct LIBCOMMON_EXPORT basic_cartridge : public ::vcc::core::cartridge
 	{
 	public:
 
-		using path_type = std::string;
-		using container_type = std::vector<unsigned char>;
-		using value_type = container_type::value_type;
-		using size_type = container_type::size_type;
+		using name_type = std::string;
+		using catalog_id_type = std::string;
 
 
 	public:
 
-		LIBCOMMON_EXPORT rom_image() = default;
-		LIBCOMMON_EXPORT ~rom_image() = default;
+		using cartridge::cartridge;
 
-		bool empty() const
-		{
-			return data_.empty();
-		}
+		name_type name() const override;
+		catalog_id_type catalog_id() const override;
+		description_type description() const override;
 
-		path_type filename() const
-		{
-			return filename_;
-		}
+		void start() override;
+		void stop() override;
 
-		LIBCOMMON_EXPORT bool load(path_type filename);
-
-		void clear()
-		{
-			filename_.clear();
-			data_.clear();
-		}
-
-		value_type read_memory_byte(size_type memory_address) const
-		{
-			if (data_.empty())
-			{
-				return 0;
-			}
-
-			return data_[memory_address % data_.size()];
-		}
+		void reset() override;
+		void process_horizontal_sync() override;
+		void write_port(unsigned char port_id, unsigned char value) override;
+		unsigned char read_port(unsigned char port_id) override;
+		unsigned char read_memory_byte(unsigned short memory_address) override;
+		void status(char* text_buffer, size_t buffer_size) override;
+		unsigned short sample_audio() override;
+		void menu_item_clicked(unsigned char menu_item_id) override;
 
 
-	private:
+	protected:
 
-		path_type filename_;
-		container_type data_;
+		virtual void initialize_pak();
+		virtual void initialize_bus();
 	};
 
-} }
+}

--- a/libcommon/include/vcc/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/cartridges/legacy_cartridge.h
@@ -22,10 +22,10 @@
 #include <string>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::cartridges
 {
 
-	class legacy_cartridge: public cartridge
+	class legacy_cartridge: public ::vcc::core::cartridge
 	{
 	public:
 
@@ -80,4 +80,4 @@ namespace vcc { namespace core { namespace cartridges
 		const PakMenuItemClickedModuleFunction menu_item_clicked_;
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/cartridges/null_cartridge.h
+++ b/libcommon/include/vcc/cartridges/null_cartridge.h
@@ -16,33 +16,13 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/detail/exports.h>
-#include <string>
+#include <vcc/cartridges/basic_cartridge.h>
 
 
-namespace vcc { namespace core
+namespace vcc::cartridges
 {
 
-	class configuration_serializer
-	{
-	public:
+	class LIBCOMMON_EXPORT null_cartridge : public basic_cartridge
+	{};
 
-		using path_type = ::std::string;
-		using string_type = ::std::string;
-
-	public:
-
-		LIBCOMMON_EXPORT explicit configuration_serializer(path_type path);
-
-		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, int value) const;
-		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, const string_type& value) const;
-
-		LIBCOMMON_EXPORT int read(const string_type& section, const string_type& key, int default_value) const;
-		LIBCOMMON_EXPORT string_type read(const string_type& section, const string_type& key, const string_type& default_value = {}) const;
-
-
-	private:
-
-		const path_type path_;
-	};
-} }
+}

--- a/libcommon/include/vcc/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/cartridges/rom_cartridge.h
@@ -16,13 +16,13 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridges/basic_cartridge.h>
+#include <vcc/cartridges/basic_cartridge.h>
 #include <vcc/core/cartridge_context.h>
 #include <vector>
 #include <memory>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::cartridges
 {
 
 	class rom_cartridge : public basic_cartridge
@@ -70,4 +70,4 @@ namespace vcc { namespace core { namespace cartridges
 		size_type bank_offset_;
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/devices/rom/banked_rom_image.h
+++ b/libcommon/include/vcc/devices/rom/banked_rom_image.h
@@ -1,15 +1,15 @@
 #pragma once
-#include <vcc/core/rom_image.h>
+#include <vcc/devices/rom/rom_image.h>
 
 
-namespace vcc::core
+namespace vcc::devices::rom
 {
 
 	class banked_rom_image
 	{
 	public:
 
-		using rom_image_type = ::vcc::core::rom_image;
+		using rom_image_type = ::vcc::devices::rom::rom_image;
 		using value_type = rom_image_type::value_type;
 		using size_type = rom_image_type::size_type;
 

--- a/libcommon/include/vcc/devices/rom/rom_image.h
+++ b/libcommon/include/vcc/devices/rom/rom_image.h
@@ -16,13 +16,61 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridges/basic_cartridge.h>
+#include <vcc/core/detail/exports.h>
+#include <string>
+#include <vector>
 
-
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::devices::rom
 {
 
-	class LIBCOMMON_EXPORT null_cartridge : public basic_cartridge
-	{};
+	class rom_image
+	{
+	public:
 
-} } }
+		using path_type = std::string;
+		using container_type = std::vector<unsigned char>;
+		using value_type = container_type::value_type;
+		using size_type = container_type::size_type;
+
+
+	public:
+
+		LIBCOMMON_EXPORT rom_image() = default;
+		LIBCOMMON_EXPORT ~rom_image() = default;
+
+		bool empty() const
+		{
+			return data_.empty();
+		}
+
+		path_type filename() const
+		{
+			return filename_;
+		}
+
+		LIBCOMMON_EXPORT bool load(path_type filename);
+
+		void clear()
+		{
+			filename_.clear();
+			data_.clear();
+		}
+
+		value_type read_memory_byte(size_type memory_address) const
+		{
+			if (data_.empty())
+			{
+				return 0;
+			}
+
+			return data_[memory_address % data_.size()];
+		}
+
+
+	private:
+
+		path_type filename_;
+		container_type data_;
+	};
+
+}

--- a/libcommon/include/vcc/utils/cartridge_loader.h
+++ b/libcommon/include/vcc/utils/cartridge_loader.h
@@ -19,13 +19,13 @@
 #include <vcc/core/cartridge.h>
 #include <vcc/core/cartridge_context.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
-#include <vcc/core/utils/dll_deleter.h>
+#include <vcc/utils/dll_deleter.h>
 #include <string>
 #include <memory>
 #include <Windows.h>
 
 
-namespace vcc { namespace core
+namespace vcc::utils
 {
 
 	enum class cartridge_file_type
@@ -48,7 +48,7 @@ namespace vcc { namespace core
 
 	struct LIBCOMMON_EXPORT cartridge_loader_result
 	{
-		using handle_type = std::unique_ptr<std::remove_pointer_t<HMODULE>, vcc::core::dll_deleter>;
+		using handle_type = std::unique_ptr<std::remove_pointer_t<HMODULE>, vcc::utils::dll_deleter>;
 		using cartridge_ptr_type = std::unique_ptr<vcc::core::cartridge>;
 
 #pragma warning(push)
@@ -63,20 +63,20 @@ namespace vcc { namespace core
 
 	LIBCOMMON_EXPORT cartridge_loader_result load_rom_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context);
+		std::unique_ptr<::vcc::core::cartridge_context> cartridge_context);
 
 	LIBCOMMON_EXPORT cartridge_loader_result load_legacy_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<::vcc::core::cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
 		const cpak_cartridge_context& cpak_context);
 
 	LIBCOMMON_EXPORT cartridge_loader_result load_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<::vcc::core::cartridge_context> cartridge_context,
 		const cpak_cartridge_context& cpak_context,
 		void* const host_context,
 		const std::string& iniPath);
 
-} }
+}

--- a/libcommon/include/vcc/utils/configuration_serializer.h
+++ b/libcommon/include/vcc/utils/configuration_serializer.h
@@ -16,45 +16,33 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridge.h>
+#include <vcc/core/detail/exports.h>
+#include <string>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::utils
 {
 
-	struct LIBCOMMON_EXPORT basic_cartridge : public ::vcc::core::cartridge
+	class configuration_serializer
 	{
 	public:
 
-		using name_type = std::string;
-		using catalog_id_type = std::string;
-
+		using path_type = ::std::string;
+		using string_type = ::std::string;
 
 	public:
 
-		using cartridge::cartridge;
+		LIBCOMMON_EXPORT explicit configuration_serializer(path_type path);
 
-		name_type name() const override;
-		catalog_id_type catalog_id() const override;
-		description_type description() const override;
+		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, int value) const;
+		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, const string_type& value) const;
 
-		void start() override;
-		void stop() override;
-
-		void reset() override;
-		void process_horizontal_sync() override;
-		void write_port(unsigned char port_id, unsigned char value) override;
-		unsigned char read_port(unsigned char port_id) override;
-		unsigned char read_memory_byte(unsigned short memory_address) override;
-		void status(char* text_buffer, size_t buffer_size) override;
-		unsigned short sample_audio() override;
-		void menu_item_clicked(unsigned char menu_item_id) override;
+		LIBCOMMON_EXPORT int read(const string_type& section, const string_type& key, int default_value) const;
+		LIBCOMMON_EXPORT string_type read(const string_type& section, const string_type& key, const string_type& default_value = {}) const;
 
 
-	protected:
+	private:
 
-		virtual void initialize_pak();
-		virtual void initialize_bus();
+		const path_type path_;
 	};
-
-} } }
+}

--- a/libcommon/include/vcc/utils/critical_section.h
+++ b/libcommon/include/vcc/utils/critical_section.h
@@ -3,7 +3,7 @@
 #include <Windows.h>
 
 
-namespace vcc { namespace core { namespace utils
+namespace vcc::utils
 {
 
 	class critical_section
@@ -64,4 +64,4 @@ namespace vcc { namespace core { namespace utils
 		const critical_section& section_;
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/utils/dll_deleter.h
+++ b/libcommon/include/vcc/utils/dll_deleter.h
@@ -16,18 +16,22 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/detail/exports.h>
-#include <string>
+#include <vcc/common/logger.h>
 #include <Windows.h>
 
-
-namespace vcc { namespace core { namespace utils
+namespace vcc::utils
 {
 
-	LIBCOMMON_EXPORT std::string get_module_path(HMODULE module_handle = nullptr);
-	LIBCOMMON_EXPORT std::string find_pak_module_path(std::string path);
-	LIBCOMMON_EXPORT std::string get_directory_from_path(std::string path);
-	LIBCOMMON_EXPORT std::string get_filename(std::string path);
-	LIBCOMMON_EXPORT std::string strip_application_path(std::string path);
+	struct LIBCOMMON_EXPORT dll_deleter
+	{
+		void operator()(HMODULE instance) const
+		{
+			if (instance != nullptr)
+			{
+				const auto result(FreeLibrary(instance));
+				DLOG_C("pak:err FreeLibrary %d %d\n", instance, result);
+			}
+		};
+	};
 
-} } }
+}

--- a/libcommon/include/vcc/utils/filesystem.h
+++ b/libcommon/include/vcc/utils/filesystem.h
@@ -15,40 +15,19 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/rom_image.h>
-#include <fstream>
+#pragma once
+#include <vcc/core/detail/exports.h>
+#include <string>
 #include <Windows.h>
 
 
-namespace vcc { namespace core
+namespace vcc::utils
 {
 
-	bool rom_image::load(path_type filename)
-	{
-		std::ifstream input(filename, std::ios::binary);
-		if (!input.is_open())
-		{
-			return false;
-		}
+	LIBCOMMON_EXPORT std::string get_module_path(HMODULE module_handle = nullptr);
+	LIBCOMMON_EXPORT std::string find_pak_module_path(std::string path);
+	LIBCOMMON_EXPORT std::string get_directory_from_path(std::string path);
+	LIBCOMMON_EXPORT std::string get_filename(std::string path);
+	LIBCOMMON_EXPORT std::string strip_application_path(std::string path);
 
-		std::streamoff begin = input.tellg();
-		input.seekg(0, std::ios::end);
-		std::streamoff end = input.tellg();
-		std::streamoff file_length = end - begin;
-		input.seekg(0, std::ios::beg);
-
-		std::vector<unsigned char> rom_data(static_cast<size_t>(file_length));
-		input.read(reinterpret_cast<char*>(&rom_data[0]), rom_data.size());
-
-		if (file_length != rom_data.size())
-		{
-			return false;
-		}
-
-		filename_ = move(filename);
-		data_ = move(rom_data);
-
-		return true;
-	}
-
-} }
+}

--- a/libcommon/include/vcc/utils/winapi.h
+++ b/libcommon/include/vcc/utils/winapi.h
@@ -16,22 +16,14 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/common/logger.h>
+#include <vcc/core/detail/exports.h>
 #include <Windows.h>
+#include <string>
 
-namespace vcc { namespace core
+
+namespace vcc::utils
 {
 
-	struct LIBCOMMON_EXPORT dll_deleter
-	{
-		void operator()(HMODULE instance) const
-		{
-			if (instance != nullptr)
-			{
-				const auto result(FreeLibrary(instance));
-				DLOG_C("pak:err FreeLibrary %d %d\n", instance, result);
-			}
-		};
-	};
+	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id);
 
-} }
+}

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -98,47 +98,48 @@
     <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="src\core\banked_rom_image.cpp" />
-    <ClCompile Include="src\core\cartridges\basic_cartridge.cpp" />
-    <ClCompile Include="src\core\cartridges\legacy_cartridge.cpp" />
-    <ClCompile Include="src\core\cartridges\rom_cartridge.cpp" />
-    <ClCompile Include="src\core\cartridge_loader.cpp" />
-    <ClCompile Include="src\core\rom_image.cpp" />
-    <ClCompile Include="src\core\utils\configuration_serializer.cpp" />
-    <ClCompile Include="src\core\utils\filesystem.cpp" />
-    <ClCompile Include="src\core\utils\winapi.cpp" />
+    <ClCompile Include="src\cartridges\basic_cartridge.cpp" />
+    <ClCompile Include="src\cartridges\legacy_cartridge.cpp" />
+    <ClCompile Include="src\cartridges\rom_cartridge.cpp" />
+    <ClCompile Include="src\devices\rom\banked_rom_image.cpp" />
+    <ClCompile Include="src\devices\rom\rom_image.cpp" />
     <ClCompile Include="src\devices\rtc\cloud9.cpp" />
     <ClCompile Include="src\devices\rtc\oki_m6242b.cpp" />
     <ClCompile Include="src\DialogOps.cpp" />
     <ClCompile Include="src\Fileops.cpp" />
     <ClCompile Include="src\logger.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\utils\cartridge_loader.cpp" />
+    <ClCompile Include="src\utils\configuration_serializer.cpp" />
+    <ClCompile Include="src\utils\filesystem.cpp" />
+    <ClCompile Include="src\utils\winapi.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="include\vcc\cartridges\basic_cartridge.h" />
+    <ClInclude Include="include\vcc\cartridges\legacy_cartridge.h" />
+    <ClInclude Include="include\vcc\cartridges\null_cartridge.h" />
+    <ClInclude Include="include\vcc\cartridges\rom_cartridge.h" />
     <ClInclude Include="include\vcc\common\DialogOps.h" />
     <ClInclude Include="include\vcc\common\FileOps.h" />
     <ClInclude Include="include\vcc\common\logger.h" />
     <ClInclude Include="include\vcc\core\banked_rom_image.h" />
     <ClInclude Include="include\vcc\core\cartridge.h" />
-    <ClInclude Include="include\vcc\core\cartridges\basic_cartridge.h" />
-    <ClInclude Include="include\vcc\core\cartridges\legacy_cartridge.h" />
-    <ClInclude Include="include\vcc\core\cartridges\null_cartridge.h" />
-    <ClInclude Include="include\vcc\core\cartridges\rom_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridge_context.h" />
     <ClInclude Include="include\vcc\core\cartridge_factory.h" />
-    <ClInclude Include="include\vcc\core\cartridge_loader.h" />
     <ClInclude Include="include\vcc\core\detail\exports.h" />
     <ClInclude Include="include\vcc\core\interrupts.h" />
     <ClInclude Include="include\vcc\core\legacy_cartridge_definitions.h" />
     <ClInclude Include="include\vcc\core\limits.h" />
-    <ClInclude Include="include\vcc\core\rom_image.h" />
-    <ClInclude Include="include\vcc\core\utils\configuration_serializer.h" />
-    <ClInclude Include="include\vcc\core\utils\critical_section.h" />
-    <ClInclude Include="include\vcc\core\utils\dll_deleter.h" />
-    <ClInclude Include="include\vcc\core\utils\filesystem.h" />
-    <ClInclude Include="include\vcc\core\utils\winapi.h" />
+    <ClInclude Include="include\vcc\devices\rom\banked_rom_image.h" />
+    <ClInclude Include="include\vcc\devices\rom\rom_image.h" />
     <ClInclude Include="include\vcc\devices\rtc\cloud9.h" />
     <ClInclude Include="include\vcc\devices\rtc\oki_m6242b.h" />
+    <ClInclude Include="include\vcc\utils\cartridge_loader.h" />
+    <ClInclude Include="include\vcc\utils\configuration_serializer.h" />
+    <ClInclude Include="include\vcc\utils\critical_section.h" />
+    <ClInclude Include="include\vcc\utils\dll_deleter.h" />
+    <ClInclude Include="include\vcc\utils\filesystem.h" />
+    <ClInclude Include="include\vcc\utils\winapi.h" />
     <ClInclude Include="resource\resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -122,7 +122,6 @@
     <ClInclude Include="include\vcc\common\DialogOps.h" />
     <ClInclude Include="include\vcc\common\FileOps.h" />
     <ClInclude Include="include\vcc\common\logger.h" />
-    <ClInclude Include="include\vcc\core\banked_rom_image.h" />
     <ClInclude Include="include\vcc\core\cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridge_context.h" />
     <ClInclude Include="include\vcc\core\cartridge_factory.h" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -22,23 +22,8 @@
     <Filter Include="Header Files\core">
       <UniqueIdentifier>{6ca923e2-199b-44f0-8260-de0e62abca33}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\core">
-      <UniqueIdentifier>{3338d5c7-a9a1-4858-bc0f-b0ed9fa6b918}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Header Files\core\cartridges">
-      <UniqueIdentifier>{cc0a281d-6ff8-4a04-95a0-5bef8957ba5f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\core\cartridges">
-      <UniqueIdentifier>{6344b600-e0a8-4961-8a19-7ef6249e9a3e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Header Files\core\utils">
-      <UniqueIdentifier>{f5ac3a16-8b52-47c1-a81c-d58a404a2181}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Header Files\core\detail">
       <UniqueIdentifier>{fd029ab9-8064-4e1f-9460-edb495cf58ab}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\core\utils">
-      <UniqueIdentifier>{c3048278-09ca-471f-9cff-e11566354e5d}</UniqueIdentifier>
     </Filter>
     <Filter Include="Header Files\devices">
       <UniqueIdentifier>{b50b01e9-581e-4c73-8f71-43979671a294}</UniqueIdentifier>
@@ -52,6 +37,24 @@
     <Filter Include="Source Files\devices\rtc">
       <UniqueIdentifier>{7916028f-7cb9-4a17-8897-43634a51ba3d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\cartridges">
+      <UniqueIdentifier>{cc0a281d-6ff8-4a04-95a0-5bef8957ba5f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{f5ac3a16-8b52-47c1-a81c-d58a404a2181}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cartridges">
+      <UniqueIdentifier>{6344b600-e0a8-4961-8a19-7ef6249e9a3e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{c3048278-09ca-471f-9cff-e11566354e5d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\devices\rom">
+      <UniqueIdentifier>{29529fa0-403b-47f9-9537-8a84b9ba90b3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\devices\rom">
+      <UniqueIdentifier>{3338d5c7-a9a1-4858-bc0f-b0ed9fa6b918}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogOps.cpp">
@@ -63,32 +66,8 @@
     <ClCompile Include="src\logger.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
-    <ClCompile Include="src\core\cartridges\legacy_cartridge.cpp">
-      <Filter>Source Files\core\cartridges</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\cartridges\rom_cartridge.cpp">
-      <Filter>Source Files\core\cartridges</Filter>
-    </ClCompile>
     <ClCompile Include="src\main.cpp">
       <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\cartridge_loader.cpp">
-      <Filter>Source Files\core</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\utils\configuration_serializer.cpp">
-      <Filter>Source Files\core\utils</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\utils\filesystem.cpp">
-      <Filter>Source Files\core\utils</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\utils\winapi.cpp">
-      <Filter>Source Files\core\utils</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\cartridges\basic_cartridge.cpp">
-      <Filter>Source Files\core\cartridges</Filter>
-    </ClCompile>
-    <ClCompile Include="src\core\rom_image.cpp">
-      <Filter>Source Files\core</Filter>
     </ClCompile>
     <ClCompile Include="src\devices\rtc\cloud9.cpp">
       <Filter>Source Files\devices\rtc</Filter>
@@ -96,8 +75,32 @@
     <ClCompile Include="src\devices\rtc\oki_m6242b.cpp">
       <Filter>Source Files\devices\rtc</Filter>
     </ClCompile>
-    <ClCompile Include="src\core\banked_rom_image.cpp">
-      <Filter>Source Files\core</Filter>
+    <ClCompile Include="src\cartridges\basic_cartridge.cpp">
+      <Filter>Source Files\cartridges</Filter>
+    </ClCompile>
+    <ClCompile Include="src\cartridges\legacy_cartridge.cpp">
+      <Filter>Source Files\cartridges</Filter>
+    </ClCompile>
+    <ClCompile Include="src\cartridges\rom_cartridge.cpp">
+      <Filter>Source Files\cartridges</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\configuration_serializer.cpp">
+      <Filter>Source Files\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\filesystem.cpp">
+      <Filter>Source Files\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\winapi.cpp">
+      <Filter>Source Files\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\devices\rom\rom_image.cpp">
+      <Filter>Source Files\devices\rom</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\cartridge_loader.cpp">
+      <Filter>Source Files\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\devices\rom\banked_rom_image.cpp">
+      <Filter>Source Files\devices\rom</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -116,18 +119,6 @@
     <ClInclude Include="include\vcc\core\cartridge.h">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="include\vcc\core\cartridges\legacy_cartridge.h">
-      <Filter>Header Files\core\cartridges</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\cartridges\null_cartridge.h">
-      <Filter>Header Files\core\cartridges</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\cartridges\rom_cartridge.h">
-      <Filter>Header Files\core\cartridges</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\utils\dll_deleter.h">
-      <Filter>Header Files\core\utils</Filter>
-    </ClInclude>
     <ClInclude Include="include\vcc\core\detail\exports.h">
       <Filter>Header Files\core\detail</Filter>
     </ClInclude>
@@ -140,31 +131,10 @@
     <ClInclude Include="include\vcc\core\interrupts.h">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="include\vcc\core\cartridge_loader.h">
-      <Filter>Header Files\core</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\utils\filesystem.h">
-      <Filter>Header Files\core\utils</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\utils\configuration_serializer.h">
-      <Filter>Header Files\core\utils</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\utils\winapi.h">
-      <Filter>Header Files\core\utils</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\utils\critical_section.h">
-      <Filter>Header Files\core\utils</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\cartridges\basic_cartridge.h">
-      <Filter>Header Files\core\cartridges</Filter>
-    </ClInclude>
     <ClInclude Include="include\vcc\core\cartridge_context.h">
       <Filter>Header Files\core</Filter>
     </ClInclude>
     <ClInclude Include="include\vcc\core\cartridge_factory.h">
-      <Filter>Header Files\core</Filter>
-    </ClInclude>
-    <ClInclude Include="include\vcc\core\rom_image.h">
       <Filter>Header Files\core</Filter>
     </ClInclude>
     <ClInclude Include="include\vcc\devices\rtc\cloud9.h">
@@ -175,6 +145,42 @@
     </ClInclude>
     <ClInclude Include="include\vcc\devices\rtc\oki_m6242b.h">
       <Filter>Header Files\devices\rtc</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\cartridges\basic_cartridge.h">
+      <Filter>Header Files\cartridges</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\cartridges\legacy_cartridge.h">
+      <Filter>Header Files\cartridges</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\cartridges\null_cartridge.h">
+      <Filter>Header Files\cartridges</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\cartridges\rom_cartridge.h">
+      <Filter>Header Files\cartridges</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\configuration_serializer.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\critical_section.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\dll_deleter.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\filesystem.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\winapi.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\devices\rom\rom_image.h">
+      <Filter>Header Files\devices\rom</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\cartridge_loader.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\devices\rom\banked_rom_image.h">
+      <Filter>Header Files\devices\rom</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -140,9 +140,6 @@
     <ClInclude Include="include\vcc\devices\rtc\cloud9.h">
       <Filter>Header Files\devices\rtc</Filter>
     </ClInclude>
-    <ClInclude Include="include\vcc\core\banked_rom_image.h">
-      <Filter>Header Files\core</Filter>
-    </ClInclude>
     <ClInclude Include="include\vcc\devices\rtc\oki_m6242b.h">
       <Filter>Header Files\devices\rtc</Filter>
     </ClInclude>

--- a/libcommon/src/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/cartridges/basic_cartridge.cpp
@@ -15,10 +15,10 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/cartridges/basic_cartridge.h>
+#include <vcc/cartridges/basic_cartridge.h>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::cartridges
 {
 
 	basic_cartridge::name_type basic_cartridge::name() const
@@ -84,4 +84,4 @@ namespace vcc { namespace core { namespace cartridges
 	void basic_cartridge::initialize_bus()
 	{}
 
-} } }
+}

--- a/libcommon/src/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/cartridges/legacy_cartridge.cpp
@@ -15,10 +15,10 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/cartridges/legacy_cartridge.h>
+#include <vcc/cartridges/legacy_cartridge.h>
 #include <stdexcept>
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::cartridges
 {
 
 	namespace
@@ -171,4 +171,4 @@ namespace vcc { namespace core { namespace cartridges
 		menu_item_clicked_(menu_item_id);
 	}
 
-} } }
+}

--- a/libcommon/src/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/cartridges/rom_cartridge.cpp
@@ -15,10 +15,10 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/cartridges/rom_cartridge.h>
+#include <vcc/cartridges/rom_cartridge.h>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::cartridges
 {
 
 	rom_cartridge::rom_cartridge(
@@ -76,4 +76,4 @@ namespace vcc { namespace core { namespace cartridges
 		context_->assert_cartridge_line(true);
 	}
 
-} } }
+}

--- a/libcommon/src/devices/rom/banked_rom_image.cpp
+++ b/libcommon/src/devices/rom/banked_rom_image.cpp
@@ -1,7 +1,7 @@
-#include <vcc/core/banked_rom_image.h>
+#include <vcc/devices/rom/banked_rom_image.h>
 
 
-namespace vcc::core
+namespace vcc::devices::rom
 {
 
 	bool banked_rom_image::load(std::string filename)

--- a/libcommon/src/main.cpp
+++ b/libcommon/src/main.cpp
@@ -3,8 +3,8 @@
 #include <vcc/core/detail/exports.h>
 // NOTE: The following includes are here to force exporting implicit
 // definitions.
-#include <vcc/core/cartridges/null_cartridge.h>
-#include <vcc/core/utils/dll_deleter.h>
+#include <vcc/cartridges/null_cartridge.h>
+#include <vcc/utils/dll_deleter.h>
 
 
 BOOL APIENTRY DllMain( HMODULE hModule,

--- a/libcommon/src/utils/cartridge_loader.cpp
+++ b/libcommon/src/utils/cartridge_loader.cpp
@@ -15,16 +15,16 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/cartridge_loader.h>
-#include <vcc/core/cartridges/rom_cartridge.h>
-#include <vcc/core/cartridges/legacy_cartridge.h>
+#include <vcc/utils/cartridge_loader.h>
+#include <vcc/cartridges/rom_cartridge.h>
+#include <vcc/cartridges/legacy_cartridge.h>
 #include <vector>
 #include <fstream>
 #include <iterator>
 #include <vcc/core/cartridge_factory.h>
 
 
-namespace vcc { namespace core
+namespace vcc::utils
 {
 
 	namespace
@@ -62,7 +62,7 @@ namespace vcc { namespace core
 	}
 
 	cartridge_loader_result load_rom_cartridge(
-		std::unique_ptr<cartridge_context> context,
+		std::unique_ptr<::vcc::core::cartridge_context> context,
 		const std::string& filename)
 	{
 		constexpr size_t PAK_MAX_MEM = 0x40000;
@@ -96,7 +96,7 @@ namespace vcc { namespace core
 
 		return {
 			nullptr,
-			std::make_unique<vcc::core::cartridges::rom_cartridge>(
+			std::make_unique<vcc::cartridges::rom_cartridge>(
 				move(context),
 				extract_filename(filename),
 				"",
@@ -108,7 +108,7 @@ namespace vcc { namespace core
 
 	cartridge_loader_result load_legacy_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<::vcc::core::cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
 		const cpak_cartridge_context& cpak_context)
@@ -139,7 +139,7 @@ namespace vcc { namespace core
 
 		if (GetProcAddress(details.handle.get(), "PakInitialize") != nullptr)
 		{
-			details.cartridge = std::make_unique<vcc::core::cartridges::legacy_cartridge>(
+			details.cartridge = std::make_unique<vcc::cartridges::legacy_cartridge>(
 				details.handle.get(),
 				host_context,
 				iniPath,
@@ -154,22 +154,22 @@ namespace vcc { namespace core
 
 	cartridge_loader_result load_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<::vcc::core::cartridge_context> cartridge_context,
 		const cpak_cartridge_context& cpak_context,
 		void* const host_context,
 		const std::string& iniPath)
 	{
-		switch (vcc::core::determine_cartridge_type(filename))
+		switch (::vcc::utils::determine_cartridge_type(filename))
 		{
 		default:
 		case cartridge_file_type::not_opened:	//	File doesn't exist or can't be opened
 			return { nullptr, nullptr, cartridge_loader_status::cannot_open };
 
 		case cartridge_file_type::rom_image:	//	File is a ROM image
-			return vcc::core::load_rom_cartridge(move(cartridge_context), filename);
+			return load_rom_cartridge(move(cartridge_context), filename);
 
 		case cartridge_file_type::library:		//	File is a DLL
-			return vcc::core::load_legacy_cartridge(
+			return load_legacy_cartridge(
 				filename,
 				move(cartridge_context),
 				host_context,
@@ -178,4 +178,4 @@ namespace vcc { namespace core
 		}
 	}
 
-} }
+}

--- a/libcommon/src/utils/configuration_serializer.cpp
+++ b/libcommon/src/utils/configuration_serializer.cpp
@@ -15,11 +15,11 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/utils/configuration_serializer.h>
+#include <vcc/utils/configuration_serializer.h>
 #include <Windows.h>
 
 
-namespace vcc { namespace core
+namespace vcc::utils
 {
 
 	configuration_serializer::configuration_serializer(path_type path)
@@ -71,4 +71,4 @@ namespace vcc { namespace core
 		return loaded_string;
 	}
 
-} }
+}

--- a/libcommon/src/utils/filesystem.cpp
+++ b/libcommon/src/utils/filesystem.cpp
@@ -15,11 +15,11 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/utils/filesystem.h>
-#include <vcc/core/utils/winapi.h>
+#include <vcc/utils/filesystem.h>
+#include <vcc/utils/winapi.h>
 
 
-namespace vcc { namespace core { namespace utils
+namespace vcc::utils
 {
 
 
@@ -58,7 +58,7 @@ namespace vcc { namespace core { namespace utils
 		auto file_handle(CreateFile(path.c_str(), 0, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
 		if (file_handle == INVALID_HANDLE_VALUE)
 		{
-			const auto application_path = get_directory_from_path(::vcc::core::utils::get_module_path());
+			const auto application_path = get_directory_from_path(::vcc::utils::get_module_path());
 			const auto alternate_path = application_path + path;
 			file_handle = CreateFile(alternate_path.c_str(), 0, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
 			if (file_handle == INVALID_HANDLE_VALUE)
@@ -85,7 +85,7 @@ namespace vcc { namespace core { namespace utils
 
 	LIBCOMMON_EXPORT std::string strip_application_path(std::string path)
 	{
-		const auto module_path = get_directory_from_path(vcc::core::utils::get_module_path(nullptr));
+		const auto module_path = get_directory_from_path(vcc::utils::get_module_path(nullptr));
 		auto temp_path(get_directory_from_path(path));
 		if (module_path == temp_path)	// If they match remove the Path
 		{
@@ -108,4 +108,4 @@ namespace vcc { namespace core { namespace utils
 		return path;
 	}
 
-} } }
+}

--- a/libcommon/src/utils/winapi.cpp
+++ b/libcommon/src/utils/winapi.cpp
@@ -15,15 +15,37 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#pragma once
-#include <vcc/core/detail/exports.h>
-#include <Windows.h>
+
+#include <vcc/utils/winapi.h>
 #include <string>
+#include <windows.h>
 
-
-namespace vcc { namespace core { namespace utils
+namespace vcc::utils
 {
 
-	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id);
+	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id)
+	{
+		const wchar_t* buffer_ptr;
+		// Get len of string to load
+		const int length = LoadStringW(instance, id, reinterpret_cast<LPWSTR>(&buffer_ptr), 0);
+		if (length == 0)
+			return {};
 
-} } }
+		// Copy load string to wide_str
+		const std::wstring wide_str(buffer_ptr, length);
+
+		// Get len of string when converted
+		const int utf8_len = WideCharToMultiByte(CP_UTF8, 0, wide_str.data(), wide_str.size(), nullptr, 0, nullptr, nullptr);
+		if (utf8_len == 0)
+		{
+			return {};
+		}
+
+		// Convert string from wide_str to utf8_str
+		std::string utf8_str(utf8_len, '\0');
+		WideCharToMultiByte(CP_UTF8, 0, wide_str.data(), wide_str.size(), utf8_str.data(), utf8_len, nullptr, nullptr);
+
+		return utf8_str;
+	}
+}
+

--- a/mpi/cartridge_slot.cpp
+++ b/mpi/cartridge_slot.cpp
@@ -16,14 +16,14 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #include "cartridge_slot.h"
-#include <vcc/core/cartridges/null_cartridge.h>
+#include <vcc/cartridges/null_cartridge.h>
 
 
 namespace vcc { namespace modules { namespace mpi
 {
 
 	cartridge_slot::cartridge_slot()
-		: cartridge_(std::make_unique<::vcc::core::cartridges::null_cartridge>())
+		: cartridge_(std::make_unique<::vcc::cartridges::null_cartridge>())
 	{}
 
 	cartridge_slot::cartridge_slot(path_type path, handle_type handle, cartridge_ptr_type cartridge)

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -16,8 +16,8 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+#include <vcc/utils/cartridge_loader.h>
 #include <vcc/core/cartridge.h>
-#include <vcc/core/cartridge_loader.h>
 #include <vcc/core/cartridge_context.h>
 #include "../CartridgeMenu.h"
 
@@ -37,7 +37,7 @@ namespace vcc { namespace modules { namespace mpi
 		using description_type = cartridge_type::description_type;
 		using path_type = ::std::string;
 		using label_type = ::std::string;
-		using handle_type = ::vcc::core::cartridge_loader_result::handle_type;
+		using handle_type = ::vcc::utils::cartridge_loader_result::handle_type;
 		using menu_item_type = CartMenuItem;
 		using menu_item_collection_type = std::vector<menu_item_type>;
 

--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -18,15 +18,15 @@
 #include "configuration_dialog.h"
 #include "resource.h"
 #include <vcc/common/DialogOps.h>
-#include <vcc/core/utils/critical_section.h>
-#include <vcc/core/utils/filesystem.h>
+#include <vcc/utils/critical_section.h>
+#include <vcc/utils/filesystem.h>
 #include <array>
 
 
 namespace
 {
 
-	using cartridge_loader_status = vcc::core::cartridge_loader_status;
+	using cartridge_loader_status = vcc::utils::cartridge_loader_status;
 
 	struct cartridge_ui_element_identifiers
 	{
@@ -94,7 +94,7 @@ void configuration_dialog::select_new_cartridge(slot_id_type slot)
 		if (mpi_.mount_cartridge(slot, dlg.path()) == cartridge_loader_status::success)
 		{
 			configuration_.slot_cartridge_path(slot, dlg.path());
-			configuration_.last_accessed_module_path(::vcc::core::utils::get_directory_from_path(dlg.path()));
+			configuration_.last_accessed_module_path(::vcc::utils::get_directory_from_path(dlg.path()));
 		}
 
 		mpi_.build_menu();

--- a/mpi/configuration_dialog.h
+++ b/mpi/configuration_dialog.h
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include "multipak_configuration.h"
-#include <vcc/core/cartridge_loader.h>
+#include <vcc/utils/cartridge_loader.h>
 #include <Windows.h>
 
 
@@ -26,7 +26,7 @@ class multipak_controller
 public:
 
 	using context_type = ::vcc::core::cartridge_context;
-	using mount_status_type = ::vcc::core::cartridge_loader_status;
+	using mount_status_type = ::vcc::utils::cartridge_loader_status;
 	using slot_id_type = ::multipak_configuration::slot_id_type;
 	using path_type = ::multipak_configuration::path_type;
 	using label_type = ::std::string;

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -18,8 +18,8 @@
 #include "multipak_cartridge.h"
 #include "multipak_cartridge_context.h"
 #include "resource.h"
-#include <vcc/core/utils/winapi.h>
-#include <vcc/core/utils/filesystem.h>
+#include <vcc/utils/winapi.h>
+#include <vcc/utils/filesystem.h>
 
 
 namespace
@@ -81,17 +81,17 @@ multipak_cartridge::multipak_cartridge(
 
 multipak_cartridge::name_type multipak_cartridge::name() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_MODULE_NAME);
+	return ::vcc::utils::load_string(module_instance_, IDS_MODULE_NAME);
 }
 
 multipak_cartridge::catalog_id_type multipak_cartridge::catalog_id() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_CATNUMBER);
+	return ::vcc::utils::load_string(module_instance_, IDS_CATNUMBER);
 }
 
 multipak_cartridge::description_type multipak_cartridge:: description() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_CATNUMBER);
+	return ::vcc::utils::load_string(module_instance_, IDS_CATNUMBER);
 }
 
 
@@ -105,7 +105,7 @@ void multipak_cartridge::start()
 	// Mount them
 	for (auto slot(0u); slot < slots_.size(); slot++)
 	{
-		const auto path(vcc::core::utils::find_pak_module_path(configuration_.slot_cartridge_path(slot)));
+		const auto path(vcc::utils::find_pak_module_path(configuration_.slot_cartridge_path(slot)));
 		if (!path.empty())
 		{
 			mount_cartridge(slot, path);
@@ -129,7 +129,7 @@ void multipak_cartridge::stop()
 
 void multipak_cartridge::reset()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	cached_cts_slot_ = switch_slot_;
 	cached_scs_slot_ = switch_slot_;
@@ -143,7 +143,7 @@ void multipak_cartridge::reset()
 
 void multipak_cartridge::process_horizontal_sync()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	for(const auto& cartridge_slot : slots_)
 	{
@@ -153,7 +153,7 @@ void multipak_cartridge::process_horizontal_sync()
 
 void multipak_cartridge::write_port(unsigned char port_id, unsigned char value)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	if (port_id == slot_select_port_id)
 	{
@@ -181,7 +181,7 @@ void multipak_cartridge::write_port(unsigned char port_id, unsigned char value)
 
 unsigned char multipak_cartridge::read_port(unsigned char port_id)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	if (port_id == slot_select_port_id)	// Self
 	{
@@ -213,14 +213,14 @@ unsigned char multipak_cartridge::read_port(unsigned char port_id)
 
 unsigned char multipak_cartridge::read_memory_byte(unsigned short memory_address)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	return slots_[cached_cts_slot_].read_memory_byte(memory_address);
 }
 
 void multipak_cartridge::status(char* text_buffer, size_t buffer_size)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	char TempStatus[64] = "";
 
@@ -239,7 +239,7 @@ void multipak_cartridge::status(char* text_buffer, size_t buffer_size)
 
 unsigned short multipak_cartridge::sample_audio()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	unsigned short sample = 0;
 	for (const auto& cartridge_slot : slots_)
@@ -258,7 +258,7 @@ void multipak_cartridge::menu_item_clicked(unsigned char menu_item_id)
 		return;
 	}
 
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	//Configs for loaded carts
 	if (menu_item_id >= 20 && menu_item_id <= 40)
@@ -285,28 +285,28 @@ void multipak_cartridge::menu_item_clicked(unsigned char menu_item_id)
 
 multipak_cartridge::label_type multipak_cartridge::slot_label(slot_id_type slot) const
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	return slots_[slot].label();
 }
 
 multipak_cartridge::description_type multipak_cartridge::slot_description(slot_id_type slot) const
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	return slots_[slot].description();
 }
 
 bool multipak_cartridge::empty(slot_id_type slot) const
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	return slots_[slot].empty();
 }
 
 void multipak_cartridge::eject_cartridge(slot_id_type slot)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	slots_[slot].stop();
 
@@ -317,7 +317,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 	slot_id_type slot,
 	const path_type& filename)
 {
-	auto loadedCartridge(vcc::core::load_cartridge(
+	auto loadedCartridge(vcc::utils::load_cartridge(
 		filename,
 		std::make_unique<multipak_cartridge_context>(slot, *context_, *this),
 		cpak_contexts_[slot],
@@ -331,7 +331,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 	// FIXME-CHET: We should probably call eject(slot) here in order to ensure that the
 	// cartridge is shut down correctly.
 
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	slots_[slot] = {
 		filename,
@@ -347,7 +347,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 
 void multipak_cartridge::switch_to_slot(slot_id_type slot)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	switch_slot_ = slot;
 	cached_scs_slot_ = slot;
@@ -372,7 +372,7 @@ void multipak_cartridge::append_menu_item(slot_id_type slot, menu_item_type item
 	switch (item.menu_id) {
 	case MID_BEGIN:
 	{
-		vcc::core::utils::section_locker lock(mutex_);
+		vcc::utils::section_locker lock(mutex_);
 
 		slots_[slot].reset_menu();
 	}
@@ -389,7 +389,7 @@ void multipak_cartridge::append_menu_item(slot_id_type slot, menu_item_type item
 			item.menu_id += (slot + 1) * 20;
 		}
 		{
-			vcc::core::utils::section_locker lock(mutex_);
+			vcc::utils::section_locker lock(mutex_);
 
 			slots_[slot].append_menu_item(item);
 		}
@@ -400,7 +400,7 @@ void multipak_cartridge::append_menu_item(slot_id_type slot, menu_item_type item
 // This gets called any time a cartridge menu is changed. It draws the entire menu.
 void multipak_cartridge::build_menu()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	// Init the menu, establish MPI config control, build slot menus, then draw it.
 	context_->add_menu_item("", MID_BEGIN, MIT_Head);
@@ -416,7 +416,7 @@ void multipak_cartridge::build_menu()
 
 void multipak_cartridge::assert_cartridge_line(slot_id_type slot, bool line_state)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	vcc::utils::section_locker lock(mutex_);
 
 	slots_[slot].line_state(line_state);
 	if (selected_scs_slot() == slot)

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -19,8 +19,8 @@
 #include "cartridge_slot.h"
 #include "configuration_dialog.h"
 #include "multipak_configuration.h"
-#include <vcc/core/cartridges/basic_cartridge.h>
-#include <vcc/core/utils/critical_section.h>
+#include <vcc/cartridges/basic_cartridge.h>
+#include <vcc/utils/critical_section.h>
 #include "../CartridgeMenu.h"
 #include <array>
 
@@ -33,7 +33,7 @@ class multipak_cartridge
 public:
 
 	using context_type = ::vcc::core::cartridge_context;
-	using mount_status_type = ::vcc::core::cartridge_loader_status;
+	using mount_status_type = ::vcc::utils::cartridge_loader_status;
 	using slot_id_type = ::std::size_t;
 	using path_type = ::std::string;
 	using label_type = ::std::string;
@@ -121,7 +121,7 @@ private:
 	static const size_t default_switch_slot_value = 0x03;
 	static const size_t default_slot_register_value = 0xff;
 
-	vcc::core::utils::critical_section mutex_;
+	vcc::utils::critical_section mutex_;
 	const HINSTANCE module_instance_;
 	multipak_configuration& configuration_;
 	std::shared_ptr<context_type> context_;

--- a/mpi/multipak_configuration.cpp
+++ b/mpi/multipak_configuration.cpp
@@ -1,8 +1,8 @@
 #include "multipak_configuration.h"
-#include <vcc/core/utils/configuration_serializer.h>
+#include <vcc/utils/configuration_serializer.h>
 
 
-using serializer = ::vcc::core::configuration_serializer;
+using serializer = ::vcc::utils::configuration_serializer;
 
 
 multipak_configuration::multipak_configuration(string_type section)

--- a/orch90/main.cpp
+++ b/orch90/main.cpp
@@ -20,12 +20,12 @@
 #include <stdio.h>
 #include "resource.h" 
 #include <vcc/common/FileOps.h>
+#include <vcc/utils/winapi.h>
+#include <vcc/utils/filesystem.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
+#include <vcc/core/cartridge_factory.h>
 #include <vcc/core/limits.h>
 #include <memory>
-#include <vcc/core/utils/winapi.h>
-#include <vcc/core/utils/filesystem.h>
-#include <vcc/core/cartridge_factory.h>
 
 
 static HINSTANCE gModuleInstance=nullptr;

--- a/orch90/orchestra90cc_cartridge.cpp
+++ b/orch90/orchestra90cc_cartridge.cpp
@@ -18,8 +18,8 @@
 #include "orchestra90cc_cartridge.h"
 #include "resource.h"
 #include <vcc/common/FileOps.h>
-#include <vcc/core/utils/winapi.h>
-#include <vcc/core/utils/filesystem.h>
+#include <vcc/utils/winapi.h>
+#include <vcc/utils/filesystem.h>
 #include <Windows.h>
 
 
@@ -64,18 +64,18 @@ orchestra90cc_cartridge::orchestra90cc_cartridge(
 
 orchestra90cc_cartridge::name_type orchestra90cc_cartridge::name() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_MODULE_NAME);
+	return ::vcc::utils::load_string(module_instance_, IDS_MODULE_NAME);
 }
 
 orchestra90cc_cartridge::catalog_id_type orchestra90cc_cartridge::catalog_id() const
 {
-	return ::vcc::core::utils::load_string(module_instance_, IDS_CATNUMBER);
+	return ::vcc::utils::load_string(module_instance_, IDS_CATNUMBER);
 }
 
 void orchestra90cc_cartridge::reset()
 {
-	using ::vcc::core::utils::get_module_path;
-	using ::vcc::core::utils::get_directory_from_path;
+	using ::vcc::utils::get_module_path;
+	using ::vcc::utils::get_directory_from_path;
 
 	if (LoadExtRom(get_directory_from_path(get_module_path(module_instance_)) + "ORCH90.ROM"))
 	{

--- a/orch90/orchestra90cc_cartridge.h
+++ b/orch90/orchestra90cc_cartridge.h
@@ -16,13 +16,13 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridges/basic_cartridge.h>
+#include <vcc/cartridges/basic_cartridge.h>
 #include <vcc/core/cartridge_context.h>
 #include <memory>
 #include <Windows.h>
 
 
-class orchestra90cc_cartridge : public ::vcc::core::cartridges::basic_cartridge
+class orchestra90cc_cartridge : public ::vcc::cartridges::basic_cartridge
 {
 public:
 	

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -17,14 +17,14 @@ This file is part of VCC (Virtual Color Computer).
 */
 
 #pragma once
-#include <vcc/core/cartridge_loader.h>
+#include <vcc/utils/cartridge_loader.h>
 
 void PakTimer();
 unsigned char PakReadPort (unsigned char);
 void PakWritePort(unsigned char,unsigned char);
 unsigned char PackMem8Read (unsigned short);
 void GetModuleStatus( SystemState *);
-vcc::core::cartridge_loader_status PakLoadCartridge(const char* filename);
+vcc::utils::cartridge_loader_status PakLoadCartridge(const char* filename);
 void PakLoadCartridgeUI();
 unsigned short PackAudioSample();
 void ResetBus();


### PR DESCRIPTION
This reorganizes the libcommon directory structure. It makes no changes to code logic.

- move vcc/core/utils to vcc/utils
- move vcc/core/cartridges to vcc/cartridges
- move cartridge_loader from core to utils
- move rom_image from core to vcc/devices/rom
- move banked_rom_image from mpi pak to vcc/devices/rom
