### PR TITLE
General cleanup of FD502 cartridge configuration

### DIFF
--- a/ExecutionTrace.cpp
+++ b/ExecutionTrace.cpp
@@ -25,6 +25,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <stdexcept>
 #include <Richedit.h>
 #include <sstream>
+#include <cstddef>
 #include <array>
 #include <windowsx.h>
 #include <vcc/common/FileOps.h>
@@ -363,7 +364,7 @@ namespace VCC::Debugger::UI { namespace
 		// Draw our current page of samples
 		SetTextColor(hdc, RGB(0, 0, 0));
 		int y = rect.top + 20;
-		int lines = min((long)currentTrace.size(), tracePage);
+		int lines = ::std::min((long)currentTrace.size(), tracePage);
 		for (int i = 0; i < lines; i++)
 		{
 			std::string s;
@@ -1099,7 +1100,7 @@ namespace VCC::Debugger::UI { namespace
 		EmuState.Debugger.LockTrace();
 		unsigned int offset = start > 1 ? start-1 : 0;
 		auto & _trace = EmuState.Debugger.GetTraceResult();
-		int count = min((unsigned int)_trace.size(), nlines);
+		int count = ::std::min((unsigned int)_trace.size(), nlines);
 		const size_t lineSize = 65536;
 		char *line = new char[lineSize];
 

--- a/FD502/defines.h
+++ b/FD502/defines.h
@@ -1,28 +1,24 @@
-#ifndef __DEFINES_H__
-#define __DEFINES_H__
-/*
-Copyright 2015 by Joseph Forgione
-This file is part of VCC (Virtual Color Computer).
-
-    VCC (Virtual Color Computer) is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    VCC (Virtual Color Computer) is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
-*/
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
 
 // FIXME: These are duplicates from the defines.h file in vcc and should be consolidates.
 constexpr auto TARGETFRAMERATE = 60u;
 constexpr auto LINESPERFIELD = 262u;
 constexpr auto QUERY = 255u;
 constexpr auto INDEXTIME = LINESPERFIELD * TARGETFRAMERATE / 5;
-
-#endif
-

--- a/FD502/defines.h
+++ b/FD502/defines.h
@@ -16,6 +16,7 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+#include <cstddef>
 
 // FIXME: These are duplicates from the defines.h file in vcc and should be consolidates.
 constexpr auto TARGETFRAMERATE = 60u;

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -1,21 +1,20 @@
-//---------------------------------------------------------------------------------
-// Copyright 2015 by Joseph Forgione
-// This file is part of VCC (Virtual Color Computer).
-//
-// VCC (Virtual Color Computer) is free software: you can redistribute it and/or
-// modify it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or any later
-// version.
-//
-// VCC (Virtual Color Computer) is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-// more details.  You should have received a copy of the GNU General Public License
-// along with VCC (Virtual Color Computer).  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-//---------------------------------------------------------------------------------
-#pragma warning( disable : 4800 ) // For legacy builds
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
 
 //#define USE_LOGGING
 #include "resource.h"

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -20,6 +20,7 @@
 #include "resource.h"
 #include "wd1793.h"
 #include "fd502.h"
+#include "utils.h"
 #include "../CartridgeMenu.h"
 #include <vcc/devices/becker/beckerport.h>
 #include <vcc/common/FileOps.h>
@@ -28,52 +29,65 @@
 #include <vcc/utils/winapi.h>
 #include <vcc/devices/rtc/oki_m6242b.h>
 #include <vcc/core/limits.h>
+#include <vcc/devices/rom/rom_image.h>
 #include <Windows.h>
+#include <array>
+#include <vcc/utils/configuration_serializer.h>
+#include <vcc/utils/filesystem.h>
 
-constexpr auto EXTROMSIZE = 16384u;
 
-using namespace std;
-
-extern DiskInfo Drive[5];
-static unsigned char ExternalRom[EXTROMSIZE];
-static unsigned char DiskRom[EXTROMSIZE];
-static unsigned char RGBDiskRom[EXTROMSIZE];
-static char FloppyPath[MAX_PATH];
-static char RomFileName[MAX_PATH]="";
-static char TempRomFileName[MAX_PATH]="";
+static const auto default_selected_rom_index = 1u;
 static void* gHostKeyPtr = nullptr;
 void* const& gHostKey(gHostKeyPtr);
 PakAssertInteruptHostCallback AssertInt = nullptr;
 static PakAppendCartridgeMenuHostCallback CartMenuCallback = nullptr;
-unsigned char PhysicalDriveA=0,PhysicalDriveB=0,OldPhysicalDriveA=0,OldPhysicalDriveB=0;
-static unsigned char *RomPointer[3]={ExternalRom,DiskRom,RGBDiskRom};
-static unsigned char SelectRom=0;
-unsigned char SetChip(unsigned char);
-static unsigned char NewDiskNumber=0,CreateFlag=0;
-static unsigned char PersistDisks=0;
+
+static std::string FloppyPath;
+static size_t SelectRomIndex = default_selected_rom_index;
+static std::string RomFileName;
+static auto PersistDisks = false;
+static auto ClockEnabled = true;
+
+static auto BeckerEnabled = false;
+static std::string BeckerAddr;
+static std::string BeckerPort;
+
+
+static ::vcc::devices::rom::rom_image ExternalRom;
+static ::vcc::devices::rom::rom_image DiskRom;
+static ::vcc::devices::rom::rom_image RGBDiskRom;
+
+unsigned char PhysicalDriveA = 0;
+unsigned char PhysicalDriveB = 0;
+unsigned char OldPhysicalDriveA = 0;
+unsigned char OldPhysicalDriveB = 0;
+static const std::array<::vcc::devices::rom::rom_image*, 3> RomPointer = { &ExternalRom, &DiskRom, &RGBDiskRom };
+static unsigned char NewDiskNumber = 0;
+static unsigned char CreateFlag = 0;
 static char IniFile[MAX_PATH]="";
-static unsigned char TempSelectRom=0;
-static unsigned char ClockEnabled=1;
-LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
-LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
-void LoadConfig();
-void SaveConfig();
-long CreateDiskHeader(const char *,unsigned char,unsigned char,unsigned char);
-void Load_Disk(unsigned char);
+static size_t TempSelectRomIndex = default_selected_rom_index;
 
 static HWND g_hConfDlg = nullptr;
 static HINSTANCE gModuleInstance;
 static unsigned long RealDisks=0;
 long CreateDisk (unsigned char);
 static char TempFileName[MAX_PATH]="";
-unsigned char LoadExtRom( unsigned char, const char *);
+static char TempRomFileName[MAX_PATH]="";
 
-int BeckerEnabled=0;
-char BeckerAddr[MAX_PATH]="";
-char BeckerPort[32]="";
 
 static ::vcc::devices::rtc::oki_m6242b gDistoRtc;
 static ::vcc::devices::beckerport::Becker gBecker;
+
+unsigned char SetChip(unsigned char);
+
+LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
+LRESULT CALLBACK NewDisk(HWND,UINT, WPARAM, LPARAM);
+void LoadConfig();
+void SaveConfig();
+void Load_Disk(unsigned char);
+
+
+
 
 //----------------------------------------------------------------------------
 BOOL WINAPI DllMain(
@@ -240,7 +254,7 @@ extern "C"
 {
 	__declspec(dllexport) unsigned char PakReadMemoryByte(unsigned short Address)
 	{
-		return(RomPointer[SelectRom][Address & (EXTROMSIZE-1)]);
+		return RomPointer[SelectRomIndex]->read_memory_byte(Address);
 	}
 }
 
@@ -277,7 +291,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 
 		case WM_INITDIALOG:
 			CenterDialog(hDlg);
-			TempSelectRom=SelectRom;
+			TempSelectRomIndex = SelectRomIndex;
 			if (!RealDisks)
 			{
 				EnableWindow(GetDlgItem(hDlg, IDC_DISKA), FALSE);
@@ -285,14 +299,16 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 				PhysicalDriveA=0;
 				PhysicalDriveB=0;
 			}
-			SendDlgItemMessage(hDlg,IDC_CLOCK,BM_SETCHECK,ClockEnabled,0);
+			SendDlgItemMessage(hDlg, IDC_CLOCK, BM_SETCHECK, ClockEnabled, false);
 			OldPhysicalDriveA=PhysicalDriveA;
 			OldPhysicalDriveB=PhysicalDriveB;
-			strcpy(TempRomFileName,RomFileName);
+			strcpy(TempRomFileName,RomFileName.c_str());
 			SendDlgItemMessage(hDlg,IDC_TURBO,BM_SETCHECK,SetTurboDisk(QUERY),0);
-			SendDlgItemMessage(hDlg,IDC_PERSIST,BM_SETCHECK,PersistDisks,0);
-			for (temp=0;temp<sizeof(ChipChoice) / sizeof(*ChipChoice);temp++)
-				SendDlgItemMessage(hDlg,ChipChoice[temp],BM_SETCHECK,(temp==TempSelectRom),0);
+			SendDlgItemMessage(hDlg, IDC_PERSIST, BM_SETCHECK, PersistDisks, false);
+			for (temp = 0; temp < RomPointer.size(); temp++)
+			{
+				SendDlgItemMessage(hDlg, ChipChoice[temp], BM_SETCHECK, (temp == TempSelectRomIndex), 0);
+			}
 			for (temp=0;temp<2;temp++)
 				for (temp2=0;temp2<5;temp2++)
 						SendDlgItemMessage (hDlg,VirtualDrive[temp], CB_ADDSTRING, 0, (LPARAM) VirtualNames[temp2]);
@@ -301,9 +317,9 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 			SendDlgItemMessage (hDlg, IDC_DISKB,CB_SETCURSEL,(WPARAM)PhysicalDriveB,(LPARAM)0);
 			SendDlgItemMessage (hDlg,IDC_ROMPATH,WM_SETTEXT,0,(LPARAM)(LPCSTR)TempRomFileName);
 
-			SendDlgItemMessage (hDlg,IDC_BECKER_ENAB,BM_SETCHECK,BeckerEnabled,0);
-			SendDlgItemMessage (hDlg,IDC_BECKER_HOST,WM_SETTEXT,0,(LPARAM)(LPSTR)BeckerAddr);
-			SendDlgItemMessage (hDlg,IDC_BECKER_PORT,WM_SETTEXT,0,(LPARAM)(LPCSTR)BeckerPort);
+			SendDlgItemMessage(hDlg, IDC_BECKER_ENAB, BM_SETCHECK, BeckerEnabled, false);
+			SendDlgItemMessage (hDlg,IDC_BECKER_HOST,WM_SETTEXT,0,reinterpret_cast<const LPARAM>(BeckerAddr.c_str()));
+			SendDlgItemMessage (hDlg,IDC_BECKER_PORT,WM_SETTEXT,0,reinterpret_cast<const LPARAM>(BeckerPort.c_str()));
 
 			return TRUE;
 
@@ -311,9 +327,9 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 			switch (LOWORD(wParam))
 			{
 				case IDOK:
-					ClockEnabled=(unsigned char)SendDlgItemMessage(hDlg,IDC_CLOCK,BM_GETCHECK,0,0);
+					ClockEnabled = SendDlgItemMessage(hDlg, IDC_CLOCK, BM_GETCHECK, 0, 0) != 0;
 					SetTurboDisk((unsigned char)SendDlgItemMessage(hDlg,IDC_TURBO,BM_GETCHECK,0,0));
-					PersistDisks=(unsigned char) SendDlgItemMessage(hDlg,IDC_PERSIST,BM_GETCHECK,0,0);
+					PersistDisks = SendDlgItemMessage(hDlg, IDC_PERSIST, BM_GETCHECK, 0, 0) != 0;
 					PhysicalDriveA=(unsigned char)SendDlgItemMessage(hDlg,IDC_DISKA,CB_GETCURSEL,0,0);
 					PhysicalDriveB=(unsigned char)SendDlgItemMessage(hDlg,IDC_DISKB,CB_GETCURSEL,0,0);
 					if (!RealDisks)
@@ -339,14 +355,13 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 								mount_disk_image("*Floppy B:",PhysicalDriveB-1);
 						}
 					}
-					SelectRom=TempSelectRom;
-					strcpy(RomFileName,TempRomFileName );
-					CheckPath(RomFileName);
-					LoadExtRom(External,RomFileName); //JF
-					GetDlgItemText(hDlg,IDC_BECKER_HOST,BeckerAddr,MAX_PATH);
-					GetDlgItemText(hDlg,IDC_BECKER_PORT,BeckerPort,32);
-					gBecker.sethost(BeckerAddr,BeckerPort);
-					BeckerEnabled = SendDlgItemMessage (hDlg,IDC_BECKER_ENAB,BM_GETCHECK,0,0);
+					SelectRomIndex = ::std::min(TempSelectRomIndex, RomPointer.size());
+					RomFileName = ::vcc::utils::find_pak_module_path(TempRomFileName);
+					ExternalRom.load(RomFileName); //JF
+					BeckerAddr = ::vcc::utils::get_dialog_item_text(hDlg, IDC_BECKER_HOST);
+					BeckerPort = ::vcc::utils::get_dialog_item_text(hDlg, IDC_BECKER_PORT);
+					gBecker.sethost(BeckerAddr.c_str(), BeckerPort.c_str());
+					BeckerEnabled = SendDlgItemMessage(hDlg, IDC_BECKER_ENAB, BM_GETCHECK, 0, 0) != 0;
 					gBecker.enable(BeckerEnabled);
 					SaveConfig();
 					DestroyWindow(hDlg);
@@ -362,7 +377,7 @@ LRESULT CALLBACK Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*
 							for (temp2=0;temp2<sizeof(ChipChoice) / sizeof(*ChipChoice);temp2++)
 								SendDlgItemMessage(hDlg,ChipChoice[temp2],BM_SETCHECK,0,0);
 							SendDlgItemMessage(hDlg,ChipChoice[temp],BM_SETCHECK,1,0);
-							TempSelectRom=temp;
+							TempSelectRomIndex = temp;
 						}
 					break;
 				case IDC_BROWSE:
@@ -401,7 +416,7 @@ void Load_Disk(unsigned char disk)
 {
 	HWND h_own = GetActiveWindow();
 	FileDialog dlg;
-	dlg.setInitialDir(FloppyPath);
+	dlg.setInitialDir(FloppyPath.c_str());
 	dlg.setFilter("Disk Images\0*.dsk;*.os9\0\0");
 	dlg.setDefExt("dsk");
 	dlg.setTitle("Insert Disk Image");
@@ -426,19 +441,12 @@ void Load_Disk(unsigned char disk)
 			if (mount_disk_image(TempFileName,disk)==0) {
 				MessageBox(g_hConfDlg,"Can't open file","Error",0);
 			} else {
-				dlg.getdir(FloppyPath);
+				FloppyPath = ::vcc::utils::get_directory_from_path(dlg.path());
 				SaveConfig();
 			}
 		}
 	}
 	return;
-}
-
-unsigned char SetChip(unsigned char Tmp)
-{
-	if (Tmp!=QUERY)
-		SelectRom=Tmp;
-	return SelectRom;
 }
 
 void BuildCartridgeMenu()
