### PR TITLE
Change workflow for Build Logging only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,4 @@ jobs:
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: cmd.exe /c BuildAll.bat
+      run: cmd.exe /c BuildLogging.bat

--- a/BuildLogging.bat
+++ b/BuildLogging.bat
@@ -4,9 +4,6 @@
 set VCC_CONFIG=Release
 if exist "%VSINSTALLDIR%\MSBuild\Current\Bin\MSBuild.exe" (
   msbuild vcc.sln /t:Clean /p:Configuration=%VCC_CONFIG% /p:Platform=x86
-  set _CL_=
-  call Build.bat
-  msbuild vcc.sln /t:Clean /p:Configuration=%VCC_CONFIG% /p:Platform=x86
   set _CL_=/DUSE_LOGGING
   call Build.bat
 ) else (


### PR DESCRIPTION
Buildlogging builds VCC with Logging enabled.  This should be sufficient for workflow testing and saves workflow time.