### PR TITLE
change memory read cartridge function signatures 

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -252,7 +252,7 @@ extern "C"
 
 extern "C"
 {
-	__declspec(dllexport) unsigned char PakReadMemoryByte(unsigned short Address)
+	__declspec(dllexport) unsigned char PakReadMemoryByte(::std::size_t Address)
 	{
 		return RomPointer[SelectRomIndex]->read_memory_byte(Address);
 	}

--- a/GMC/gmc_cartridge.cpp
+++ b/GMC/gmc_cartridge.cpp
@@ -98,7 +98,7 @@ unsigned char gmc_cartridge::read_port(unsigned char port)
 	return 0;
 }
 
-unsigned char gmc_cartridge::read_memory_byte(unsigned short address)
+unsigned char gmc_cartridge::read_memory_byte(size_type address)
 {
 	return rom_image_.read_memory_byte(address);
 }

--- a/GMC/gmc_cartridge.h
+++ b/GMC/gmc_cartridge.h
@@ -28,7 +28,7 @@ public:
 	void stop() override;
 	void reset() override;
 
-	unsigned char read_memory_byte(unsigned short memory_address) override;
+	unsigned char read_memory_byte(size_type memory_address) override;
 
 	void write_port(unsigned char port_id, unsigned char value) override;
 	unsigned char read_port(unsigned char port_id) override;

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -171,7 +171,7 @@ __declspec(dllexport) void PakReset()
 // Dll export pak rom read
 //-----------------------------------------------------------------------
 extern "C"
-__declspec(dllexport) unsigned char PakReadMemoryByte(unsigned short Address)
+__declspec(dllexport) unsigned char PakReadMemoryByte(::std::size_t Address)
 {
     return(Rom[Address & 8191]);
 }

--- a/libcommon/include/vcc/cartridges/capi_adapter_cartridge.h
+++ b/libcommon/include/vcc/cartridges/capi_adapter_cartridge.h
@@ -48,7 +48,7 @@ namespace vcc::cartridges
 		LIBCOMMON_EXPORT void stop() override;
 		LIBCOMMON_EXPORT void reset() override;
 
-		LIBCOMMON_EXPORT [[nodiscard]] unsigned char read_memory_byte(unsigned short memory_address) override;
+		LIBCOMMON_EXPORT [[nodiscard]] unsigned char read_memory_byte(size_type memory_address) override;
 
 		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;
 		LIBCOMMON_EXPORT [[nodiscard]] unsigned char read_port(unsigned char port_id) override;
@@ -56,7 +56,7 @@ namespace vcc::cartridges
 		LIBCOMMON_EXPORT void process_horizontal_sync() override;
 		LIBCOMMON_EXPORT [[nodiscard]] unsigned short sample_audio() override;
 
-		LIBCOMMON_EXPORT void status(char* text_buffer, size_t buffer_size) override;
+		LIBCOMMON_EXPORT void status(char* text_buffer, size_type buffer_size) override;
 		LIBCOMMON_EXPORT void menu_item_clicked(unsigned char menu_item_id) override;
 
 

--- a/libcommon/include/vcc/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/cartridges/rom_cartridge.h
@@ -53,7 +53,7 @@ namespace vcc::cartridges
 		LIBCOMMON_EXPORT void start() override;
 		LIBCOMMON_EXPORT void reset() override;
 
-		LIBCOMMON_EXPORT [[nodiscard]] unsigned char read_memory_byte(unsigned short memory_address) override;
+		LIBCOMMON_EXPORT [[nodiscard]] unsigned char read_memory_byte(size_type memory_address) override;
 
 		LIBCOMMON_EXPORT void write_port(unsigned char port_id, unsigned char value) override;
 

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -30,6 +30,7 @@ namespace vcc::core
 		using name_type = ::std::string;
 		using catalog_id_type = ::std::string;
 		using description_type = ::std::string;
+		using size_type = ::std::size_t;
 
 
 	public:
@@ -48,7 +49,7 @@ namespace vcc::core
 		virtual void stop();
 		virtual void reset();
 
-		virtual [[nodiscard]] unsigned char read_memory_byte(unsigned short memory_address);
+		virtual [[nodiscard]] unsigned char read_memory_byte(size_type memory_address);
 
 		virtual void write_port(unsigned char port_id, unsigned char value);
 		virtual [[nodiscard]] unsigned char read_port(unsigned char port_id);
@@ -57,7 +58,7 @@ namespace vcc::core
 
 		virtual [[nodiscard]] unsigned short sample_audio();
 
-		virtual void status(char* text_buffer, size_t buffer_size);
+		virtual void status(char* text_buffer, size_type buffer_size);
 		virtual void menu_item_clicked(unsigned char menu_item_id);
 	};
 

--- a/libcommon/include/vcc/core/cartridge_capi.h
+++ b/libcommon/include/vcc/core/cartridge_capi.h
@@ -44,7 +44,7 @@ extern "C"
 	using PakHeartBeatModuleFunction = void (*)();
 	using PakGetStatusModuleFunction = void (*)(char* text_buffer, size_t buffer_size);
 	using PakWritePortModuleFunction = void (*)(unsigned char port, unsigned char value);