@@ -454,7 +462,7 @@ void BuildCartridgeMenu()
 	CartMenuCallback(gHostKey, "FD-502 Drive 0",MID_ENTRY,MIT_Head);
 	CartMenuCallback(gHostKey, "Insert",ControlId(10),MIT_Slave);
 	strcpy(TempMsg,"Eject: ");
-	strcpy(TempBuf,Drive[0].ImageName);
+	strcpy(TempBuf, get_mounted_disk_filename(0).c_str());
 	PathStripPath(TempBuf);
 	strcat(TempMsg,TempBuf);
 	CartMenuCallback(gHostKey, TempMsg,ControlId(11),MIT_Slave);
@@ -462,7 +470,7 @@ void BuildCartridgeMenu()
 	CartMenuCallback(gHostKey, "FD-502 Drive 1",MID_ENTRY,MIT_Head);
 	CartMenuCallback(gHostKey, "Insert",ControlId(12),MIT_Slave);
 	strcpy(TempMsg,"Eject: ");
-	strcpy(TempBuf,Drive[1].ImageName);
+	strcpy(TempBuf, get_mounted_disk_filename(1).c_str());
 	PathStripPath(TempBuf);
 	strcat(TempMsg,TempBuf);
 	CartMenuCallback(gHostKey, TempMsg,ControlId(13),MIT_Slave);
