### PR TITLE
ACIA call BuildCartridgeMenu() on init

### DIFF
--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -122,19 +122,18 @@ extern "C"
 		CartMenuCallback = context->add_menu_item;
 		AssertInt = context->assert_interrupt;
 		strcpy(IniFile, configuration_path);
-
 		LoadConfig();
+		BuildCartridgeMenu();
 		LoadExtRom("RS232.ROM");
 		sc6551_init();
 	}
+
 	__declspec(dllexport) void PakTerminate()
 	{
 		CloseCartDialog(g_hDlg);
 		sc6551_close();
 		AciaStat[0]='\0';
 	}
-	
-
 }
 
 //-----------------------------------------------------------------------


### PR DESCRIPTION
Fixes Acia broken by eda4552 Refactor C API cartridge interface #466