-	using PakReadMemoryByteModuleFunction = unsigned char (*)(unsigned short address);
+	using PakReadMemoryByteModuleFunction = unsigned char (*)(size_t address);
 	using PakReadPortModuleFunction = unsigned char (*)(unsigned char port);
 	using PakSampleAudioModuleFunction = unsigned short (*)();
 	using PakMenuItemClickedModuleFunction = void (*)(unsigned char itemId);

--- a/libcommon/src/cartridges/capi_adapter_cartridge.cpp
+++ b/libcommon/src/cartridges/capi_adapter_cartridge.cpp
@@ -51,7 +51,7 @@ namespace vcc::cartridges
 			return {};
 		}
 
-		unsigned char default_read_memory_byte(unsigned short)
+		unsigned char default_read_memory_byte(size_t)
 		{
 			return {};
 		}
@@ -158,9 +158,11 @@ namespace vcc::cartridges
 		return read_port_(port_id);
 	}
 
-	unsigned char capi_adapter_cartridge::read_memory_byte(unsigned short memory_address)
+	unsigned char capi_adapter_cartridge::read_memory_byte(size_type memory_address)
 	{
-		return read_memory_byte_(memory_address);
+		// FIXME: This cast goes away when the signature of read memory is changed
+		// to take a size_t instead of a short.
+		return read_memory_byte_(static_cast<unsigned short>(memory_address));
 	}
 
 	unsigned short capi_adapter_cartridge::sample_audio()

--- a/libcommon/src/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/cartridges/rom_cartridge.cpp
@@ -73,7 +73,7 @@ namespace vcc::cartridges
 		}
 	}
 
-	unsigned char rom_cartridge::read_memory_byte(unsigned short memory_address)
+	unsigned char rom_cartridge::read_memory_byte(size_type memory_address)
 	{
 		return buffer_[((memory_address & 0x7fff) + bank_offset_) % buffer_.size()];
 	}

--- a/libcommon/src/core/cartridge.cpp
+++ b/libcommon/src/core/cartridge.cpp
@@ -43,7 +43,7 @@ namespace vcc::core
 		return {};
 	}
 
-	unsigned char cartridge::read_memory_byte([[maybe_unused]] unsigned short memory_address)
+	unsigned char cartridge::read_memory_byte([[maybe_unused]] size_type memory_address)
 	{
 		return {};
 	}

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -40,6 +40,7 @@ namespace vcc::modules::mpi
 		using handle_type = ::vcc::utils::cartridge_loader_result::handle_type;
 		using menu_item_type = CartMenuItem;
 		using menu_item_collection_type = std::vector<menu_item_type>;
+		using size_type = ::std::size_t;
 
 
 	public:
@@ -109,7 +110,7 @@ namespace vcc::modules::mpi
 			return cartridge_->read_port(port_id);
 		}
 
-		unsigned char read_memory_byte(unsigned short memory_address) const
+		unsigned char read_memory_byte(size_type memory_address) const
 		{
 			return cartridge_->read_memory_byte(memory_address);
 		}

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -211,7 +211,7 @@ unsigned char multipak_cartridge::read_port(unsigned char port_id)
 	return 0;
 }
 
-unsigned char multipak_cartridge::read_memory_byte(unsigned short memory_address)
+unsigned char multipak_cartridge::read_memory_byte(size_type memory_address)
 {
 	vcc::utils::section_locker lock(mutex_);
 

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -63,7 +63,7 @@ public:
 	void stop() override;
 	void reset() override;
 
-	unsigned char read_memory_byte(unsigned short memory_address) override;
+	unsigned char read_memory_byte(size_type memory_address) override;
 
 	void write_port(unsigned char port_id, unsigned char value) override;
 	unsigned char read_port(unsigned char port_id) override;

--- a/orch90/orchestra90cc_cartridge.cpp
+++ b/orch90/orchestra90cc_cartridge.cpp
@@ -104,7 +104,7 @@ void orchestra90cc_cartridge::write_port(unsigned char Port,unsigned char Data)
 	}
 }
 
-unsigned char orchestra90cc_cartridge::read_memory_byte(unsigned short Address)
+unsigned char orchestra90cc_cartridge::read_memory_byte(size_type Address)
 {
 	return Rom[Address & 8191];
 }

--- a/orch90/orchestra90cc_cartridge.h
+++ b/orch90/orchestra90cc_cartridge.h
@@ -36,7 +36,7 @@ public:
 
 	void reset() override;
 
-	unsigned char read_memory_byte(unsigned short memory_address) override;
+	unsigned char read_memory_byte(size_type memory_address) override;
 
 	void write_port(unsigned char port_id, unsigned char value) override;
 

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -466,11 +466,11 @@ extern "C"
 
 
     // Return a byte from the current PAK ROM
-    __declspec(dllexport) unsigned char PakReadMemoryByte(unsigned short adr)
+    __declspec(dllexport) unsigned char PakReadMemoryByte(::std::size_t adr)
     {
         adr &= 0x3FFF;
         if (EnableBankWrite) {
-            return WriteFlashBank(adr);
+            return WriteFlashBank(static_cast<unsigned short>(adr));
         } else {
             BankWriteState = 0;  // Any read resets write state
             return(PakRom[adr]);


### PR DESCRIPTION
Changes the function signature of `cartridge.read_memory_byte` and `PakReadMemoryByteModuleFunction` to take a `size_t`/`size_type` as the address.