### PR TITLE
reduce usage of MAX_LOAD_STRING

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -18,19 +18,18 @@
 #pragma warning( disable : 4800 ) // For legacy builds
 
 //#define USE_LOGGING
-#include <Windows.h>
-#include <stdio.h>
-#include <iostream>
 #include "resource.h"
 #include "wd1793.h"
 #include "fd502.h"
 #include "../CartridgeMenu.h"
-#include <vcc/devices/rtc/oki_m6242b.h>
 #include <vcc/devices/becker/beckerport.h>
 #include <vcc/common/FileOps.h>
 #include <vcc/common/DialogOps.h>
 #include <vcc/common/logger.h>
+#include <vcc/utils/winapi.h>
+#include <vcc/devices/rtc/oki_m6242b.h>
 #include <vcc/core/limits.h>
+#include <Windows.h>
 
 constexpr auto EXTROMSIZE = 16384u;
 
@@ -96,29 +95,23 @@ extern "C"
 
 	__declspec(dllexport) const char* PakGetName()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto name(::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME));
 
-		LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return name.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetCatalogId()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto catalog_id(::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER));
 
-		LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return catalog_id.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetDescription()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto description(::vcc::utils::load_string(gModuleInstance, IDS_DESCRIPTION));
 
-		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return description.c_str();
 	}
 
 	__declspec(dllexport) void PakInitialize(

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -18,6 +18,8 @@ This file is part of VCC (Virtual Color Computer).
     along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "defines.h"
+#include <Windows.h>
+
 unsigned char disk_io_read(unsigned char port);
 void disk_io_write(unsigned char data,unsigned char port);	
 int mount_disk_image(const char *,unsigned char );

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -41,6 +41,7 @@ static char NewVHDfile[MAX_PATH];
 static char IniFile[MAX_PATH]  { 0 };
 static char HardDiskPath[MAX_PATH];
 static ::vcc::devices::rtc::cloud9 cloud9_rtc;
+static const char* const gConfigurationSection = "Hard Drive";
 
 static void* gHostKey = nullptr;
 static PakReadMemoryByteHostCallback MemRead8 = nullptr;
@@ -304,43 +305,39 @@ void LoadHardDisk(int drive)
 // Get configuration items from ini file
 void LoadConfig()
 {
-    char ModName[MAX_LOADSTRING]="";
     HANDLE hr;
 
     GetPrivateProfileString("DefaultPaths", "HardDiskPath", "",
                              HardDiskPath, MAX_PATH, IniFile);
 
-    // Determine module name for config lookups
-    LoadString(gModuleInstance,IDS_MODULE_NAME, ModName, MAX_LOADSTRING);
-
     // Verify HD0 image file exists and mount it.
-    GetPrivateProfileString(ModName,"VHDImage" ,"",VHDfile0,MAX_PATH,IniFile);
+    GetPrivateProfileString(gConfigurationSection,"VHDImage" ,"",VHDfile0,MAX_PATH,IniFile);
     CheckPath(VHDfile0);
     hr = CreateFile (VHDfile0,0,FILE_SHARE_READ,nullptr,
                      OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
     if (hr==INVALID_HANDLE_VALUE) {
         strcpy(VHDfile0,"");
-        WritePrivateProfileString(ModName,"VHDImage","",IniFile);
+        WritePrivateProfileString(gConfigurationSection,"VHDImage","",IniFile);
     } else {
         CloseHandle(hr);
         MountHD(VHDfile0,0);
     }
 
     // Verify HD1 image file exists and mount it.
-    GetPrivateProfileString(ModName,"VHDImage1","",VHDfile1,MAX_PATH,IniFile);
+    GetPrivateProfileString(gConfigurationSection,"VHDImage1","",VHDfile1,MAX_PATH,IniFile);
     CheckPath(VHDfile1);
     hr = CreateFile (VHDfile1,0,FILE_SHARE_READ,nullptr,
                      OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
     if (hr==INVALID_HANDLE_VALUE) {
         strcpy(VHDfile1,"");
-        WritePrivateProfileString(ModName,"VHDImage1","",IniFile);
+        WritePrivateProfileString(gConfigurationSection,"VHDImage1","",IniFile);
     } else {
         CloseHandle(hr);
         MountHD(VHDfile1,1);
     }
 
-	ClockEnabled = GetPrivateProfileInt(ModName, "ClkEnable", 1, IniFile) != 0;
-	ClockReadOnly = GetPrivateProfileInt(ModName, "ClkRdOnly", 1, IniFile) != 0;
+	ClockEnabled = GetPrivateProfileInt(gConfigurationSection, "ClkEnable", 1, IniFile) != 0;
+	ClockReadOnly = GetPrivateProfileInt(gConfigurationSection, "ClkRdOnly", 1, IniFile) != 0;
 
     // Create config menu
 	BuildCartridgeMenu();
@@ -350,19 +347,16 @@ void LoadConfig()
 // Save config saves the hard disk path and vhd file names
 void SaveConfig()
 {
-    char ModName[MAX_LOADSTRING]="";
-    LoadString(gModuleInstance,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
-
     ValidatePath(VHDfile0);
     ValidatePath(VHDfile1);
     if (strcmp(HardDiskPath, "") != 0) {
         WritePrivateProfileString
             ("DefaultPaths", "HardDiskPath", HardDiskPath, IniFile);
     }
-    WritePrivateProfileString(ModName,"VHDImage",VHDfile0 ,IniFile);
-    WritePrivateProfileString(ModName,"VHDImage1",VHDfile1 ,IniFile);
-	WritePrivateProfileInt(ModName, "ClkEnable", ClockEnabled, IniFile);
-	WritePrivateProfileInt(ModName, "ClkRdOnly", ClockReadOnly, IniFile);
+    WritePrivateProfileString(gConfigurationSection,"VHDImage",VHDfile0 ,IniFile);
+    WritePrivateProfileString(gConfigurationSection,"VHDImage1",VHDfile1 ,IniFile);
+	WritePrivateProfileInt(gConfigurationSection, "ClkEnable", ClockEnabled, IniFile);
+	WritePrivateProfileInt(gConfigurationSection, "ClkRdOnly", ClockReadOnly, IniFile);
     return;
 }
 

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -27,6 +27,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <vcc/common/FileOps.h>
 #include <vcc/common/DialogOps.h>
 #include "../CartridgeMenu.h"
+#include <vcc/utils/winapi.h>
 #include <vcc/core/interrupts.h>
 #include <vcc/core/cartridge_capi.h>
 #include <vcc/core/limits.h>
@@ -90,29 +91,23 @@ extern "C"
 
 	__declspec(dllexport) const char* PakGetName()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto name(::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME));
 
-		LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return name.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetCatalogId()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto catalog_id(::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER));
 
-		LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return catalog_id.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetDescription()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto description(::vcc::utils::load_string(gModuleInstance, IDS_DESCRIPTION));
 
-		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return description.c_str();
 	}
 
 	__declspec(dllexport) void PakInitialize(

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -27,6 +27,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "../CartridgeMenu.h"
 #include <vcc/common/DialogOps.h>
 #include <vcc/core/cartridge_capi.h>
+#include <vcc/utils/winapi.h>
 #include <vcc/core/limits.h>
 
 static char FileName[MAX_PATH] { 0 };
@@ -72,29 +73,23 @@ extern "C"
 
 	__declspec(dllexport) const char* PakGetName()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto name(::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME));
 
-		LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return name.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetCatalogId()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto catalog_id(::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER));
 
-		LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return catalog_id.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetDescription()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto description(::vcc::utils::load_string(gModuleInstance, IDS_DESCRIPTION));
 
-		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return description.c_str();
 	}
 
 	__declspec(dllexport) void PakInitialize(

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -51,6 +51,7 @@ static HINSTANCE gModuleInstance;
 static HWND hConfDlg = nullptr;
 static void* gHostKeyPtr = nullptr;
 static void* const& gHostKey(gHostKeyPtr);
+static const char* const gConfigurationSection = "Glenside-IDE /w Clock";
 
 using namespace std;
 
@@ -327,15 +328,13 @@ void Select_Disk(unsigned char Disk)
 
 void SaveConfig()
 {
-	char ModName[MAX_LOADSTRING]="";
-	LoadString(gModuleInstance,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 	QueryDisk(MASTER,FileName);
-	WritePrivateProfileString(ModName,"Master",FileName,IniFile);
+	WritePrivateProfileString(gConfigurationSection,"Master",FileName,IniFile);
 	QueryDisk(SLAVE,FileName);
-	WritePrivateProfileString(ModName,"Slave",FileName,IniFile);
-	WritePrivateProfileInt(ModName,"BaseAddr",BaseAddr ,IniFile);
-	WritePrivateProfileInt(ModName,"ClkEnable",ClockEnabled ,IniFile);
-	WritePrivateProfileInt(ModName, "ClkRdOnly", ClockReadOnly, IniFile);
+	WritePrivateProfileString(gConfigurationSection,"Slave",FileName,IniFile);
+	WritePrivateProfileInt(gConfigurationSection,"BaseAddr",BaseAddr ,IniFile);
+	WritePrivateProfileInt(gConfigurationSection,"ClkEnable",ClockEnabled ,IniFile);
+	WritePrivateProfileInt(gConfigurationSection, "ClkRdOnly", ClockReadOnly, IniFile);
 	if (strcmp(SuperIDEPath, "") != 0) { 
 		WritePrivateProfileString("DefaultPaths", "SuperIDEPath", SuperIDEPath, IniFile); 
 	}
@@ -345,16 +344,13 @@ void SaveConfig()
 
 void LoadConfig()
 {
-	char ModName[MAX_LOADSTRING]="";
-
-	LoadString(gModuleInstance,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
 	GetPrivateProfileString("DefaultPaths", "SuperIDEPath", "", SuperIDEPath, MAX_PATH, IniFile);
-	GetPrivateProfileString(ModName,"Master","",FileName,MAX_PATH,IniFile);
+	GetPrivateProfileString(gConfigurationSection,"Master","",FileName,MAX_PATH,IniFile);
 	MountDisk(FileName ,MASTER);
-	GetPrivateProfileString(ModName,"Slave","",FileName,MAX_PATH,IniFile);
-	BaseAddr=GetPrivateProfileInt(ModName,"BaseAddr",1,IniFile); 
-	ClockEnabled = GetPrivateProfileInt(ModName, "ClkEnable", true, IniFile) != 0;
-	ClockReadOnly = GetPrivateProfileInt(ModName, "ClkRdOnly", true, IniFile) != 0;
+	GetPrivateProfileString(gConfigurationSection,"Slave","",FileName,MAX_PATH,IniFile);
+	BaseAddr=GetPrivateProfileInt(gConfigurationSection,"BaseAddr",1,IniFile); 
+	ClockEnabled = GetPrivateProfileInt(gConfigurationSection, "ClkEnable", true, IniFile) != 0;
+	ClockReadOnly = GetPrivateProfileInt(gConfigurationSection, "ClkRdOnly", true, IniFile) != 0;
 	BaseAddr&=3;
 	if (BaseAddr == 3)
 		ClockEnabled = false;

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -52,7 +52,6 @@ PakAssertInteruptHostCallback AssertInt = nullptr;
 static HINSTANCE gModuleInstance;      // DLL handle
 static HWND g_hDlg = nullptr;           // Config dialog
 static char IniFile[MAX_PATH];       // Ini file name
-static char IniSect[MAX_LOADSTRING]; // Ini file section
 
 // Status for Vcc status line
 char AciaStat[32];

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -22,10 +22,11 @@
 //------------------------------------------------------------------
 
 #include "acia.h"
-#include "../CartridgeMenu.h"
-#include <vcc/core/limits.h>
 #include <vcc/common/DialogOps.h>
+#include "../CartridgeMenu.h"
 #include <vcc/common/logger.h>
+#include <vcc/utils/winapi.h>
+#include <vcc/core/limits.h>
 
 //------------------------------------------------------------------------
 // Local Functions
@@ -91,31 +92,26 @@ DllMain(HINSTANCE hinst, DWORD reason, LPVOID foo)
 
 extern "C"
 {
+
 	__declspec(dllexport) const char* PakGetName()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto name(::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME));
 
-		LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return name.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetCatalogId()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto catalog_id(::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER));
 
-		LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return catalog_id.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetDescription()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto description(::vcc::utils::load_string(gModuleInstance, IDS_DESCRIPTION));
 
-		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return description.c_str();
 	}
 
 	__declspec(dllexport) void PakInitialize(

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -21,7 +21,7 @@
 #include "becker.h"
 #include "resource.h"
 #include "../CartridgeMenu.h"
-
+#include <vcc/utils/winapi.h>
 #include <vcc/core/cartridge_capi.h>
 #include <vcc/devices/becker/beckerport.h>
 #include <vcc/core/limits.h>
@@ -65,25 +65,26 @@ BOOL APIENTRY DllMain( HINSTANCE  hinstDLL,
 
 extern "C"
 {
+
 	__declspec(dllexport) const char* PakGetName()
 	{
-		static char string_buffer[MAX_LOADSTRING];
-		LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
-		return string_buffer;
+		static const auto name(::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME));
+
+		return name.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetCatalogId()
 	{
-		static char string_buffer[MAX_LOADSTRING];
-		LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
-		return string_buffer;
+		static const auto catalog_id(::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER));
+
+		return catalog_id.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetDescription()
 	{
-		static char string_buffer[MAX_LOADSTRING];
-		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
-		return string_buffer;
+		static const auto description(::vcc::utils::load_string(gModuleInstance, IDS_DESCRIPTION));
+
+		return description.c_str();
 	}
 
 	__declspec(dllexport) void PakInitialize(

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -151,6 +151,7 @@
 #include <vcc/common/DialogOps.h>
 #include "../CartridgeMenu.h"
 #include <vcc/core/cartridge_capi.h>
+#include <vcc/utils/winapi.h>
 #include <vcc/core/limits.h>
 #include "sdc.h"
 
@@ -355,31 +356,26 @@ static char MPIPath[MAX_PATH];
 //======================================================================
 extern "C"
 {
+
 	__declspec(dllexport) const char* PakGetName()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto name(::vcc::utils::load_string(gModuleInstance, IDS_MODULE_NAME));
 
-		LoadString(gModuleInstance, IDS_MODULE_NAME, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return name.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetCatalogId()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto catalog_id(::vcc::utils::load_string(gModuleInstance, IDS_CATNUMBER));
 
-		LoadString(gModuleInstance, IDS_CATNUMBER, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return catalog_id.c_str();
 	}
 
 	__declspec(dllexport) const char* PakGetDescription()
 	{
-		static char string_buffer[MAX_LOADSTRING];
+		static const auto description(::vcc::utils::load_string(gModuleInstance, IDS_DESCRIPTION));
 
-		LoadString(gModuleInstance, IDS_DESCRIPTION, string_buffer, MAX_LOADSTRING);
-
-		return string_buffer;
+		return description.c_str();
 	}
 
 	__declspec(dllexport) void PakInitialize(


### PR DESCRIPTION
This reduces the use of fixed sized character strings used to store text loaded from the string table resource and thus reduces the use of `MAX_LOADSTRING`.

- change use of `LoadString` to `::vcc::utils::load_string` when retrieving name, catalog id, and description in cartridges.
- added hard coded configuration section to _harddisk_, _SuperIDE_, and _acia_ cartridges.
- removed loading of configuration section from the cartridge name resource of the string table.
