### PR TITLE
Change MPI config load pak

### DIFF
--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -82,9 +82,9 @@ void configuration_dialog::select_new_cartridge(slot_id_type slot)
 	dlg.setTitle("Load Program Pak");
 	dlg.setInitialDir(configuration_.last_accessed_module_path().c_str());
 	dlg.setFilter(
-		"All Pak Types (*.dll; *.rom; *.ccc; *.pak)\0*.dll;*.ccc;*.rom;*.pak\0"
 		"Hardware Pak (*.dll)\0*.dll\0"
 		"Rom Pak (*.rom; *.ccc; *.pak)\0*.rom;*.ccc;*.pak\0"
+		"All Pak Types (*.dll; *.rom; *.ccc; *.pak)\0*.dll;*.ccc;*.rom;*.pak\0"
 		"\0");
 	dlg.setFlags(OFN_FILEMUSTEXIST);
 	if (dlg.show(0, dialog_handle_))


### PR DESCRIPTION
In most cases hardware paks are loaded from MPI config.

Move "All Files" to the bottom of the file select list when loading a program pak from MPI config. User is first presented with a list of hardware paks (.dlls) in the current load directory. They can select ROM pak (.rom,.ccc,.pak) to filter only rom files.  Lastly they can select all paks to see all of those files.