@@ -470,7 +478,7 @@ void BuildCartridgeMenu()
 	CartMenuCallback(gHostKey, "FD-502 Drive 2",MID_ENTRY,MIT_Head);
 	CartMenuCallback(gHostKey, "Insert",ControlId(14),MIT_Slave);
 	strcpy(TempMsg,"Eject: ");
-	strcpy(TempBuf,Drive[2].ImageName);
+	strcpy(TempBuf, get_mounted_disk_filename(2).c_str());
 	PathStripPath(TempBuf);
 	strcat(TempMsg,TempBuf);
 	CartMenuCallback(gHostKey, TempMsg,ControlId(15),MIT_Slave);
@@ -478,7 +486,7 @@ void BuildCartridgeMenu()
 	CartMenuCallback(gHostKey, "FD-502 Drive 3",MID_ENTRY,MIT_Head);
 	CartMenuCallback(gHostKey, "Insert",ControlId(17),MIT_Slave);
 	strcpy(TempMsg,"Eject: ");
-	strcpy(TempBuf,Drive[3].ImageName);
+	strcpy(TempBuf, get_mounted_disk_filename(3).c_str());
 	PathStripPath(TempBuf);
 	strcat(TempMsg,TempBuf);
 	CartMenuCallback(gHostKey, TempMsg,ControlId(18),MIT_Slave);
@@ -583,181 +591,98 @@ LRESULT CALLBACK NewDisk(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam
     return FALSE;
 }
 
-long CreateDiskHeader(const char *FileName,unsigned char Type,unsigned char Tracks,unsigned char DblSided)
-{
-	HANDLE hr=nullptr;
-	unsigned char Dummy=0;
-	unsigned char HeaderBuffer[16]="";
-	unsigned char TrackTable[3]={35,40,80};
-	unsigned short TrackSize=0x1900;
-	unsigned char IgnoreDensity=0,SingleDensity=0,HeaderSize=0;
-	unsigned long BytesWritten=0,FileSize=0;
-	hr=CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,nullptr,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,nullptr);
-	if (hr==INVALID_HANDLE_VALUE)
-		return 1; //Failed to create File
+static const auto becker_section_name = "HDBDOS/DW/Becker";
+static const auto fd502_section_name = "FD-502";
 
-	switch (Type)
-	{
-		case DMK:
-			HeaderBuffer[0]=0;
-			HeaderBuffer[1]=TrackTable[Tracks];
-			HeaderBuffer[2]=(TrackSize & 0xFF);
-			HeaderBuffer[3]=(TrackSize >>8);
-			HeaderBuffer[4]=(IgnoreDensity<<7) | (SingleDensity<<6) | ((!DblSided)<<4);
-			HeaderBuffer[0xC]=0;
-			HeaderBuffer[0xD]=0;
-			HeaderBuffer[0xE]=0;
-			HeaderBuffer[0xF]=0;
-			HeaderSize=0x10;
-			FileSize= HeaderSize + (HeaderBuffer[1] * TrackSize * (DblSided+1) );
-		break;
-
-		case JVC:	// has variable header size
-			HeaderSize=0;
-			HeaderBuffer[0]=18;			//18 Sectors
-			HeaderBuffer[1]=DblSided+1;	// Double or single Sided;
-			FileSize = (HeaderBuffer[0] * 0x100 * TrackTable[Tracks] * (DblSided+1));
-			if (DblSided)
-			{
-				FileSize+=2;
-				HeaderSize=2;
-			}
-		break;
-
-		case VDK:
-			HeaderBuffer[9]=DblSided+1;
-			HeaderSize=12;
-			FileSize = ( 18 * 0x100 * TrackTable[Tracks] * (DblSided+1));
-			FileSize+=HeaderSize;
-		break;
-
-		case 3:
-			HeaderBuffer[0]=0;
-			HeaderBuffer[1]=TrackTable[Tracks];
-			HeaderBuffer[2]=(TrackSize & 0xFF);
-			HeaderBuffer[3]=(TrackSize >>8);
-			HeaderBuffer[4]=((!DblSided)<<4);
-			HeaderBuffer[0xC]=0x12;
-			HeaderBuffer[0xD]=0x34;
-			HeaderBuffer[0xE]=0x56;
-			HeaderBuffer[0xF]=0x78;
-			HeaderSize=0x10;
-			FileSize=1;
-		break;
-
-	}
-	SetFilePointer(hr,0,nullptr,FILE_BEGIN);
-	WriteFile(hr,HeaderBuffer,HeaderSize,&BytesWritten,nullptr);
-	SetFilePointer(hr,FileSize-1,nullptr,FILE_BEGIN);
-	WriteFile(hr,&Dummy,1,&BytesWritten,nullptr);
-	CloseHandle(hr);
-	return 0;
-}
 
 void LoadConfig()  // Called on SetIniPath
 {
-	char ModName[MAX_LOADSTRING]="";
-	unsigned char Index=0;
-	char Temp[16]="";
-	char DiskRomPath[MAX_PATH], RGBRomPath[MAX_PATH];
-	char DiskName[MAX_PATH]="";
-	unsigned int RetVal=0;
+	namespace utils = ::vcc::utils;
 
-	strcpy(ModName,"HDBDOS/DW/Becker");
-	BeckerEnabled=GetPrivateProfileInt(ModName,"DWEnable", 0, IniFile);
-	GetPrivateProfileString(ModName,"DWServerAddr","127.0.0.1",BeckerAddr,MAX_PATH,IniFile);
-	GetPrivateProfileString(ModName,"DWServerPort","65504",BeckerPort,32,IniFile);
-	if(*BeckerAddr == '\0') strcpy(BeckerAddr,"127.0.0.1");
-	if(*BeckerPort == '\0') strcpy(BeckerPort,"65504");
-	gBecker.sethost(BeckerAddr,BeckerPort);
+	char DiskRomPath[MAX_PATH];
+	char RGBRomPath[MAX_PATH];
+
+	utils::configuration_serializer serializer(IniFile);
+
+	BeckerEnabled = serializer.read(becker_section_name, "DWEnable", false);
+	BeckerAddr = serializer.read(becker_section_name, "DWServerAddr", "127.0.0.1");
+	BeckerPort = serializer.read(becker_section_name, "DWServerPort", "65504");
+	gBecker.sethost(BeckerAddr.c_str(), BeckerPort.c_str());
 	gBecker.enable(BeckerEnabled);
 
-	LoadString(gModuleInstance,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
-	GetPrivateProfileString("DefaultPaths", "FloppyPath", "", FloppyPath, MAX_PATH, IniFile);
+	FloppyPath = serializer.read("DefaultPaths", "FloppyPath");
+	SelectRomIndex = std::min(
+		serializer.read(fd502_section_name, "DiskRom", default_selected_rom_index),
+		RomPointer.size());
+	RomFileName = utils::find_pak_module_path(serializer.read(fd502_section_name, "RomPath"));
+	PersistDisks = serializer.read(fd502_section_name, "Persist", true);
 
-	SelectRom = GetPrivateProfileInt(ModName,"DiskRom",1,IniFile);  //0 External 1=TRSDOS 2=RGB Dos
-	GetPrivateProfileString(ModName,"RomPath","",RomFileName,MAX_PATH,IniFile);
-	PersistDisks=GetPrivateProfileInt(ModName,"Persist",1,IniFile);
-	CheckPath(RomFileName);
-	LoadExtRom(External,RomFileName); //JF
+	RomFileName = utils::find_pak_module_path(RomFileName);
+	ExternalRom.load(RomFileName); //JF
+
 	GetModuleFileName(nullptr, DiskRomPath, MAX_PATH);
 	PathRemoveFileSpec(DiskRomPath);
 	strcpy(RGBRomPath, DiskRomPath);
 	strcat(DiskRomPath, "disk11.rom"); //Failing silent, Maybe we should throw a warning?
 	strcat(RGBRomPath, "rgbdos.rom");  //Future, Grey out dialog option if can't find file
-	LoadExtRom(TandyDisk, DiskRomPath);
-	LoadExtRom(RGBDisk, RGBRomPath);
+	DiskRom.load(DiskRomPath);
+	RGBDiskRom.load(RGBRomPath);
+
 	if (PersistDisks)
-		for (Index=0;Index<4;Index++)
+	{
+		for (auto Index = 0; Index < 4; Index++)
 		{
-			sprintf(Temp,"Disk#%i",Index);
-			GetPrivateProfileString(ModName,Temp,"",DiskName,MAX_PATH,IniFile);
-			if (strlen(DiskName))
+			const auto settings_key = "Disk#" + std::to_string(Index);
+			const auto disk_filename(serializer.read(fd502_section_name, settings_key));
+			if (!disk_filename.empty())
 			{
-				RetVal=mount_disk_image(DiskName,Index);
-				//MessageBox(0, "Disk load attempt", "OK", 0);
-				if (RetVal)
+				if (mount_disk_image(disk_filename.c_str(), Index))
 				{
-					if (!strcmp(DiskName,"*Floppy A:"))	//RealDisks
-						PhysicalDriveA=Index+1;
-					if (!strcmp(DiskName,"*Floppy B:"))
-						PhysicalDriveB=Index+1;
+					if (disk_filename == "*Floppy A:")	//RealDisks
+					{
+						PhysicalDriveA = Index + 1;
+					}
+
+					if (disk_filename == "*Floppy B:")
+					{
+						PhysicalDriveB = Index + 1;
+					}
 				}
 			}
 		}
-	ClockEnabled=GetPrivateProfileInt(ModName,"ClkEnable",1,IniFile);
-	SetTurboDisk(GetPrivateProfileInt(ModName, "TurboDisk", 1, IniFile));
+	}
 
-	BuildCartridgeMenu();
-	return;
+	ClockEnabled = serializer.read(fd502_section_name, "ClkEnable", true);
+	SetTurboDisk(GetPrivateProfileInt(fd502_section_name, "TurboDisk", 1, IniFile));
 }
 
 void SaveConfig()
 {
-	unsigned char Index=0;
-	char ModName[MAX_LOADSTRING]="";
-	char Temp[16]="";
-	LoadString(gModuleInstance,IDS_MODULE_NAME,ModName, MAX_LOADSTRING);
-	ValidatePath(RomFileName);
-	WritePrivateProfileInt(ModName,"DiskRom",SelectRom ,IniFile);
-	WritePrivateProfileString(ModName,"RomPath",RomFileName,IniFile);
-	WritePrivateProfileInt(ModName,"Persist",PersistDisks ,IniFile);
+	unsigned char Index = 0;
+	char Temp[16] = "";
+
+	::vcc::utils::configuration_serializer serializer(IniFile);
+
+	RomFileName = ::vcc::utils::strip_application_path(RomFileName);
+	serializer.write(fd502_section_name, "DiskRom", SelectRomIndex);
+	serializer.write(fd502_section_name, "RomPath", RomFileName);
+	serializer.write(fd502_section_name, "Persist", PersistDisks);
 	if (PersistDisks)
-		for (Index=0;Index<4;Index++)
-		{
-			sprintf(Temp,"Disk#%i",Index);
-			WritePrivateProfileString(ModName,Temp,Drive[Index].ImageName,IniFile);
-		}
-	WritePrivateProfileInt(ModName,"ClkEnable",ClockEnabled ,IniFile);
-	WritePrivateProfileInt(ModName, "TurboDisk", SetTurboDisk(QUERY), IniFile);
-	if (strcmp(FloppyPath, "") != 0) {
-		WritePrivateProfileString("DefaultPaths", "FloppyPath", FloppyPath, IniFile);
-	}
-    strcpy(ModName,"HDBDOS/DW/Becker");
-	WritePrivateProfileInt(ModName,"DWEnable", BeckerEnabled, IniFile);
-	WritePrivateProfileString(ModName,"DWServerAddr", BeckerAddr, IniFile);
-	WritePrivateProfileString(ModName,"DWServerPort", BeckerPort, IniFile);
-	return;
-}
-
-unsigned char LoadExtRom( unsigned char RomType,const char *FilePath)	//Returns 1 on if loaded
-{
-
-	FILE *rom_handle=nullptr;
-	unsigned short index=0;
-	unsigned char RetVal=0;
-	unsigned char *ThisRom[3]={ExternalRom,DiskRom,RGBDiskRom};
-
-	rom_handle=fopen(FilePath,"rb");
-	if (rom_handle==nullptr)
-		memset(ThisRom[RomType],0xFF,EXTROMSIZE);
-	else
 	{
-		while ((feof(rom_handle)==0) & (index<EXTROMSIZE))
-			ThisRom[RomType][index++]=fgetc(rom_handle);
-		RetVal=1;
-		fclose(rom_handle);
+		for (auto disk_id = 0; disk_id < 4; disk_id++)
+		{
+			sprintf(Temp, "Disk#%i", disk_id);
+			serializer.write(fd502_section_name, Temp, get_mounted_disk_filename(disk_id));
+		}
+	}
+	serializer.write(fd502_section_name, "ClkEnable", ClockEnabled);
+	serializer.write(fd502_section_name, "TurboDisk", SetTurboDisk(QUERY));
+	if (!FloppyPath.empty())
+	{
+		serializer.write("DefaultPaths", "FloppyPath", FloppyPath);
 	}
 
-	return RetVal;
+	serializer.write(becker_section_name, "DWEnable", BeckerEnabled);
+	serializer.write(becker_section_name, "DWServerAddr", BeckerAddr);
+	serializer.write(becker_section_name, "DWServerPort", BeckerPort);
 }

--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -1,20 +1,20 @@
-//---------------------------------------------------------------------------------
-// Copyright 2015 by Joseph Forgione
-// This file is part of VCC (Virtual Color Computer).
-//
-// VCC (Virtual Color Computer) is free software: you can redistribute it and/or
-// modify it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or any later
-// version.
-//
-// VCC (Virtual Color Computer) is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-// more details.  You should have received a copy of the GNU General Public License
-// along with VCC (Virtual Color Computer).  If not, see
-// <http://www.gnu.org/licenses/>.
-//
-//---------------------------------------------------------------------------------
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <vcc/core/cartridge_capi.h>
 

--- a/FD502/fd502.vcxproj
+++ b/FD502/fd502.vcxproj
@@ -85,6 +85,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="fd502.cpp" />
+    <ClCompile Include="utils.cpp" />
     <ClCompile Include="wd1793.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -92,7 +93,9 @@
     <ClInclude Include="fd502.h" />
     <ClInclude Include="fdrawcmd.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="utils.h" />
     <ClInclude Include="wd1793.h" />
+    <ClInclude Include="wd1793defs.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="fd502.rc" />

--- a/FD502/fd502.vcxproj.filters
+++ b/FD502/fd502.vcxproj.filters
@@ -7,6 +7,9 @@
     <ClCompile Include="wd1793.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="utils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="defines.h">
@@ -23,6 +26,12 @@
     </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>Resource Files</Filter>
+    </ClInclude>
+    <ClInclude Include="utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wd1793defs.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/FD502/fd502.vcxproj.filters
+++ b/FD502/fd502.vcxproj.filters
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="fd502.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wd1793.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="defines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fd502.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fdrawcmd.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wd1793.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Resource Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{2ed54a5a-d4e4-4c84-a3cf-ce12a5022870}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{5d86c2ed-de3e-4da8-b674-34de8b520fa3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{04066375-3871-44cb-a434-779e80a935b3}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="fd502.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/FD502/utils.cpp
+++ b/FD502/utils.cpp
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include "utils.h"
+#include "wd1793.h"
+#include <Windows.h>
+
+
+long CreateDiskHeader(const char *FileName,unsigned char Type,unsigned char Tracks,unsigned char DblSided)
+{
+	HANDLE hr=nullptr;
+	unsigned char Dummy=0;
+	unsigned char HeaderBuffer[16]="";
+	unsigned char TrackTable[3]={35,40,80};
+	unsigned short TrackSize=0x1900;
+	unsigned char IgnoreDensity=0,SingleDensity=0,HeaderSize=0;
+	unsigned long BytesWritten=0,FileSize=0;
+	hr=CreateFile( FileName,GENERIC_READ | GENERIC_WRITE,0,nullptr,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,nullptr);
+	if (hr==INVALID_HANDLE_VALUE)
+		return 1; //Failed to create File
+
+	switch (Type)
+	{
+	case DMK:
+		HeaderBuffer[0]=0;
+		HeaderBuffer[1]=TrackTable[Tracks];
+		HeaderBuffer[2]=(TrackSize & 0xFF);
+		HeaderBuffer[3]=(TrackSize >>8);
+		HeaderBuffer[4]=(IgnoreDensity<<7) | (SingleDensity<<6) | ((!DblSided)<<4);
+		HeaderBuffer[0xC]=0;
+		HeaderBuffer[0xD]=0;
+		HeaderBuffer[0xE]=0;
+		HeaderBuffer[0xF]=0;
+		HeaderSize=0x10;
+		FileSize= HeaderSize + (HeaderBuffer[1] * TrackSize * (DblSided+1) );
+		break;
+
+	case JVC:	// has variable header size
+		HeaderSize=0;
+		HeaderBuffer[0]=18;			//18 Sectors
+		HeaderBuffer[1]=DblSided+1;	// Double or single Sided;
+		FileSize = (HeaderBuffer[0] * 0x100 * TrackTable[Tracks] * (DblSided+1));
+		if (DblSided)
+		{
+			FileSize+=2;
+			HeaderSize=2;
+		}
+		break;
+
+	case VDK:
+		HeaderBuffer[9]=DblSided+1;
+		HeaderSize=12;
+		FileSize = ( 18 * 0x100 * TrackTable[Tracks] * (DblSided+1));
+		FileSize+=HeaderSize;
+		break;
+
+	case 3:
+		HeaderBuffer[0]=0;
+		HeaderBuffer[1]=TrackTable[Tracks];
+		HeaderBuffer[2]=(TrackSize & 0xFF);
+		HeaderBuffer[3]=(TrackSize >>8);
+		HeaderBuffer[4]=((!DblSided)<<4);
+		HeaderBuffer[0xC]=0x12;
+		HeaderBuffer[0xD]=0x34;
+		HeaderBuffer[0xE]=0x56;
+		HeaderBuffer[0xF]=0x78;
+		HeaderSize=0x10;
+		FileSize=1;
+		break;
+
+	}
+	SetFilePointer(hr,0,nullptr,FILE_BEGIN);
+	WriteFile(hr,HeaderBuffer,HeaderSize,&BytesWritten,nullptr);
+	SetFilePointer(hr,FileSize-1,nullptr,FILE_BEGIN);
+	WriteFile(hr,&Dummy,1,&BytesWritten,nullptr);
+	CloseHandle(hr);
+	return 0;
+}

--- a/FD502/utils.h
+++ b/FD502/utils.h
@@ -16,9 +16,10 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridge_capi.h>
 
-extern void*const& gHostKey;
-extern PakAssertInteruptHostCallback AssertInt;
-void BuildCartridgeMenu();
 
+long CreateDiskHeader(
+	const char* FileName,
+	unsigned char Type,
+	unsigned char Tracks,
+	unsigned char DblSided);

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -1,36 +1,20 @@
-/*
-Copyright 2015 by Joseph Forgione
-This file is part of VCC (Virtual Color Computer).
-
-    VCC (Virtual Color Computer) is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    VCC (Virtual Color Computer) is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/********************************************************************************
-*  File name: wd1793.c															*
-*  Copyright 2005 by Joseph Forgione											*
-*  This will Emulate the Western Digital wd1793 Floppy Disk Controller chip		*
-*  and  support circuts as implemented in the Tandy Color Computer 1,2 and 3.	*
-*  Last change date 03/16/2005													*				
-*  Last change date 07/14/2005 Changes NMI assert fucntion						*
-*  Last change date 07/26/2005 Complete rewrite to get F**king nitros09 to boot	*
-*  Last change date 02/04/2006 rewritten again for DMK and writetrack support	*
-*  Last change date 06/27/2006 seek time more closely emulated					*
-*  Last change date 05/16/2007 Better DMK support. Diecom protection works now	*
-*  Last change date 05/21/2007 Added fdrawcmd support for real disk access/		*
-*																				*
-********************************************************************************/
-
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
 #include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -15,15 +15,16 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
+#include "wd1793.h"
+#include "wd1793defs.h"
+#include "defines.h"
+#include "fd502.h"
+#include "fdrawcmd.h"	// http://simonowen.com/fdrawcmd/
+#include <vcc/core/interrupts.h>
+#include <winioctl.h>
 #include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <winioctl.h>
-#include "defines.h"
-#include <vcc/core/interrupts.h>
-#include "wd1793.h"
-#include "fd502.h"
-#include "fdrawcmd.h"	// http://simonowen.com/fdrawcmd/
 /****************Fuction Protos for this Module************/
 
 unsigned char GetBytefromSector ();
@@ -57,7 +58,7 @@ bool CmdFormat (HANDLE , PFD_FORMAT_PARAMS , ULONG );
 static unsigned char StepTimesMS[4]={6,12,20,30};
 static unsigned short BytesperSector[4]={128,256,512,1024};
 static unsigned char TransferBuffer[16384]="";
-DiskInfo Drive[5];
+static DiskInfo Drive[5];
 static unsigned char StatusReg=READY;
 static unsigned char DataReg=0;
 static unsigned char TrackReg=0;
@@ -96,6 +97,12 @@ bool SetDataRate (HANDLE , BYTE );
 static FD_READ_WRITE_PARAMS rwp;
 static bool DirtyDisk=true;
 char ImageFormat[5][4]={"JVC","VDK","DMK","OS9","RAW"};
+
+
+::std::string get_mounted_disk_filename(::std::size_t drive_index)
+{
+	return Drive[drive_index].ImageName;
+}
 
 /*************************************************************/
 unsigned char disk_io_read(unsigned char port)

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -18,6 +18,8 @@
 #pragma once
 #include "defines.h"
 #include <Windows.h>
+#include <string>
+
 
 unsigned char disk_io_read(unsigned char port);
 void disk_io_write(unsigned char data,unsigned char port);	
@@ -29,118 +31,14 @@ unsigned char SetTurboDisk( unsigned char);
 //unsigned char UseKeyboardLeds(unsigned char);
 DWORD GetDriverVersion ();
 unsigned short InitController ();
-//unsigned long UseRawDisk(unsigned char,unsigned char);
-// Commands for the wd1793 disk controller $FF48
+::std::string get_mounted_disk_filename(::std::size_t drive_index);
 
-struct DiskInfo 
+// FIXME: Needs a name and should be scoped
+enum
 {
-	HANDLE FileHandle;
-	char ImageName[MAX_PATH];
-	long FileSize;				
-	unsigned char HeaderSize;
-	unsigned char Sides;		// Number of Sides 1 ot 2
-	unsigned char Sectors;		//Sectors Per Track
-	unsigned char SectorSize;	//0=128 1=256 2=512 3=1024
-	unsigned char FirstSector;	// 0 or 1
-	unsigned char ImageType;	//0=JVC 1=VDK 2=DMK 3=OS9
-	unsigned short TrackSize;
-	unsigned char WriteProtect;
-	unsigned char HeadPosition;	// The "Physical" Track the head is over
-	unsigned char RawDrive;
-	char ImageTypeName[4];
+	JVC,
+	VDK,
+	DMK,
+	OS9,
+	RAW
 };
-
-struct SectorInfo
-{
-	unsigned char Track = 0;
-	unsigned char Side = 0;
-	unsigned char Sector = 0;
-	unsigned short Lenth = 0;
-	unsigned short CRC = 0;
-	long DAM = 0;
-	unsigned char Density = 0;
-};
-
-
-#define IDLE 255
-#define NONE 4
-#define JVC	0
-#define VDK	1
-#define DMK	2
-#define OS9	3
-#define RAW 4
-
-
-//Control register masks
-#define CTRL_DRIVE0		0x01
-#define CTRL_DRIVE1		0x02
-#define CTRL_DRIVE2		0x04
-#define CTRL_MOTOR_EN	0x08
-#define CTRL_WRT_PRECMP	0x10
-#define CTRL_DENSITY	0x20
-#define CTRL_DRIVE3		0x40
-#define CTRL_HALT_FLAG	0x80
-#define SIDESELECT		0x40
-
-//Status Register return codes
-#define READY			0
-#define	BUSY			0x01
-#define DRQ				0x02
-#define INDEXPULSE		0x02
-#define TRACK_ZERO		0x04
-#define LOSTDATA		0x04
-#define RECNOTFOUND		0x10
-#define WRITEPROTECT	0x40
-
-
-#define WAITTIME		5
-#define STEPTIME		15	// 1 Millisecond = 15.78 Pings
-#define SETTLETIME		10	// CyclestoSettle
-
-#define RESTORE			0
-#define	SEEK			1
-#define STEP			2
-#define STEPUPD			3
-#define	STEPIN			4
-#define	STEPINUPD		5
-#define STEPOUT			6
-#define STEPOUTUPD		7
-#define	READSECTOR		8
-#define READSECTORM		9
-#define WRITESECTOR		10
-#define	WRITESECTORM	11
-#define	READADDRESS		12
-#define	FORCEINTERUPT	13
-#define	READTRACK		14
-#define WRITETRACK		15
-
-#define HEADERBUFFERSIZE	256
-
-
-//#define IOCTL_KEYBOARD_SET_INDICATORS        CTL_CODE(FILE_DEVICE_KEYBOARD, 0x0002, METHOD_BUFFERED, FILE_ANY_ACCESS)
-//#define IOCTL_KEYBOARD_QUERY_TYPEMATIC       CTL_CODE(FILE_DEVICE_KEYBOARD, 0x0008, METHOD_BUFFERED, FILE_ANY_ACCESS)
-//#define IOCTL_KEYBOARD_QUERY_INDICATORS      CTL_CODE(FILE_DEVICE_KEYBOARD, 0x0010, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-//typedef struct _KEYBOARD_INDICATOR_PARAMETERS {
-//    USHORT UnitId;		// Unit identifier.
-//    USHORT LedFlags;		// LED indicator state.
-//
-//} KEYBOARD_INDICATOR_PARAMETERS, *PKEYBOARD_INDICATOR_PARAMETERS;
-
-//#define KEYBOARD_CAPS_LOCK_ON     4
-//#define KEYBOARD_NUM_LOCK_ON      2
-//#define KEYBOARD_SCROLL_LOCK_ON   1
-
-
-//
-#define DISK_SIDES          1       // sides per disk
-#define DISK_TRACKS         35      // tracks per side
-#define DISK_SECTORS        18      // sectors per track
-#define DISK_DATARATE       2       // 2 is double-density
-#define SECTOR_SIZE_CODE    1       // 0=128, 1=256, 2=512, 3=1024, ...
-#define SECTOR_GAP3         16    // gap3 size between sectors
-#define SECTOR_FILL         0xFF    // fill byte for formatted sectors
-#define SECTOR_BASE         1       // first sector number on track
-#define TRACK_SKEW          1       // format skew to the same sector on the next track
-
-#define TRACK_SIZE          ((128<<SECTOR_SIZE_CODE)*DISK_SECTORS)

--- a/FD502/wd1793.h
+++ b/FD502/wd1793.h
@@ -1,22 +1,21 @@
-#ifndef __WD1793_H__
-#define __WD1793_H__
-/*
-Copyright 2015 by Joseph Forgione
-This file is part of VCC (Virtual Color Computer).
-
-    VCC (Virtual Color Computer) is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    VCC (Virtual Color Computer) is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licenses/>.
-*/
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
 #include "defines.h"
 #include <Windows.h>
 
@@ -145,5 +144,3 @@ struct SectorInfo
 #define TRACK_SKEW          1       // format skew to the same sector on the next track
 
 #define TRACK_SIZE          ((128<<SECTOR_SIZE_CODE)*DISK_SECTORS)
-
-#endif

--- a/FD502/wd1793defs.h
+++ b/FD502/wd1793defs.h
@@ -1,0 +1,98 @@
+#pragma once
+#include "defines.h"
+#include <Windows.h>
+
+
+
+struct DiskInfo 
+{
+	HANDLE FileHandle;
+	char ImageName[MAX_PATH];
+	long FileSize;				
+	unsigned char HeaderSize;
+	unsigned char Sides;		// Number of Sides 1 ot 2
+	unsigned char Sectors;		//Sectors Per Track
+	unsigned char SectorSize;	//0=128 1=256 2=512 3=1024
+	unsigned char FirstSector;	// 0 or 1
+	unsigned char ImageType;	//0=JVC 1=VDK 2=DMK 3=OS9
+	unsigned short TrackSize;
+	unsigned char WriteProtect;
+	unsigned char HeadPosition;	// The "Physical" Track the head is over
+	unsigned char RawDrive;
+	char ImageTypeName[4];
+};
+
+struct SectorInfo
+{
+	unsigned char Track = 0;
+	unsigned char Side = 0;
+	unsigned char Sector = 0;
+	unsigned short Lenth = 0;
+	unsigned short CRC = 0;
+	long DAM = 0;
+	unsigned char Density = 0;
+};
+
+
+#define IDLE 255
+#define NONE 4
+
+
+
+//Control register masks
+#define CTRL_DRIVE0		0x01
+#define CTRL_DRIVE1		0x02
+#define CTRL_DRIVE2		0x04
+#define CTRL_MOTOR_EN	0x08
+#define CTRL_WRT_PRECMP	0x10
+#define CTRL_DENSITY	0x20
+#define CTRL_DRIVE3		0x40
+#define CTRL_HALT_FLAG	0x80
+#define SIDESELECT		0x40
+
+//Status Register return codes
+#define READY			0
+#define	BUSY			0x01
+#define DRQ				0x02
+#define INDEXPULSE		0x02
+#define TRACK_ZERO		0x04
+#define LOSTDATA		0x04
+#define RECNOTFOUND		0x10
+#define WRITEPROTECT	0x40
+
+
+#define WAITTIME		5
+#define STEPTIME		15	// 1 Millisecond = 15.78 Pings
+#define SETTLETIME		10	// CyclestoSettle
+
+#define RESTORE			0
+#define	SEEK			1
+#define STEP			2
+#define STEPUPD			3
+#define	STEPIN			4
+#define	STEPINUPD		5
+#define STEPOUT			6
+#define STEPOUTUPD		7
+#define	READSECTOR		8
+#define READSECTORM		9
+#define WRITESECTOR		10
+#define	WRITESECTORM	11
+#define	READADDRESS		12
+#define	FORCEINTERUPT	13
+#define	READTRACK		14
+#define WRITETRACK		15
+
+#define HEADERBUFFERSIZE	256
+
+//
+#define DISK_SIDES          1       // sides per disk
+#define DISK_TRACKS         35      // tracks per side
+#define DISK_SECTORS        18      // sectors per track
+#define DISK_DATARATE       2       // 2 is double-density
+#define SECTOR_SIZE_CODE    1       // 0=128, 1=256, 2=512, 3=1024, ...
+#define SECTOR_GAP3         16    // gap3 size between sectors
+#define SECTOR_FILL         0xFF    // fill byte for formatted sectors
+#define SECTOR_BASE         1       // first sector number on track
+#define TRACK_SKEW          1       // format skew to the same sector on the next track
+
+#define TRACK_SIZE          ((128<<SECTOR_SIZE_CODE)*DISK_SECTORS)

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -642,11 +642,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					maxHorizontalPosition -= (displayDetails.leftBorderColumns + displayDetails.rightBorderColumns);
 					maxVerticalPosition -= (displayDetails.topBorderRows + displayDetails.bottomBorderRows);
 
-					mouseXPosition = min(
-						max(0, mouseXPosition - displayDetails.leftBorderColumns),
+					mouseXPosition = ::std::min(
+						::std::max(0, mouseXPosition - displayDetails.leftBorderColumns),
 						maxHorizontalPosition);
-					mouseYPosition = min(
-						max(0, mouseYPosition - displayDetails.topBorderRows),
+					mouseYPosition = ::std::min(
+						::std::max(0, mouseYPosition - displayDetails.topBorderRows),
 						maxVerticalPosition);
 
 #if USE_DEBUG_MOUSE

--- a/config.cpp
+++ b/config.cpp
@@ -896,7 +896,7 @@ void UpdateSoundBar(const unsigned int * audioBuf,unsigned int bufLen)
 	int lMax = lval;
 	int rMin = rval;
 	int rMax = rval;
-	for (size_t i = 1; i < min(bufLen,100); ++i) {
+	for (size_t i = 1; i < ::std::min(bufLen,100u); ++i) {
 		int lval = audioBuf[i] >> 16;
 		int rval = audioBuf[i] & 0xFFFF;
 		if (lval > lMax) lMax = lval;

--- a/libcommon/include/vcc/utils/configuration_serializer.h
+++ b/libcommon/include/vcc/utils/configuration_serializer.h
@@ -29,6 +29,7 @@ namespace vcc::utils
 
 		using path_type = ::std::string;
 		using string_type = ::std::string;
+		using size_type = ::std::size_t;
 
 	public:
 
@@ -43,10 +44,18 @@ namespace vcc::utils
 			const string_type& key,
 			const string_type& value) const;
 
+		LIBCOMMON_EXPORT [[nodiscard]] bool read(
+			const string_type& section,
+			const string_type& key,
+			bool default_value) const;
 		LIBCOMMON_EXPORT [[nodiscard]] int read(
 			const string_type& section,
 			const string_type& key,
-			int default_value) const;
+			const int& default_value) const;
+		LIBCOMMON_EXPORT [[nodiscard]] size_type read(
+			const string_type& section,
+			const string_type& key,
+			const size_type& default_value) const;
 		LIBCOMMON_EXPORT [[nodiscard]] string_type read(
 			const string_type& section,
 			const string_type& key,

--- a/libcommon/include/vcc/utils/configuration_serializer.h
+++ b/libcommon/include/vcc/utils/configuration_serializer.h
@@ -60,6 +60,10 @@ namespace vcc::utils
 			const string_type& section,
 			const string_type& key,
 			const string_type& default_value = {}) const;
+		LIBCOMMON_EXPORT [[nodiscard]] string_type read(
+			const string_type& section,
+			const string_type& key,
+			const char* default_value) const;
 
 
 	private:

--- a/libcommon/src/utils/configuration_serializer.cpp
+++ b/libcommon/src/utils/configuration_serializer.cpp
@@ -70,13 +70,26 @@ namespace vcc::utils
 		const string_type& key,
 		const string_type& default_value) const
 	{
-		// FIXME-CHET: Need to determine the size of the string
+		return read(section, key, default_value.c_str());
+	}
+
+	configuration_serializer::string_type configuration_serializer::read(
+		const string_type& section,
+		const string_type& key,
+		const char* default_value) const
+	{
+		// FIXME-CHET: There is no way to effectively determining the length of
+		// the string that will be loaded. This will need to either use a fixed
+		// buffer of 65536 characters (the maximum allowed), iterate growing
+		// the buffer the string is loaded into until it is big enough, switch
+		// to a library that better supports INI configuration instead of using
+		// an API that's intended for 16bit compatibility.
 		char loaded_string[MAX_PATH] = {};
 
 		GetPrivateProfileString(
 			section.c_str(),
 			key.c_str(),
-			default_value.c_str(),
+			default_value,
 			loaded_string,
 			MAX_PATH,
 			path_.c_str());

--- a/libcommon/src/utils/configuration_serializer.cpp
+++ b/libcommon/src/utils/configuration_serializer.cpp
@@ -47,9 +47,22 @@ namespace vcc::utils
 		WritePrivateProfileString(section.c_str(), key.c_str(), value.c_str(), path_.c_str());
 	}
 
-	int configuration_serializer::read(const string_type& section, const string_type& key, int default_value) const
+	int configuration_serializer::read(const string_type& section, const string_type& key, const int& default_value) const
 	{
 		return GetPrivateProfileInt(section.c_str(), key.c_str(), default_value, path_.c_str());
+	}
+
+	configuration_serializer::size_type configuration_serializer::read(
+		const string_type& section,
+		const string_type& key,
+		const size_type& default_value) const
+	{
+		return GetPrivateProfileInt(section.c_str(), key.c_str(), default_value, path_.c_str());
+	}
+
+	bool configuration_serializer::read(const string_type& section, const string_type& key, bool default_value) const
+	{
+		return GetPrivateProfileInt(section.c_str(), key.c_str(), default_value, path_.c_str()) != 0;
 	}
 
 	configuration_serializer::string_type configuration_serializer::read(

--- a/vcc-base.props
+++ b/vcc-base.props
@@ -11,7 +11,7 @@
     <ClCompile>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;_CRT_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BrowseInformation>true</BrowseInformation>
       <AdditionalIncludeDirectories>$(SolutionDir)libcommon/include</AdditionalIncludeDirectories>
     </ClCompile>
@@ -22,4 +22,3 @@
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>
-


### PR DESCRIPTION
- Moved `CreateDiskHeader` into utils.cpp
- Switched to using vcc/utils/configuration_serializer for load/save config
- Added read function for bool types in `configuration_serializer`
- Added `get_dialog_item_text` to winapi utilities
- Switched to using vcc/devices/rom/rom_image for loading and accessing roms
- Moved private definitions into wd1703defs.h
