### PR TITLE
add disk_image abstract class and disk image implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vcc/disk11.rom
 *.swp
 *.*~
 *~
+/packages

--- a/Build.bat
+++ b/Build.bat
@@ -3,6 +3,7 @@
 
 set VCC_CONFIG=Release
 if exist "%VSINSTALLDIR%\MSBuild\Current\Bin\MSBuild.exe" (
+  nuget restore
   msbuild vcc.sln /m /p:Configuration=%VCC_CONFIG% /p:Platform=x86
   if errorlevel 0 (
     echo Find Vcc.exe in %cd%\__obj\Win32\%VCC_CONFIG%\vcc\out\vcc.exe

--- a/Vcc.sln
+++ b/Vcc.sln
@@ -27,6 +27,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sdc", "sdc\sdc.vcxproj", "{
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcommon", "libcommon\libcommon.vcxproj", "{E0AA25BD-5527-475F-8D8B-B549A6311B0C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcommon-test", "libcommon-test\libcommon-test.vcxproj", "{B4228078-E3E3-4664-9A84-C8674C71AD76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -106,6 +108,12 @@ Global
 		{E0AA25BD-5527-475F-8D8B-B549A6311B0C}.Legacy|x86.Build.0 = Legacy|Win32
 		{E0AA25BD-5527-475F-8D8B-B549A6311B0C}.Release|x86.ActiveCfg = Release|Win32
 		{E0AA25BD-5527-475F-8D8B-B549A6311B0C}.Release|x86.Build.0 = Release|Win32
+		{B4228078-E3E3-4664-9A84-C8674C71AD76}.Debug|x86.ActiveCfg = Debug|Win32
+		{B4228078-E3E3-4664-9A84-C8674C71AD76}.Debug|x86.Build.0 = Debug|Win32
+		{B4228078-E3E3-4664-9A84-C8674C71AD76}.Legacy|x86.ActiveCfg = Debug|Win32
+		{B4228078-E3E3-4664-9A84-C8674C71AD76}.Legacy|x86.Build.0 = Debug|Win32
+		{B4228078-E3E3-4664-9A84-C8674C71AD76}.Release|x86.ActiveCfg = Release|Win32
+		{B4228078-E3E3-4664-9A84-C8674C71AD76}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/libcommon-test/libcommon-test.vcxproj
+++ b/libcommon-test/libcommon-test.vcxproj
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{b4228078-e3e3-4664-9a84-c8674c71ad76}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="..\vcc-base.props" />
+    <Import Project="..\vcc-debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="..\vcc-base.props" />
+    <Import Project="..\vcc-debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="..\vcc-base.props" />
+    <Import Project="..\vss-release.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="..\vcc-base.props" />
+    <Import Project="..\vss-release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)__obj\$(Platform)\$(Configuration)\vcc\out\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)__obj\$(Platform)\$(Configuration)\vcc\out\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)__obj\$(Platform)\$(Configuration)\vcc\out\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)__obj\$(Platform)\$(Configuration)\vcc\out\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>_SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>_SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING;X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>_SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>_SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING;X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libcommon\libcommon.vcxproj">
+      <Project>{e0aa25bd-5527-475f-8d8b-b549a6311b0c}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\media\disk_images\test_generic_disk_image.h" />
+    <ClInclude Include="src\media\memory_stream_buffer.h" />
+    <ClInclude Include="src\media\test_disk_image.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\media\disk_images\test_generic_disk_image.cpp" />
+    <ClCompile Include="src\media\test_disk_image.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/libcommon-test/libcommon-test.vcxproj.filters
+++ b/libcommon-test/libcommon-test.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{3d8e57b8-dfc3-42b8-834f-74aeca5764c8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\media">
+      <UniqueIdentifier>{43779a20-4fad-4c5b-abce-e0898a332ecd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\media\disk_images">
+      <UniqueIdentifier>{f797b596-84b8-4706-9986-e69e965b2da6}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\media\memory_stream_buffer.h">
+      <Filter>src\media</Filter>
+    </ClInclude>
+    <ClInclude Include="src\media\disk_images\test_generic_disk_image.h">
+      <Filter>src\media\disk_images</Filter>
+    </ClInclude>
+    <ClInclude Include="src\media\test_disk_image.h">
+      <Filter>src\media</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\media\disk_images\test_generic_disk_image.cpp">
+      <Filter>src\media\disk_images</Filter>
+    </ClCompile>
+    <ClCompile Include="src\media\test_disk_image.cpp">
+      <Filter>src\media</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/libcommon-test/packages.config
+++ b/libcommon-test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.7" targetFramework="native" />
+</packages>

--- a/libcommon-test/src/media/disk_images/test_generic_disk_image.cpp
+++ b/libcommon-test/src/media/disk_images/test_generic_disk_image.cpp
@@ -1,0 +1,452 @@
+#include "test_generic_disk_image.h"
+#include <vcc/media/exceptions.h>
+
+
+// Validates the constructor throws an exception on invalid arguments.
+TEST_F(test_generic_disk_image, invalid_ctor_arguments)
+{
+	// Must throw on a nullptr stream
+	EXPECT_THROW(generic_disk_image({}, test_geometry_, 0, 0, false), ::std::invalid_argument);
+
+	// Must throw if stream is an fstream and not open.
+	EXPECT_THROW(
+		generic_disk_image(std::make_unique<std::fstream>(), test_geometry_, 0, 0, false),
+		::std::invalid_argument);
+
+#ifdef INCLUDE_INCOMPLETE_AND_BROKEN_LIBCOMMON_CODE
+	// Must throw if stream size is too small
+	auto stream(create_stream(buffer_stream_, test_geometry_));
+	buffer_stream_.resize(1);
+
+	EXPECT_THROW(
+		generic_disk_image(move(stream), test_geometry_, 0, 0, true),
+		::std::runtime_error);
+#endif
+}
+
+// Validates the head count returned is the same value passed to the constructor.
+TEST_F(test_generic_disk_image, is_write_protected)
+{
+	EXPECT_TRUE(generic_disk_image(
+		create_stream(buffer_stream_, test_geometry_),
+		test_geometry_,
+		0,
+		0,
+		true).is_write_protected());
+
+	EXPECT_FALSE(generic_disk_image(
+		create_stream(buffer_stream_, test_geometry_),
+		test_geometry_,
+		0,
+		0,
+		false).is_write_protected());
+}
+
+
+// Validates the head validation
+TEST_F(test_generic_disk_image, is_valid_disk_head)
+{
+	geometry_type geometry;
+	geometry.head_count = *std::max_element(test_value_sequence_.begin(), test_value_sequence_.end()) + 1;
+
+	for (const auto head : test_value_sequence_)
+	{
+		EXPECT_TRUE(generic_disk_image(create_stream(buffer_stream_, geometry), geometry).is_valid_disk_head(head));
+	}
+}
+
+// Validates the track validation
+TEST_F(test_generic_disk_image, is_valid_disk_track)
+{
+	geometry_type geometry;
+	geometry.track_count = *std::max_element(test_value_sequence_.begin(), test_value_sequence_.end()) + 1;
+
+	for (const auto track : test_value_sequence_)
+	{
+		EXPECT_TRUE(generic_disk_image(create_stream(buffer_stream_, geometry), geometry).is_valid_disk_track(track));
+	}
+}
+
+// Validates the head count returned is the same as the one specified in the geometry
+TEST_F(test_generic_disk_image, head_count_property)
+{
+	for (const auto head_count : test_value_sequence_)
+	{
+		geometry_type geometry;
+		geometry.head_count = head_count;
+
+		EXPECT_EQ(
+			generic_disk_image(create_stream(buffer_stream_, geometry), geometry).head_count(),
+			geometry.head_count);
+	}
+}
+
+// Validates the track count returned is the same as the one specified in the geometry
+TEST_F(test_generic_disk_image, track_count_property)
+{
+	for (const auto track_count : test_value_sequence_)
+	{
+		geometry_type geometry;
+		geometry.track_count = track_count;
+
+		EXPECT_EQ(
+			generic_disk_image(create_stream(buffer_stream_, geometry), geometry).track_count(),
+			geometry.track_count);
+	}
+}
+
+// Validates the sector count returned is the same as the one specified in the geometry
+TEST_F(test_generic_disk_image, sector_count_property)
+{
+	for (const auto head_count : test_value_sequence_)
+	{
+		geometry_type geometry;
+		geometry.head_count = head_count;
+
+		EXPECT_EQ(
+			generic_disk_image(create_stream(buffer_stream_, geometry), geometry).head_count(),
+			geometry.head_count);
+	}
+}
+
+// Validates the first valid sector id returned is the same as the one specified passed
+// to the constructor
+TEST_F(test_generic_disk_image, first_valid_sector_id_property)
+{
+	EXPECT_EQ(
+		generic_disk_image(create_stream(buffer_stream_, test_geometry_), test_geometry_, 0, 0).first_valid_sector_id(),
+		0);
+
+	EXPECT_EQ(
+		generic_disk_image(create_stream(buffer_stream_, test_geometry_), test_geometry_, 0, 1).first_valid_sector_id(),
+		1);
+
+	EXPECT_EQ(
+		generic_disk_image(create_stream(buffer_stream_, test_geometry_), test_geometry_, 0, 5).first_valid_sector_id(),
+		5);
+}
+
+// Validates the size of each sector on the disk can be retrieved.
+TEST_F(test_generic_disk_image, get_sector_size)
+{
+	iterate_geometry(
+		generic_disk_image{ create_stream(buffer_stream_, test_geometry_), test_geometry_},
+		buffer_stream_,
+		test_geometry_,
+		[](generic_disk_image& image,
+		   [[maybe_unused]] memory_stream_buffer& stream_buffer,
+		   const geometry_type& geometry,
+		   size_type head,
+		   size_type track,
+		   size_type sector)
+		{
+			ASSERT_EQ(
+				image.get_sector_size(
+					head,
+					track,
+					head,
+					track,
+					sector),
+				geometry.sector_size);
+		});
+}
+
+// Validates get sector size throws on invalid arguments
+TEST_F(test_generic_disk_image, get_sector_size_throws_on_invalid_arguments)
+{
+	generic_disk_image image(create_stream(buffer_stream_, test_geometry_), test_geometry_);
+
+	// Pass invalid disk head
+	EXPECT_THROW(
+		(void)image.get_sector_size(
+			test_geometry_.head_count,
+			0, // drive track
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id()),
+		std::invalid_argument);
+
+	// Pass invalid disk track
+	EXPECT_THROW(
+		(void)image.get_sector_size(
+			0, // drive head
+			test_geometry_.track_count,
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id()),
+		std::invalid_argument);
+
+	// Pass invalid head id
+	EXPECT_THROW(
+		(void)image.get_sector_size(
+			0, // drive head
+			0, // drive track
+			test_geometry_.head_count,
+			0, // track id
+			image.first_valid_sector_id()),
+		std::invalid_argument);
+
+	// Pass invalid track id
+	EXPECT_THROW(
+		(void)image.get_sector_size(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			test_geometry_.track_count,
+			image.first_valid_sector_id()),
+		std::invalid_argument);
+
+	// Pass invalid sector id
+	EXPECT_THROW(
+		(void)image.get_sector_size(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			0, // track id
+			test_geometry_.sector_count + image.first_valid_sector_id()),
+		std::invalid_argument);
+}
+
+// Validates sector record headers can be read for all valid sectors on the disk.
+TEST_F(test_generic_disk_image, query_sector_header_by_index_returns_all_known_headers)
+{
+	generic_disk_image image(create_stream(buffer_stream_, test_geometry_), test_geometry_);
+
+	for (auto head(0u); head < test_geometry_.head_count; ++head)
+	{
+		for (auto track(0u); track < test_geometry_.track_count; ++track)
+		{
+			for (auto sector(image.first_valid_sector_id());
+				 sector < test_geometry_.sector_count + image.first_valid_sector_id();
+				 ++sector)
+			{
+				const auto record(image.query_sector_header_by_index(head, track, sector));
+
+				EXPECT_TRUE(record.has_value());
+				EXPECT_EQ(record->head_id, head);
+				EXPECT_EQ(record->track_id, track);
+				EXPECT_EQ(record->sector_id, sector);
+			}
+		}
+	}
+}
+
+// Validates the query throws an exception on invalid arguments..
+TEST_F(test_generic_disk_image, query_sector_header_by_index_throws_on_invalid_arguments)
+{
+	generic_disk_image image(create_stream(buffer_stream_, test_geometry_), test_geometry_);
+
+	EXPECT_THROW(
+		((void)image.query_sector_header_by_index(test_geometry_.head_count, 0, image.first_valid_sector_id())),
+		std::invalid_argument);
+
+	EXPECT_THROW(
+		((void)image.query_sector_header_by_index(0, test_geometry_.track_count, image.first_valid_sector_id())),
+		std::invalid_argument);
+
+	EXPECT_GT(image.first_valid_sector_id(), 0u);
+	EXPECT_THROW(
+		((void)image.query_sector_header_by_index(0, test_geometry_.track_count, 0)),
+		std::invalid_argument);
+	EXPECT_THROW(
+		((void)image.query_sector_header_by_index(
+			0,
+			0,
+			test_geometry_.sector_count + image.first_valid_sector_id() + 1)),
+		std::invalid_argument);
+}
+
+// Validates all sector can be properly written to.
+TEST_F(test_generic_disk_image, read_sector)
+{
+	const geometry_type geometry{ 2, 8, 16, 16 };
+	const auto first_sector_id = 1;
+
+	generic_disk_image image(
+		create_stream(buffer_stream_, geometry),
+		geometry,
+		0,
+		first_sector_id,
+		false);
+
+	iterate_geometry(image, buffer_stream_, geometry, fill_sector);
+	iterate_geometry(image, buffer_stream_, geometry, validate_sector_read);
+}
+
+TEST_F(test_generic_disk_image, read_sector_throws_on_invalid_arguments)
+{
+	generic_disk_image image(create_stream(buffer_stream_, test_geometry_), test_geometry_);
+	buffer_type sector_buffer;
+
+	// Pass invalid disk head
+	EXPECT_THROW(
+		image.read_sector(
+			test_geometry_.head_count,
+			0, // drive track
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid disk track
+	EXPECT_THROW(
+		image.read_sector(
+			0, // drive head
+			test_geometry_.track_count,
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid head id
+	EXPECT_THROW(
+		image.read_sector(
+			0, // drive head
+			0, // drive track
+			test_geometry_.head_count,
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid track id
+	EXPECT_THROW(
+		image.read_sector(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			test_geometry_.track_count,
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid sector id
+	EXPECT_THROW(
+		image.read_sector(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			0, // track id
+			test_geometry_.sector_count + image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+}
+
+// Validates all sector can be properly read.
+TEST_F(test_generic_disk_image, write_sector)
+{
+	const geometry_type geometry{ 2, 8, 16, 16 };
+	const auto first_sector_id = 1;
+
+	generic_disk_image image(
+		create_stream(buffer_stream_, geometry),
+		geometry,
+		0,
+		first_sector_id,
+		false);
+
+	std::fill(buffer_stream_.begin(), buffer_stream_.end(), 0xff);
+	iterate_geometry(image, buffer_stream_, geometry, validate_sector_write);
+	iterate_geometry(image, buffer_stream_, geometry, validate_sector_data);
+}
+
+TEST_F(test_generic_disk_image, read_track)
+{
+	// TODO: implementation of read_track is pending. Tests deferred.
+}
+
+TEST_F(test_generic_disk_image, write_track)
+{
+	// TODO: completion of write_track is pending. Tests deferred.
+}
+
+TEST_F(test_generic_disk_image, write_track_throws_on_invalid_arguments)
+{
+	generic_disk_image image(create_stream(buffer_stream_, test_geometry_), test_geometry_);
+	buffer_type sector_buffer;
+
+	// Pass invalid disk head
+	EXPECT_THROW(
+		image.write_sector(
+			test_geometry_.head_count,
+			0, // drive track
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid disk track
+	EXPECT_THROW(
+		image.write_sector(
+			0, // drive head
+			test_geometry_.track_count,
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid head id
+	EXPECT_THROW(
+		image.write_sector(
+			0, // drive head
+			0, // drive track
+			test_geometry_.head_count,
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid track id
+	EXPECT_THROW(
+		image.write_sector(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			test_geometry_.track_count,
+			image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid sector id
+	EXPECT_THROW(
+		image.write_sector(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			0, // track id
+			test_geometry_.sector_count + image.first_valid_sector_id(),
+			sector_buffer),
+		std::invalid_argument);
+
+	// Pass invalid sector id
+	EXPECT_THROW(
+		image.write_sector(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		vcc::media::buffer_size_error);
+}
+
+TEST_F(test_generic_disk_image, write_track_throws_on_write_protected_disks)
+{
+	generic_disk_image image(create_stream(buffer_stream_, test_geometry_), test_geometry_, 0, 1, true);
+	buffer_type sector_buffer(test_geometry_.sector_size);
+
+	// Pass invalid disk head
+	EXPECT_THROW(
+		image.write_sector(
+			0, // drive head
+			0, // drive track
+			0, // head id
+			0, // track id
+			image.first_valid_sector_id(),
+			sector_buffer),
+		vcc::media::write_protect_error);
+}

--- a/libcommon-test/src/media/disk_images/test_generic_disk_image.cpp
+++ b/libcommon-test/src/media/disk_images/test_generic_disk_image.cpp
@@ -6,12 +6,12 @@
 TEST_F(test_generic_disk_image, invalid_ctor_arguments)
 {
 	// Must throw on a nullptr stream
-	EXPECT_THROW(generic_disk_image({}, test_geometry_, 0, 0, false), ::std::invalid_argument);
+	EXPECT_THROW(generic_disk_image({}, test_geometry_, 0, 0, false), std::invalid_argument);
 
 	// Must throw if stream is an fstream and not open.
 	EXPECT_THROW(
 		generic_disk_image(std::make_unique<std::fstream>(), test_geometry_, 0, 0, false),
-		::std::invalid_argument);
+		std::invalid_argument);
 
 #ifdef INCLUDE_INCOMPLETE_AND_BROKEN_LIBCOMMON_CODE
 	// Must throw if stream size is too small
@@ -20,7 +20,7 @@ TEST_F(test_generic_disk_image, invalid_ctor_arguments)
 
 	EXPECT_THROW(
 		generic_disk_image(move(stream), test_geometry_, 0, 0, true),
-		::std::runtime_error);
+		std::runtime_error);
 #endif
 }
 

--- a/libcommon-test/src/media/disk_images/test_generic_disk_image.h
+++ b/libcommon-test/src/media/disk_images/test_generic_disk_image.h
@@ -1,0 +1,177 @@
+#pragma once
+#include "../memory_stream_buffer.h"
+#include "vcc/media/disk_images/generic_disk_image.h"
+#include "gtest/gtest.h"
+#include <fstream>
+#include <functional>
+
+
+class test_generic_disk_image : public testing::Test
+{
+protected:
+
+	using generic_disk_image = ::vcc::media::disk_images::generic_disk_image;
+	using size_type = generic_disk_image::size_type;
+	using geometry_type = generic_disk_image::geometry_type;
+	using buffer_type = generic_disk_image::buffer_type;
+
+	// FIXME: Remove first_sector_id from parameter list
+	using geometry_iterator_function_type = void(
+		generic_disk_image& image,
+		memory_stream_buffer&,
+		const geometry_type&,
+		size_type,
+		size_type,
+		size_type);
+
+
+protected:
+
+	static geometry_type create_geometry(
+		size_type head_count = 2,
+		size_type track_count = 8,
+		size_type sector_count = 16,
+		size_type sector_size = 16)
+	{
+		geometry_type geometry;
+
+		geometry.head_count = head_count;
+		geometry.track_count = track_count;
+		geometry.sector_count = sector_count;
+		geometry.sector_size = sector_size;
+
+		return geometry;
+	}
+
+	static std::unique_ptr<generic_disk_image::stream_type> create_stream(
+		memory_stream_buffer& stream_buffer,
+		const geometry_type& geometry = test_geometry_)
+	{
+		const auto image_size(geometry.head_count * geometry.track_count * geometry.sector_count * geometry.sector_size);
+
+		stream_buffer.resize(image_size);
+		return std::make_unique<generic_disk_image::stream_type>(&stream_buffer);
+	}
+
+	void iterate_geometry(
+		generic_disk_image& image,
+		memory_stream_buffer& stream_buffer,
+		const geometry_type& geometry,
+		std::function<geometry_iterator_function_type> callback) const
+	{
+		for (auto head(0u); head < geometry.head_count; ++head)
+		{
+			for (auto track(0u); track < geometry.track_count; ++track)
+			{
+				for (auto sector(image.first_valid_sector_id());
+					 sector < geometry.sector_count + image.first_valid_sector_id();
+					 ++sector)
+				{
+					callback(image, stream_buffer, geometry, head, track, sector);
+				}
+			}
+		}
+	}
+
+	static buffer_type::value_type make_validation_id(size_type head, size_type track, size_type sector)
+	{
+		return  static_cast<buffer_type::value_type>((head << 7) | (track << 4) | sector);
+	}
+
+
+	static size_type calculate_sector_position(
+		const geometry_type& geometry,
+		size_type first_sector_id,
+		size_type head,
+		size_type track,
+		size_type sector)
+	{
+		const auto track_size(geometry.sector_count * geometry.sector_size);
+		const auto image_offset(0);	//	FIXME: need this
+
+		const auto head_offset(head * track_size * geometry.track_count);
+		const auto track_offset(track * track_size);
+		const auto sector_offset((sector - first_sector_id) * geometry.sector_size);
+
+		return image_offset + head_offset + track_offset + sector_offset;
+	}
+
+	static void fill_sector(
+		generic_disk_image& image,
+		memory_stream_buffer& stream_buffer,
+		const geometry_type& geometry,
+		size_type head,
+		size_type track,
+		size_type sector)
+	{
+		const auto sector_position(calculate_sector_position(geometry, image.first_valid_sector_id(), head, track, sector));
+		const auto id(make_validation_id(head, track, sector - image.first_valid_sector_id()));
+		for (auto i(0u); i < geometry.sector_size; ++i)
+		{
+			stream_buffer[sector_position + i] = id;
+		}
+	}
+
+	static void validate_sector_read(
+		generic_disk_image& image,
+		[[maybe_unused]] memory_stream_buffer& stream_buffer,
+		const geometry_type& geometry,
+		size_type head,
+		size_type track,
+		size_type sector)
+	{
+		buffer_type sector_buffer;
+
+		image.read_sector(head, track, head, track, sector, sector_buffer);
+		ASSERT_EQ(sector_buffer.size(), geometry.sector_size);
+
+		const auto id(make_validation_id(head, track, sector - image.first_valid_sector_id()));
+		for (const auto& data : sector_buffer)
+		{
+			ASSERT_EQ(data, id);
+		}
+	};
+
+	static void validate_sector_write(
+		generic_disk_image& image,
+		[[maybe_unused]] memory_stream_buffer& stream_buffer,
+		const geometry_type& geometry,
+		size_type head,
+		size_type track,
+		size_type sector)
+	{
+		buffer_type sector_buffer(geometry.sector_size);
+
+		const auto id(make_validation_id(head, track, sector - image.first_valid_sector_id()));
+		for (auto& data : sector_buffer)
+		{
+			data = id;
+		}
+
+		(void)image.write_sector(head, track, head, track, sector, sector_buffer);
+	};
+
+	static void validate_sector_data(
+		generic_disk_image& image,
+		memory_stream_buffer& stream_buffer,
+		const geometry_type& geometry,
+		size_type head,
+		size_type track,
+		size_type sector)
+	{
+		const auto sector_position(calculate_sector_position(geometry, image.first_valid_sector_id(), head, track, sector));
+		const auto id(make_validation_id(head, track, sector - image.first_valid_sector_id()));
+
+		for (auto i(0u); i < geometry.sector_size; ++i)
+		{
+			ASSERT_EQ(stream_buffer[sector_position + i], id);
+		}
+	};
+
+protected:
+
+	static const inline geometry_type test_geometry_ = create_geometry();
+	memory_stream_buffer buffer_stream_;
+	buffer_type sector_buffer_;
+	static const inline auto test_value_sequence_ = { 1, 2, 3, 4, 5, 10 };
+};

--- a/libcommon-test/src/media/memory_stream_buffer.h
+++ b/libcommon-test/src/media/memory_stream_buffer.h
@@ -8,8 +8,8 @@
 class memory_stream_buffer : public std::strstreambuf
 {
 public:
-	using size_type = ::std::size_t;
-	using buffer_type = ::std::vector<unsigned char>;
+	using size_type = std::size_t;
+	using buffer_type = std::vector<unsigned char>;
 	using iterator = buffer_type::iterator;
 	using const_iterator = buffer_type::const_iterator;
 	using value_type = buffer_type::value_type;

--- a/libcommon-test/src/media/memory_stream_buffer.h
+++ b/libcommon-test/src/media/memory_stream_buffer.h
@@ -1,0 +1,66 @@
+#pragma once
+#include <vector>
+#include <strstream>
+
+
+// FIXME: strstreambuf is deprecated but used here until a new solution that is
+// lighter than the current alternative.
+class memory_stream_buffer : public std::strstreambuf
+{
+public:
+	using size_type = ::std::size_t;
+	using buffer_type = ::std::vector<unsigned char>;
+	using iterator = buffer_type::iterator;
+	using const_iterator = buffer_type::const_iterator;
+	using value_type = buffer_type::value_type;
+
+	memory_stream_buffer() = default;
+
+	void resize(size_type size)
+	{
+		buffer_.resize(size);
+
+		setg(reinterpret_cast<char_type*>(buffer_.data()),
+			 reinterpret_cast<char_type*>(buffer_.data()),
+			 reinterpret_cast<char_type*>(buffer_.data() + buffer_.size()));
+
+		setp(reinterpret_cast<char_type*>(buffer_.data()),
+			 reinterpret_cast<char_type*>(buffer_.data()),
+			 reinterpret_cast<char_type*>(buffer_.data() + buffer_.size()));
+	}
+
+	iterator begin()
+	{
+		return buffer_.begin();
+	}
+
+	iterator end()
+	{
+		return buffer_.end();
+	}
+
+	const_iterator begin() const
+	{
+		return buffer_.begin();
+	}
+
+	const_iterator end() const
+	{
+		return buffer_.end();
+	}
+
+	value_type& operator[](size_type index)
+	{
+		return buffer_[index];
+	}
+
+	value_type operator[](size_type index) const
+	{
+		return buffer_[index];
+	}
+
+
+private:
+
+	buffer_type buffer_;
+};

--- a/libcommon-test/src/media/test_disk_image.cpp
+++ b/libcommon-test/src/media/test_disk_image.cpp
@@ -1,0 +1,99 @@
+#include "test_disk_image.h"
+#include <vcc/media/exceptions.h>
+
+
+// Validates the constructor throws an exception on invalid arguments.
+TEST_F(test_disk_image, invalid_ctor_arguments)
+{
+	// Must throw on 0 heads
+	EXPECT_THROW(disk_image({ 0, 1 }), ::std::invalid_argument);
+
+	// Must throw on 0 tracks
+	EXPECT_THROW(disk_image({ 1, 0 }), ::std::invalid_argument);
+}
+
+// Validates the head count returned is the same as the one specified in the geometry
+TEST_F(test_disk_image, head_count_property)
+{
+	for (const auto head_count : test_value_sequence_)
+	{
+		geometry_type geometry;
+		geometry.head_count = head_count;
+
+		EXPECT_EQ(disk_image(geometry).head_count(), geometry.head_count);
+	}
+}
+
+// Validates the sector count returned is the same as the one specified in the geometry
+TEST_F(test_disk_image, sector_count_property)
+{
+	for (const auto track_count : test_value_sequence_)
+	{
+		geometry_type geometry;
+		geometry.track_count = track_count;
+
+		EXPECT_EQ(disk_image(geometry).track_count(), geometry.track_count);
+	}
+}
+
+// Validates the first valid sector id returned is the same as the one specified passed
+// to the constructor
+TEST_F(test_disk_image, first_valid_sector_id_property)
+{
+	EXPECT_EQ(disk_image(test_geometry_, 0).first_valid_sector_id(), 0);
+	EXPECT_EQ(disk_image(test_geometry_, 1).first_valid_sector_id(), 1);
+	EXPECT_EQ(disk_image(test_geometry_, 5).first_valid_sector_id(), 5);
+}
+
+// Validates the head count returned is the same value passed to the constructor.
+TEST_F(test_disk_image, is_write_protected)
+{
+	EXPECT_TRUE(disk_image(test_geometry_, 0, true).is_write_protected());
+	EXPECT_FALSE(disk_image(test_geometry_, 0, false).is_write_protected());
+}
+
+// Validates the head validation
+TEST_F(test_disk_image, is_valid_disk_head)
+{
+	geometry_type geometry;
+	geometry.head_count = *std::max_element(test_value_sequence_.begin(), test_value_sequence_.end()) + 1;
+
+	for (const auto head : test_value_sequence_)
+	{
+		EXPECT_TRUE(disk_image(geometry).is_valid_disk_head(head));
+	}
+}
+
+// Validates the head validation return false on invalid head
+TEST_F(test_disk_image, is_valid_disk_head_fails_on_invalid_head)
+{
+	geometry_type geometry;
+	geometry.head_count = 1;
+
+	EXPECT_FALSE(disk_image(geometry).is_valid_disk_head(geometry.head_count + 1));
+	EXPECT_FALSE(disk_image(geometry).is_valid_disk_head(geometry.head_count + 2));
+	EXPECT_FALSE(disk_image(geometry).is_valid_disk_head(geometry.head_count + 10));
+}
+
+// Validates the track validation
+TEST_F(test_disk_image, is_valid_disk_track)
+{
+	geometry_type geometry;
+	geometry.track_count = *std::max_element(test_value_sequence_.begin(), test_value_sequence_.end()) + 1;
+
+	for (const auto track : test_value_sequence_)
+	{
+		EXPECT_TRUE(disk_image(geometry).is_valid_disk_track(track));
+	}
+}
+
+// Validates the track validation failed on invalid track
+TEST_F(test_disk_image, is_valid_disk_track_fails_on_invalid_track)
+{
+	geometry_type geometry;
+	geometry.track_count = 1;
+
+	EXPECT_FALSE(disk_image(geometry).is_valid_disk_head(geometry.track_count + 1));
+	EXPECT_FALSE(disk_image(geometry).is_valid_disk_head(geometry.track_count + 2));
+	EXPECT_FALSE(disk_image(geometry).is_valid_disk_head(geometry.track_count + 10));
+}

--- a/libcommon-test/src/media/test_disk_image.cpp
+++ b/libcommon-test/src/media/test_disk_image.cpp
@@ -6,10 +6,10 @@
 TEST_F(test_disk_image, invalid_ctor_arguments)
 {
 	// Must throw on 0 heads
-	EXPECT_THROW(disk_image({ 0, 1 }), ::std::invalid_argument);
+	EXPECT_THROW(disk_image({ 0, 1 }), std::invalid_argument);
 
 	// Must throw on 0 tracks
-	EXPECT_THROW(disk_image({ 1, 0 }), ::std::invalid_argument);
+	EXPECT_THROW(disk_image({ 1, 0 }), std::invalid_argument);
 }
 
 // Validates the head count returned is the same as the one specified in the geometry

--- a/libcommon-test/src/media/test_disk_image.h
+++ b/libcommon-test/src/media/test_disk_image.h
@@ -1,0 +1,126 @@
+#pragma once
+#include "vcc/media/disk_image.h"
+#include "gtest/gtest.h"
+#include <fstream>
+#include <functional>
+
+
+class concrete_disk_image : public ::vcc::media::disk_image
+{ 
+public:
+
+	using ::vcc::media::disk_image::disk_image;
+
+
+	//[[nodiscard]] size_type get_sector_count(
+	//	size_type disk_head,
+	//	size_type disk_track) const override
+	//{
+	//	throw std::runtime_error("Cannot test abstract member function.");
+	//}
+
+	//[[nodiscard]] bool is_valid_track_sector(
+	//	size_type disk_head,
+	//	size_type disk_track,
+	//	size_type disk_sector) const noexcept override
+	//{
+	//	return false;
+	//}
+
+	[[nodiscard]] bool is_valid_sector_record(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id) const noexcept override
+	{
+		return false;
+	}
+
+	/// @inheritdoc
+	[[nodiscard]] size_type get_sector_size(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id) const override
+	{
+		throw std::runtime_error("Cannot test abstract member function.");
+	}
+
+	/// @inheritdoc
+	[[nodiscard]] std::optional<sector_record_header_type> query_sector_header_by_index(
+		size_type disk_head,
+		size_type disk_track,
+		size_type disk_sector) const override
+	{
+		throw std::runtime_error("Cannot test abstract member function.");
+	}
+
+	/// @inheritdoc
+	void read_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id,
+		buffer_type& data_buffer) override
+	{
+		throw std::runtime_error("Cannot test abstract member function.");
+	}
+
+	/// @inheritdoc
+	void write_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id,
+		const buffer_type& data_buffer) override
+	{
+		throw std::runtime_error("Cannot test abstract member function.");
+	}
+
+	/// @inheritdoc
+	[[nodiscard]] sector_record_vector read_track(
+		size_type disk_head,
+		size_type disk_track) override
+	{
+		throw std::runtime_error("Cannot test abstract member function.");
+	}
+
+	/// @inheritdoc
+	void write_track(
+		size_type disk_head,
+		size_type disk_track,
+		const sector_record_vector& sectors) override
+	{
+		throw std::runtime_error("Cannot test abstract member function.");
+	}
+
+protected:
+
+	size_type get_sector_count_unchecked(
+		size_type disk_head,
+		size_type disk_track) const noexcept override
+	{
+		return 0;
+	}
+
+};
+
+
+class test_disk_image : public testing::Test
+{
+protected:
+
+	using disk_image = concrete_disk_image;
+	using size_type = disk_image::size_type;
+	using geometry_type = disk_image::geometry_type;
+
+
+protected:
+
+	static const inline geometry_type test_geometry_ = { 2, 8 };
+	static const inline auto test_value_sequence_ = { 1, 2, 3, 4, 5, 10 };
+};

--- a/libcommon/include/vcc/media/disk_geometry.h
+++ b/libcommon/include/vcc/media/disk_geometry.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstddef>
+
+
+namespace vcc::media
+{
+
+	/// @brief Describes the geometry of a disk device or image.
+	struct disk_geometry
+	{
+		/// @brief Specifies the type used to store geometry properties.
+		using size_type = ::std::size_t;
+
+		/// @brief The number of heads on the drive or image. This member is initialized with a
+		/// value of 1.
+		size_type head_count = 1;
+		/// @brief The number of tracks on the drive or image. This member is initialized with
+		/// a default value of 35.
+		size_type track_count = 35;
+	};
+
+}

--- a/libcommon/include/vcc/media/disk_image.h
+++ b/libcommon/include/vcc/media/disk_image.h
@@ -1,0 +1,312 @@
+#pragma once
+#include <vcc/media/disk_geometry.h>
+#include <vcc/media/sector_record.h>
+#include <vcc/detail/exports.h>
+#include <optional>
+#include <vector>
+
+#define VIRTUAL
+
+namespace vcc::media
+{
+
+	/// @brief Defines the shape of the Disk Image interface for accessing virtual disk
+	/// images.
+	/// 
+	/// This abstract class defines the fundamental operations for reading and writing
+	/// track and sector data stored in a file containing a virtual disk image.
+	class LIBCOMMON_EXPORT disk_image
+	{
+	public:
+
+		/// @brief Specifies the type specifying a size or length.
+		using size_type = ::std::size_t;
+		/// @brief The type used to hold geometry describing the disk capacity.
+		using geometry_type = ::vcc::media::disk_geometry;
+		/// @brief Specifies the type used to represent a sector record.
+		using sector_record_type = ::vcc::media::sector_record;
+		/// @brief Specifies the type used to represent a sector record header.
+		using sector_record_header_type = sector_record_header;
+		/// @brief The type of buffer used to store sector data.
+		using buffer_type = std::vector<unsigned char>;
+		/// @brief The type of a vector of sector records.
+		using sector_record_vector = std::vector<sector_record_type>;
+
+
+	public:
+
+		/// @brief Constructs a Disk Image.
+		/// 
+		/// @todo this should thrown if either the track or head is 0.
+		/// 
+		/// @param geometry The geometry of the disk.
+		/// @param first_valid_sector_id The first identifier that can be used for a sector.
+		/// @param write_protected Specifies if the disk is write protected or not.
+		/// 
+		/// @throws std::invalid_argument The number of heads specified in the geometry is 0.
+		/// @throws std::invalid_argument The number of tracks specified in the geometry is 0.
+		explicit disk_image(
+			const geometry_type& geometry = {},
+			size_type first_valid_sector_id = 1,
+			bool write_protected = false);
+
+		virtual ~disk_image() = default;
+
+		/// @brief Indicates the total number of heads in supported by the disk.
+		/// 
+		/// @return A value greater than 0 (zero) specifying the number of heads.
+		[[nodiscard]] VIRTUAL size_type head_count() const noexcept;
+
+		/// @brief Indicates the total number of tracks in supported by the disk.
+		/// 
+		/// @return A value greater than 0 (zero) specifying the number of heads.
+		[[nodiscard]] VIRTUAL size_type track_count() const noexcept;
+
+		/// @brief Retrieves the first valid sector id supported by the disk.
+		/// 
+		/// @todo: Different file formats store the sector id differently and requires it
+		/// be handled here, however this can probably go away if the image implementation
+		/// handles it internally and/or the primary consumer up the call-chain always uses
+		/// a base 0 sector id - but that may not always work. This however may not be possible.
+		/// 
+		/// @return The first valid sector identifier.
+		[[nodiscard]] VIRTUAL size_type first_valid_sector_id() const noexcept;
+
+		/// @brief Indicates if the disk is write protected.
+		/// 
+		/// Indicates if the disk is in write protect mode and cannot be written to.
+		/// 
+		/// @return `true` if the disk is write protected; otherwise `false`.
+		[[nodiscard]] VIRTUAL bool is_write_protected() const noexcept;
+
+
+		/// @brief Retrieve the number of sectors available on a specific head and track.
+		/// 
+		/// Retrieves the number of sectors available on a specific head and track of the disk
+		/// image. If either the head or the track do not exist in the image, an exception is
+		/// thrown.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// 
+		/// @return The total number of sectors or 0 (zero) if the track has no sectors.
+		/// 
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
+		[[nodiscard]] VIRTUAL size_type get_sector_count(
+			size_type disk_head,
+			size_type disk_track) const;
+
+
+		/// @brief Check if the disk image contains a specific head.
+		/// 
+		/// @param disk_head The head to validate.
+		/// 
+		/// @return `true` if the head exists on the disk; `false` otherwise.
+		[[nodiscard]] VIRTUAL bool is_valid_disk_head(size_type disk_head) const noexcept;
+
+		/// @brief Check if the disk image contains a specific track on a specific head.
+		/// 
+		/// @param disk_track The track to validate.
+		/// 
+		/// @return `true` if the track exists on the disk; `false` otherwise.
+		[[nodiscard]] VIRTUAL bool is_valid_disk_track(size_type disk_track) const noexcept;
+
+		/// @brief Check if the disk image contains a sector on a specific head and track.
+		/// 
+		/// Check if a sector at a specific 0 (zero) based index of a head and track exists in
+		/// the disk.
+		/// 
+		/// @todo maybe expand on the index nature of the sector - is_valid_sector_index or is_valid_track_sector_index.
+		/// 
+		/// @param disk_head The head the track is on.
+		/// @param disk_track The track to validate.
+		/// @param disk_sector The zero based index of the sector to validate.
+		/// 
+		/// @return `true` if the track exists on the disk; `false` otherwise.
+		[[nodiscard]] VIRTUAL bool is_valid_track_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type disk_sector) const noexcept;
+
+		/// @brief Check if the disk image contains a specific sector record.
+		/// 
+		/// Check if a sector matching specific head, track, and sector identifiers exists
+		/// on the disk.
+		/// 
+		/// @todo declare this as `noexcept` once the unchecked version of functions it uses are available.
+		/// @todo possibly make public for read/write validation. Add to base class if moved.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param head_id The head identifier assigned to the sector to check for.
+		/// @param track_id The track identifier assigned to the sector to check for.
+		/// @param sector_id The sector identifier assigned to the sector to check for.
+		/// 
+		/// @return `true` if the sector exists; `false` otherwise.
+		[[nodiscard]] virtual bool is_valid_sector_record(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const noexcept = 0;
+
+
+		/// @brief Retrieve the number of size in bytes of a specific sector.
+		/// 
+		/// Retrieves the size in bytes of a specific sector on a specific head and track of
+		/// the disk. Every sector stored on the disk is stored in a sector record that
+		/// includes identifying properties such as head, track, and sector ids that are
+		/// different than the physical head and track of the disk. These properties are used
+		/// to identify the sector to retrieve the size of.
+		/// 
+		/// If either the head or the track do not exist in the image, or if the track does not
+		/// contain a sector that matches the specified identifiers an exception is thrown.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param head_id The head identifier assigned to the sector to retrieve the size for.
+		/// @param track_id The track identifier assigned to the sector to retrieve the size for.
+		/// @param sector_id The sector identifier assigned to the sector to retrieve the size for.
+		/// 
+		/// @return The size in bytes of the specified sector.
+		/// 
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
+		/// @throws std::invalid_argument if a sector record matching the head, track, and sector identifiers
+		/// does not exist.
+		[[nodiscard]] virtual size_type get_sector_size(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const = 0;
+
+		/// @brief Tries to retrieve the set of properties stored in a sector header.
+		/// 
+		/// @todo Add a sibling `query_sector_header_by_id` to fetch the record as usually
+		/// requested by the disk controller.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param disk_sector The 0 (zero) based index of the sector to retrieve
+		/// properties for.
+		/// @return The properties of the sector header if the sector exists; en empty value
+		/// otherwise.
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
+		/// @throws std::invalid_argument if the sector at the index specified in `disk_sector` does not exist.
+		[[nodiscard]] virtual std::optional<sector_record_header_type> query_sector_header_by_index(
+			size_type disk_head,
+			size_type disk_track,
+			size_type disk_sector) const = 0;
+
+		/// @brief Reads a sector from the disk.
+		/// 
+		/// Reads the first sector on a specified head and track of the disk that matches the
+		/// specific set of head, track, and sector identifiers, resizing the data buffer to
+		/// the exact size of the sector.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param head_id The head identifier assigned to the sector to read.
+		/// @param track_id The track identifier assigned to the sector to read.
+		/// @param sector_id The sector identifier assigned to the sector to read.
+		/// @param data_buffer The buffer to store the sector data in.
+		/// 
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
+		/// @throws std::invalid_argument if a sector record matching the head, track, and sector identifiers
+		virtual void read_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id,
+			buffer_type& data_buffer) = 0;
+
+		/// @brief Writes a sector to the disk.
+		/// 
+		/// Writes a block of data to the first sector on a specified head and track of the
+		/// disk that matches the specific set of head, track, and sector identifiers.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param head_id The head identifier assigned to the sector to write.
+		/// @param track_id The track identifier assigned to the sector to write.
+		/// @param sector_id The sector identifier assigned to the sector to write.
+		/// @param data_buffer The buffer containing the data to write to the sector.
+		/// 
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not
+		/// exist.
+		/// @throws std::invalid_argument if a sector record matching the head, track,
+		/// and sector identifiers.
+		/// @throws vcc::media::buffer_size_error if the sector buffer is smaller than the
+		/// sector it is being written to.
+		/// @throws vcc::media::fatal_io_error If the file position of the sector data cannot
+		/// be access.
+		/// @throws vcc::media::write_protect_error If the disk image has its write protect
+		/// flag enabled.
+		/// @throws vcc::media::fatal_io_error If an IO error occurs while reading the sector
+		/// data.
+		virtual void write_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id,
+			const buffer_type& data_buffer) = 0;
+
+		/// @brief Reads an entire set of sector records from a track on the disk.
+		/// 
+		/// @todo This function is not implemented yet.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// 
+		/// @return A collection of sector records in the same order they are stored in on the
+		/// disk.
+		/// 
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
+		[[nodiscard]] virtual sector_record_vector read_track(
+			size_type disk_head,
+			size_type disk_track) = 0;
+
+		/// @brief Writes an entire set of sector records to a track on the disk.
+		/// 
+		/// Writes an entire set of sector records, in the order they are stored in a
+		/// the collection passed here, to a track on the disk.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param sectors The collection of sectors to write.
+		/// 
+		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
+		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
+		/// @throws vcc::media::write_protect_error If the disk image has its write protect
+		/// flag enabled.
+		/// @throws vcc::media::sector_record_error If a sector record being written is
+		/// encountered with invalid parameters.
+		virtual void write_track(
+			size_type disk_head,
+			size_type disk_track,
+			const sector_record_vector& sectors) = 0;
+
+
+	protected:
+
+		[[nodiscard]] virtual size_type get_sector_count_unchecked(
+			size_type disk_head,
+			size_type disk_track) const noexcept = 0;
+
+	private:
+
+		const size_type head_count_;
+		const size_type track_count_;
+		const size_type first_valid_sector_id_;
+		const bool write_protected_;
+	};
+
+}

--- a/libcommon/include/vcc/media/disk_image.h
+++ b/libcommon/include/vcc/media/disk_image.h
@@ -297,6 +297,19 @@ namespace vcc::media
 
 	protected:
 
+		/// @brief Retrieve the number of sectors available on a specific head and track.
+		/// 
+		/// Retrieves the number of sectors available on a specific head and track of the disk
+		/// image without validating the head and track parameters are valid.
+		/// 
+		/// @param disk_head The head the sector is stored on. This value must be a valid
+		/// head in the disk image. If this value is not valid the behavior of the function
+		/// is undefined.
+		/// @param disk_track The track the sector is stored in. This value must be a valid
+		/// head in the disk image. If this value is not valid the behavior of the function
+		/// is undefined.
+		/// 
+		/// @return The total number of sectors or 0 (zero) if the track has no sectors.
 		[[nodiscard]] virtual size_type get_sector_count_unchecked(
 			size_type disk_head,
 			size_type disk_track) const noexcept = 0;

--- a/libcommon/include/vcc/media/disk_image.h
+++ b/libcommon/include/vcc/media/disk_image.h
@@ -5,7 +5,6 @@
 #include <optional>
 #include <vector>
 
-#define VIRTUAL
 
 namespace vcc::media
 {
@@ -55,12 +54,12 @@ namespace vcc::media
 		/// @brief Indicates the total number of heads in supported by the disk.
 		/// 
 		/// @return A value greater than 0 (zero) specifying the number of heads.
-		[[nodiscard]] VIRTUAL size_type head_count() const noexcept;
+		[[nodiscard]] virtual size_type head_count() const noexcept;
 
 		/// @brief Indicates the total number of tracks in supported by the disk.
 		/// 
 		/// @return A value greater than 0 (zero) specifying the number of heads.
-		[[nodiscard]] VIRTUAL size_type track_count() const noexcept;
+		[[nodiscard]] virtual size_type track_count() const noexcept;
 
 		/// @brief Retrieves the first valid sector id supported by the disk.
 		/// 
@@ -70,14 +69,14 @@ namespace vcc::media
 		/// a base 0 sector id - but that may not always work. This however may not be possible.
 		/// 
 		/// @return The first valid sector identifier.
-		[[nodiscard]] VIRTUAL size_type first_valid_sector_id() const noexcept;
+		[[nodiscard]] virtual size_type first_valid_sector_id() const noexcept;
 
 		/// @brief Indicates if the disk is write protected.
 		/// 
 		/// Indicates if the disk is in write protect mode and cannot be written to.
 		/// 
 		/// @return `true` if the disk is write protected; otherwise `false`.
-		[[nodiscard]] VIRTUAL bool is_write_protected() const noexcept;
+		[[nodiscard]] virtual bool is_write_protected() const noexcept;
 
 
 		/// @brief Retrieve the number of sectors available on a specific head and track.
@@ -93,7 +92,7 @@ namespace vcc::media
 		/// 
 		/// @throws std::invalid_argument if the head specified in `disk_head` does not exist.
 		/// @throws std::invalid_argument if the track specified in `disk_track` does not exist.
-		[[nodiscard]] VIRTUAL size_type get_sector_count(
+		[[nodiscard]] virtual size_type get_sector_count(
 			size_type disk_head,
 			size_type disk_track) const;
 
@@ -103,14 +102,14 @@ namespace vcc::media
 		/// @param disk_head The head to validate.
 		/// 
 		/// @return `true` if the head exists on the disk; `false` otherwise.
-		[[nodiscard]] VIRTUAL bool is_valid_disk_head(size_type disk_head) const noexcept;
+		[[nodiscard]] virtual bool is_valid_disk_head(size_type disk_head) const noexcept;
 
 		/// @brief Check if the disk image contains a specific track on a specific head.
 		/// 
 		/// @param disk_track The track to validate.
 		/// 
 		/// @return `true` if the track exists on the disk; `false` otherwise.
-		[[nodiscard]] VIRTUAL bool is_valid_disk_track(size_type disk_track) const noexcept;
+		[[nodiscard]] virtual bool is_valid_disk_track(size_type disk_track) const noexcept;
 
 		/// @brief Check if the disk image contains a sector on a specific head and track.
 		/// 
@@ -124,7 +123,7 @@ namespace vcc::media
 		/// @param disk_sector The zero based index of the sector to validate.
 		/// 
 		/// @return `true` if the track exists on the disk; `false` otherwise.
-		[[nodiscard]] VIRTUAL bool is_valid_track_sector(
+		[[nodiscard]] virtual bool is_valid_track_sector(
 			size_type disk_head,
 			size_type disk_track,
 			size_type disk_sector) const noexcept;

--- a/libcommon/include/vcc/media/disk_images/generic_disk_image.h
+++ b/libcommon/include/vcc/media/disk_images/generic_disk_image.h
@@ -22,9 +22,9 @@ namespace vcc::media::disk_images
 		/// @brief The type used to hold geometry describing the disk capacity.
 		using geometry_type = ::vcc::media::geometry::generic_disk_geometry;
 		/// @brief The type of stream used to access the disk image file.
-		using stream_type = ::std::iostream;
+		using stream_type = std::iostream;
 		/// @brief The type used to hold a pointer to the stream used to access the disk image file.
-		using stream_ptr_type = ::std::unique_ptr<stream_type>;
+		using stream_ptr_type = std::unique_ptr<stream_type>;
 		/// @brief The type used to store a position in the disk image file.
 		using position_type = stream_type::pos_type;
 

--- a/libcommon/include/vcc/media/disk_images/generic_disk_image.h
+++ b/libcommon/include/vcc/media/disk_images/generic_disk_image.h
@@ -1,0 +1,150 @@
+#pragma once
+#include <vcc/media/disk_image.h>
+#include <vcc/media/geometry/generic_disk_geometry.h>
+#include <Windows.h>
+#include <iostream>
+#include <memory>
+
+
+namespace vcc::media::disk_images
+{
+
+	/// @brief Basic implementation of the Disk Image interface.
+	/// 
+	/// This implementation of the Disk Image interface provides support for basic disk
+	/// image files that use a fixed number of tracks and sectors each with a fixed size.
+	/// It supports disk image files with track and sector data starting anywhere in the
+	/// file but requires that it be stored contiguously.
+	class generic_disk_image : public disk_image
+	{
+	public:
+
+		/// @brief The type used to hold geometry describing the disk capacity.
+		using geometry_type = ::vcc::media::geometry::generic_disk_geometry;
+		/// @brief The type of stream used to access the disk image file.
+		using stream_type = ::std::iostream;
+		/// @brief The type used to hold a pointer to the stream used to access the disk image file.
+		using stream_ptr_type = ::std::unique_ptr<stream_type>;
+		/// @brief The type used to store a position in the disk image file.
+		using position_type = stream_type::pos_type;
+
+
+	public:
+
+		/// @brief Constructs a Basic Disk Image.
+		/// 
+		/// @param stream The IO stream used to access disk image file.
+		/// @param geometry The geometry of the disk.
+		/// @param track_data_offset AN offset from the beginning of the file that points
+		/// to the location of the track and sector data.
+		/// @param first_valid_sector_id The first identifier that can be used for a sector.
+		/// @param write_protected Specifies if the disk is write protected or not.
+		/// 
+		/// @throws std::invalid_argument if the stream is null.
+		/// @throws std::invalid_argument if the stream is a file stream and is not open.
+		LIBCOMMON_EXPORT generic_disk_image(
+			stream_ptr_type stream,
+			const geometry_type& geometry,
+			position_type track_data_offset = 0,
+			size_type first_valid_sector_id = 1,
+			bool write_protected = false);
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT bool is_valid_sector_record(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const noexcept override;
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT size_type get_sector_size(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const override;
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT std::optional<sector_record_header_type> query_sector_header_by_index(
+			size_type disk_head,
+			size_type disk_track,
+			size_type disk_sector) const override;
+
+		/// @inheritdoc
+		LIBCOMMON_EXPORT void read_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id,
+			buffer_type& data_buffer) override;
+
+		/// @inheritdoc
+		LIBCOMMON_EXPORT void write_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id,
+			const buffer_type& data_buffer) override;
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT sector_record_vector read_track(
+			size_type disk_head,
+			size_type disk_track) override;
+
+		/// @inheritdoc
+		LIBCOMMON_EXPORT void write_track(
+			size_type disk_head,
+			size_type disk_track,
+			const sector_record_vector& sectors) override;
+
+
+	protected:
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT size_type get_sector_count_unchecked(
+			size_type disk_head,
+			size_type disk_track) const noexcept override;
+
+		/// @brief Move the file pointer to a specific location in the image file.
+		/// 
+		/// @param position The position to move to.
+		/// 
+		/// @return `true` if the file pointer was successfully changed; `false` otherwise.
+		[[nodiscard]] LIBCOMMON_EXPORT bool seek(const position_type& position);
+
+		/// @brief Calculates the file position of a specific sector on the disk.
+		/// 
+		/// Calculates the file position of a specific sector on the disk. This
+		/// function does not validate arguments specifying the sector to locate and
+		/// assumes they are correct.
+		/// 
+		/// @param disk_head The head the sector is stored on.
+		/// @param disk_track The track the sector is stored in.
+		/// @param head_id The head identifier assigned to the sector to read.
+		/// @param track_id The track identifier assigned to the sector to read.
+		/// @param sector_id The sector identifier assigned to the sector to read.
+		/// 
+		/// @return The file position of the specified sector.
+		[[nodiscard]] LIBCOMMON_EXPORT position_type calculate_sector_offset_unchecked(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const noexcept;
+
+
+	private:
+
+		const stream_ptr_type stream_ptr_;
+		stream_type& stream_;
+		const position_type file_size_;
+		const position_type track_data_offset_;
+		const size_type sector_count_;
+		const size_type track_size_;
+		const size_type sector_size_;
+	};
+
+}

--- a/libcommon/include/vcc/media/disk_images/placeholder_disk_image.h
+++ b/libcommon/include/vcc/media/disk_images/placeholder_disk_image.h
@@ -1,0 +1,108 @@
+#pragma once
+#include <vcc/media/disk_image.h>
+#include <vcc/media/geometry/generic_disk_geometry.h>
+#include <Windows.h>
+#include <iostream>
+#include <memory>
+
+
+namespace vcc::media::disk_images
+{
+
+	/// @brief Disk Image implementation used as a placeholder when a disk image is
+	/// needed but not available.
+	/// 
+	/// This implementation of the Disk Image interface provides support for use-cases
+	/// where a disk image is needed but one is not available such as an empty floppy disk
+	/// drive. It provides the same property and validation functionality as other disk
+	/// image types allowing for checking operation parameters used to access the disk.
+	/// 
+	/// Some behavior such as reading and writing data always throw an IO exception since
+	/// those operations are not possible. Adequate checking of operational parameters must
+	/// be performed prior to invoking read and write functions.
+	class placeholder_disk_image : public disk_image
+	{
+	public:
+
+		/// @brief The type used to hold geometry describing the disk capacity.
+		using geometry_type = ::vcc::media::geometry::generic_disk_geometry;
+
+	public:
+
+		/// @brief Constructs a Placeholder Disk Image.
+		/// 
+		/// @param geometry The geometry of the disk.
+		/// @param first_valid_sector_id The first identifier that can be used for a sector.
+		/// @param write_protected Specifies if the disk is write protected or not.
+		LIBCOMMON_EXPORT explicit placeholder_disk_image(
+			const geometry_type& geometry = {},
+			size_type first_valid_sector_id = 1,
+			bool write_protected = false);
+
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT bool is_valid_sector_record(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const noexcept override;
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT size_type get_sector_size(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id) const override;
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT std::optional<sector_record_header_type> query_sector_header_by_index(
+			size_type disk_head,
+			size_type disk_track,
+			size_type disk_sector) const override;
+
+		/// @inheritdoc
+		LIBCOMMON_EXPORT void read_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id,
+			buffer_type& data_buffer) override;
+
+		/// @inheritdoc
+		LIBCOMMON_EXPORT void write_sector(
+			size_type disk_head,
+			size_type disk_track,
+			size_type head_id,
+			size_type track_id,
+			size_type sector_id,
+			const buffer_type& data_buffer) override;
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT sector_record_vector read_track(
+			size_type disk_head,
+			size_type disk_track) override;
+
+		/// @inheritdoc
+		LIBCOMMON_EXPORT void write_track(
+			size_type disk_head,
+			size_type disk_track,
+			const sector_record_vector& sectors) override;
+
+
+	protected:
+
+		/// @inheritdoc
+		[[nodiscard]] LIBCOMMON_EXPORT virtual size_type get_sector_count_unchecked(
+			size_type disk_head,
+			size_type disk_track) const noexcept override;
+
+
+	private:
+
+		const geometry_type geometry_;
+	};
+
+}

--- a/libcommon/include/vcc/media/exceptions.h
+++ b/libcommon/include/vcc/media/exceptions.h
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include <vcc/detail/exports.h>
+#include <stdexcept>
+
+
+namespace vcc::media
+{
+	
+	class fatal_io_error : public std::runtime_error
+	{
+	public:
+
+		using std::runtime_error::runtime_error;
+	};
+
+	class buffer_size_error : public std::runtime_error
+	{
+	public:
+
+		using std::runtime_error::runtime_error;
+	};
+
+	class write_protect_error : public std::runtime_error
+	{
+	public:
+
+		using std::runtime_error::runtime_error;
+	};
+
+	class sector_record_error : public std::runtime_error
+	{
+	public:
+
+		using std::runtime_error::runtime_error;
+	};
+
+}

--- a/libcommon/include/vcc/media/geometry/generic_disk_geometry.h
+++ b/libcommon/include/vcc/media/geometry/generic_disk_geometry.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <vcc/media/disk_geometry.h>
+
+
+namespace vcc::media::geometry
+{
+
+	/// @brief Describes the geometry of a disk device or image.
+	struct generic_disk_geometry : disk_geometry
+	{
+		/// @brief The number of sectors per track on the drive or image.
+		/// 
+		/// Specifies the number of sectors per track on the drive or image. This value is not
+		/// absolute and may vary from track to track and from device to device. This member is
+		/// initialized with a default value of 18.
+		size_type sector_count = 18;
+		/// @brief The number of bytes per sector. This value is not absolute and may vary from
+		/// sector to sector, track to track, and device to device. This member is initialized
+		/// with a default value of 256.
+		size_type sector_size = 256;
+	};
+
+
+}

--- a/libcommon/include/vcc/media/sector_record.h
+++ b/libcommon/include/vcc/media/sector_record.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <vcc/media/sector_record_header.h>
+#include <vector>
+
+
+namespace vcc::media
+{
+
+	/// @brief Represents the contents of a sector stored in a disk image.
+	struct sector_record
+	{
+		/// @brief The type of buffer used to store sector data.
+		using buffer_type = std::vector<unsigned char>;
+
+		/// @brief The core properties of the rector.
+		sector_record_header header;
+		/// @brief The sector data.
+		buffer_type data;
+	};
+
+}

--- a/libcommon/include/vcc/media/sector_record_header.h
+++ b/libcommon/include/vcc/media/sector_record_header.h
@@ -9,7 +9,7 @@ namespace vcc::media
 	struct sector_record_header
 	{
 		/// @brief Specifies the type used to store header properties.
-		using size_type = ::std::size_t;
+		using size_type = std::size_t;
 
 		/// @brief The identifier of the drive stored in the sector header. This value may be
 		/// different than the physical head used to read the header. This member is

--- a/libcommon/include/vcc/media/sector_record_header.h
+++ b/libcommon/include/vcc/media/sector_record_header.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstddef>
+
+
+namespace vcc::media
+{
+
+	/// @brief Represents the properties of a disk sector
+	struct sector_record_header
+	{
+		/// @brief Specifies the type used to store header properties.
+		using size_type = ::std::size_t;
+
+		/// @brief The identifier of the drive stored in the sector header. This value may be
+		/// different than the physical head used to read the header. This member is
+		/// initialized to a default value of 0 (zero).
+		const size_type head_id = {};
+		/// @brief The identifier of the track stored in the sector header. This value may be
+		/// different than the physical track number the sector was stored in. This member is
+		/// initialized to a default value of 0 (zero).
+		const size_type track_id = {};
+		/// @brief The identifier of the sector the header represents. This member is
+		/// initialized to a default value of 0 (zero).
+		const size_type sector_id = {};
+		/// @brief The number of bytes in the sector. This member is initialized to a default
+		/// value of 0 (zero).
+		const size_type sector_length = {};
+	};
+
+}

--- a/libcommon/include/vcc/utils/streams.h
+++ b/libcommon/include/vcc/utils/streams.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <vcc/detail/exports.h>
+#include <iostream>
+
+
+
+namespace vcc::utils
+{
+
+	LIBCOMMON_EXPORT [[nodiscard]] std::iostream::pos_type get_stream_size(std::iostream& stream);
+
+}

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -115,11 +115,16 @@
     <ClCompile Include="src\devices\serial\beckerport.cpp" />
     <ClCompile Include="src\DialogOps.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\media\disk_image.cpp" />
+    <ClCompile Include="src\media\disk_images\generic_disk_image.cpp" />
+    <ClCompile Include="src\media\disk_images\placeholder_disk_image.cpp" />
+    <ClCompile Include="src\peripherals\disk_drives\basic_disk_drive.cpp" />
     <ClCompile Include="src\utils\cartridge_loader.cpp" />
     <ClCompile Include="src\utils\persistent_value_store.cpp" />
     <ClCompile Include="src\utils\Fileops.cpp" />
     <ClCompile Include="src\utils\filesystem.cpp" />
     <ClCompile Include="src\utils\logger.cpp" />
+    <ClCompile Include="src\utils\streams.cpp" />
     <ClCompile Include="src\utils\winapi.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -138,6 +143,17 @@
     <ClInclude Include="include\vcc\devices\rtc\ds1315.h" />
     <ClInclude Include="include\vcc\devices\rtc\oki_m6242b.h" />
     <ClInclude Include="include\vcc\devices\serial\beckerport.h" />
+    <ClInclude Include="include\vcc\media\disk_geometry.h" />
+    <ClInclude Include="include\vcc\media\disk_image.h" />
+    <ClInclude Include="include\vcc\media\disk_images\generic_disk_image.h" />
+    <ClInclude Include="include\vcc\media\disk_images\placeholder_disk_image.h" />
+    <ClInclude Include="include\vcc\media\exceptions.h" />
+    <ClInclude Include="include\vcc\media\geometry\generic_disk_geometry.h" />
+    <ClInclude Include="include\vcc\media\sector_record.h" />
+    <ClInclude Include="include\vcc\media\sector_record_header.h" />
+    <ClInclude Include="include\vcc\peripherals\disk_drive.h" />
+    <ClInclude Include="include\vcc\peripherals\disk_drives\basic_disk_drive.h" />
+    <ClInclude Include="include\vcc\peripherals\step_direction.h" />
     <ClInclude Include="include\vcc\utils\cartridge_loader.h" />
     <ClInclude Include="include\vcc\utils\persistent_value_store.h" />
     <ClInclude Include="include\vcc\utils\critical_section.h" />
@@ -145,6 +161,7 @@
     <ClInclude Include="include\vcc\utils\FileOps.h" />
     <ClInclude Include="include\vcc\utils\filesystem.h" />
     <ClInclude Include="include\vcc\utils\logger.h" />
+    <ClInclude Include="include\vcc\utils\streams.h" />
     <ClInclude Include="include\vcc\utils\winapi.h" />
     <ClInclude Include="resource\resource.h" />
   </ItemGroup>

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -118,7 +118,6 @@
     <ClCompile Include="src\media\disk_image.cpp" />
     <ClCompile Include="src\media\disk_images\generic_disk_image.cpp" />
     <ClCompile Include="src\media\disk_images\placeholder_disk_image.cpp" />
-    <ClCompile Include="src\peripherals\disk_drives\basic_disk_drive.cpp" />
     <ClCompile Include="src\utils\cartridge_loader.cpp" />
     <ClCompile Include="src\utils\persistent_value_store.cpp" />
     <ClCompile Include="src\utils\Fileops.cpp" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -82,12 +82,6 @@
     <Filter Include="Header Files\peripherals\disk_drives">
       <UniqueIdentifier>{7ab6f860-0d60-4d89-ac1d-ded223b42df3}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\peripherals">
-      <UniqueIdentifier>{5223b06b-9884-4cd4-aadd-cb9a7b9ef377}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\peripherals\disk_drives">
-      <UniqueIdentifier>{91b24e1a-a26d-45ca-b222-371e66367f2e}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Header Files\media\geometry">
       <UniqueIdentifier>{723c4f2c-3122-4c03-88d8-bbc635a93c2b}</UniqueIdentifier>
     </Filter>
@@ -146,9 +140,6 @@
     </ClCompile>
     <ClCompile Include="src\media\disk_images\generic_disk_image.cpp">
       <Filter>Source Files\media\disk_images</Filter>
-    </ClCompile>
-    <ClCompile Include="src\peripherals\disk_drives\basic_disk_drive.cpp">
-      <Filter>Source Files\peripherals\disk_drives</Filter>
     </ClCompile>
     <ClCompile Include="src\utils\streams.cpp">
       <Filter>Source Files\utils</Filter>

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -64,6 +64,33 @@
     <Filter Include="Header Files\bus\cartridges">
       <UniqueIdentifier>{cc0a281d-6ff8-4a04-95a0-5bef8957ba5f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\media">
+      <UniqueIdentifier>{6c8778b3-9a6c-4195-b857-99ab00dfbb75}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\media">
+      <UniqueIdentifier>{ac65f864-6773-49e6-ab1d-15c349319d87}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\media\disk_images">
+      <UniqueIdentifier>{83d22c09-e7de-44e6-b04a-fbb14ac4604f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\media\disk_images">
+      <UniqueIdentifier>{ca7ed50b-0652-4744-8ac4-05a84c227b6a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\peripherals">
+      <UniqueIdentifier>{9ccb2347-d0f2-499d-a3a3-1a04b5d52df5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\peripherals\disk_drives">
+      <UniqueIdentifier>{7ab6f860-0d60-4d89-ac1d-ded223b42df3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\peripherals">
+      <UniqueIdentifier>{5223b06b-9884-4cd4-aadd-cb9a7b9ef377}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\peripherals\disk_drives">
+      <UniqueIdentifier>{91b24e1a-a26d-45ca-b222-371e66367f2e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\media\geometry">
+      <UniqueIdentifier>{723c4f2c-3122-4c03-88d8-bbc635a93c2b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogOps.cpp">
@@ -116,6 +143,21 @@
     </ClCompile>
     <ClCompile Include="src\bus\cartridges\rom_cartridge.cpp">
       <Filter>Source Files\bus\cartridges</Filter>
+    </ClCompile>
+    <ClCompile Include="src\media\disk_images\generic_disk_image.cpp">
+      <Filter>Source Files\media\disk_images</Filter>
+    </ClCompile>
+    <ClCompile Include="src\peripherals\disk_drives\basic_disk_drive.cpp">
+      <Filter>Source Files\peripherals\disk_drives</Filter>
+    </ClCompile>
+    <ClCompile Include="src\utils\streams.cpp">
+      <Filter>Source Files\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\media\disk_images\placeholder_disk_image.cpp">
+      <Filter>Source Files\media\disk_images</Filter>
+    </ClCompile>
+    <ClCompile Include="src\media\disk_image.cpp">
+      <Filter>Source Files\media</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -190,6 +232,42 @@
     </ClInclude>
     <ClInclude Include="include\vcc\bus\cartridges\rom_cartridge.h">
       <Filter>Header Files\bus\cartridges</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\disk_image.h">
+      <Filter>Header Files\media</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\disk_geometry.h">
+      <Filter>Header Files\media</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\sector_record.h">
+      <Filter>Header Files\media</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\disk_images\generic_disk_image.h">
+      <Filter>Header Files\media\disk_images</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\sector_record_header.h">
+      <Filter>Header Files\media</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\peripherals\disk_drive.h">
+      <Filter>Header Files\peripherals</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\peripherals\disk_drives\basic_disk_drive.h">
+      <Filter>Header Files\peripherals\disk_drives</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\peripherals\step_direction.h">
+      <Filter>Header Files\peripherals</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\utils\streams.h">
+      <Filter>Header Files\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\exceptions.h">
+      <Filter>Header Files\media</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\disk_images\placeholder_disk_image.h">
+      <Filter>Header Files\media\disk_images</Filter>
+    </ClInclude>
+    <ClInclude Include="include\vcc\media\geometry\generic_disk_geometry.h">
+      <Filter>Header Files\media\geometry</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/libcommon/src/main.cpp
+++ b/libcommon/src/main.cpp
@@ -1,4 +1,4 @@
-// NOTE: The following include is here to force exporting implicit definitions.
+// NOTE: The following two includes are here to force exporting implicit definitions.
 #include <vcc/utils/dll_deleter.h>
 #include <Windows.h>
 

--- a/libcommon/src/media/disk_image.cpp
+++ b/libcommon/src/media/disk_image.cpp
@@ -1,0 +1,107 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include <vcc/media/disk_image.h>
+#include <vcc/media/exceptions.h>
+
+
+namespace vcc::media
+{
+
+	disk_image::disk_image(
+		const geometry_type& geometry,
+		size_type first_valid_sector_id,
+		bool write_protected)
+		:
+		head_count_(geometry.head_count),
+		track_count_(geometry.track_count),
+		first_valid_sector_id_(first_valid_sector_id),
+		write_protected_(write_protected)
+	{
+		if (!head_count_)
+		{
+			throw std::invalid_argument("Cannot construct Disk Image. Number of heads is 0.");
+		}
+
+		if (!track_count_)
+		{
+			throw std::invalid_argument("Cannot construct Disk Image. Number of tracks is 0.");
+		}
+	}
+
+
+	bool disk_image::is_write_protected() const noexcept
+	{
+		return write_protected_;
+	}
+
+	disk_image::size_type disk_image::head_count() const noexcept
+	{
+		return head_count_;
+	}
+
+	disk_image::size_type disk_image::track_count() const noexcept
+	{
+		return track_count_;
+	}
+
+
+	disk_image::size_type disk_image::get_sector_count(
+		size_type disk_head,
+		size_type disk_track) const
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot retrieve number of sectors. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot retrieve number of sectors. Specified drive track is invalid.");
+		}
+
+		return get_sector_count_unchecked(disk_head, disk_track);
+	}
+
+	bool disk_image::is_valid_track_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type disk_sector) const noexcept
+	{
+		return is_valid_disk_head(disk_head)
+			&& is_valid_disk_track(disk_track)
+			&& disk_sector < get_sector_count_unchecked(disk_head, disk_track);
+	}
+
+
+	bool disk_image::is_valid_disk_head(size_type disk_head) const noexcept
+	{
+		return disk_head < head_count();
+	}
+
+	bool disk_image::is_valid_disk_track([[maybe_unused]] size_type disk_track) const noexcept
+	{
+		return disk_track < track_count();
+	}
+
+
+	disk_image::size_type disk_image::first_valid_sector_id() const noexcept
+	{
+		return first_valid_sector_id_;
+	}
+
+}

--- a/libcommon/src/media/disk_images/generic_disk_image.cpp
+++ b/libcommon/src/media/disk_images/generic_disk_image.cpp
@@ -197,7 +197,7 @@ namespace vcc::media::disk_images
 		if (stream_.bad())
 		{
 			// TODO: This should throw
-			::std::fill(data_buffer.begin(), data_buffer.end(), 0xff);
+			std::fill(data_buffer.begin(), data_buffer.end(), 0xff);
 		}
 	}
 

--- a/libcommon/src/media/disk_images/generic_disk_image.cpp
+++ b/libcommon/src/media/disk_images/generic_disk_image.cpp
@@ -1,0 +1,348 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include <vcc/media/disk_images/generic_disk_image.h>
+#include <vcc/media/exceptions.h>
+#include <vcc/utils/streams.h>
+#include <fstream>
+
+
+namespace vcc::media::disk_images
+{
+
+	namespace
+	{
+		generic_disk_image::stream_ptr_type validate_stream_argument(generic_disk_image::stream_ptr_type stream)
+		{
+			if (!stream)
+			{
+				throw std::invalid_argument("Cannot construct Basic Disk Image. Stream is null.");
+			}
+
+			return stream;
+		}
+	}
+
+
+	generic_disk_image::generic_disk_image(
+		stream_ptr_type stream,
+		const geometry_type& geometry,
+		position_type track_data_offset,
+		size_type first_valid_sector_id,
+		bool write_protected)
+		:
+		disk_image(geometry, first_valid_sector_id, write_protected),
+		stream_ptr_(validate_stream_argument(move(stream))),
+		stream_(*stream_ptr_.get()),
+		file_size_(::vcc::utils::get_stream_size(stream_)),
+		track_data_offset_(move(track_data_offset)),
+		sector_count_(geometry.sector_count),
+		track_size_(geometry.sector_count * geometry.sector_size),
+		sector_size_(geometry.sector_size)
+	{
+		// TODO: find a way to do this without the cast. i.e. the file size is <0 if
+		// the file is closed. Also check good/bad flags.
+		if (const auto file_stream(dynamic_cast<std::fstream*>(&stream_));
+			file_stream && !file_stream->is_open())
+		{
+			throw std::invalid_argument("Cannot construct Basic Disk Image. File stream is closed.");
+		}
+
+		if (file_size_ < 0)
+		{
+			throw std::runtime_error("Cannot construct Basic Disk Image. Stream size cannot be determined.");
+		}
+
+#ifdef INCLUDE_INCOMPLETE_AND_BROKEN_LIBCOMMON_CODE
+		// FIXME: The solution for buffer streams is incomplete and causes tellg() and tellp()
+		// to return incorrect values. Once buffer stream support is complete this code and its
+		// associated should be compiled in.
+		const auto minimum_image_data_size(head_count_ * track_count_ * sector_count_);
+		const auto minimum_image_file_size(track_data_offset_ + position_type(minimum_image_data_size));
+		if (file_size_ < minimum_image_file_size)
+		{
+			throw std::runtime_error("Cannot construct Basic Disk Image. Stream size is too small for specified geometry.");
+		}
+#endif
+	}
+
+
+	bool generic_disk_image::is_valid_sector_record(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id) const noexcept
+	{
+		if (disk_head != head_id || disk_track != track_id)
+		{
+			return false;
+		}
+
+		if (sector_id < first_valid_sector_id())
+		{
+			return false;
+		}
+
+		return sector_id - first_valid_sector_id() < get_sector_count_unchecked(disk_head, disk_track);
+	}
+
+
+	generic_disk_image::size_type generic_disk_image::get_sector_size(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id) const
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot retrieve the size of a sector. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot retrieve the size of a sector. Specified drive track is invalid.");
+		}
+
+		if (!is_valid_sector_record(disk_head, disk_track, head_id, track_id, sector_id))
+		{
+			throw std::invalid_argument("Cannot retrieve the size of a sector. Specified sector id is invalid.");
+		}
+
+		return sector_size_;
+	}
+
+	std::optional<generic_disk_image::sector_record_header_type> generic_disk_image::query_sector_header_by_index(
+		size_type disk_head,
+		size_type disk_track,
+		size_type disk_sector) const
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot retrieve the record header by index. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot retrieve the record header by index. Specified drive track is invalid.");
+		}
+
+		if (disk_sector >= get_sector_count_unchecked(disk_head, disk_track) + first_valid_sector_id())
+		{
+			throw std::invalid_argument("Cannot retrieve the record header by index. Specified drive sector is invalid.");
+		}
+
+		return sector_record_header_type{
+			disk_head,
+			disk_track,
+			disk_sector,
+			sector_size_
+		};
+	}
+
+	void generic_disk_image::read_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id,
+		buffer_type& data_buffer)
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot read sector. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot read sector. Specified drive track is invalid.");
+		}
+
+		if (!is_valid_sector_record(disk_head, disk_track, head_id, track_id, sector_id))
+		{
+			throw std::invalid_argument("Cannot read sector. Specified sector id is invalid.");
+		}
+
+		if (!seek(calculate_sector_offset_unchecked(disk_head, disk_track, head_id, track_id, sector_id)))
+		{
+			throw fatal_io_error("Cannot read sector. Fatal IO error encountered while seeking to sector position.");
+		}
+
+		// TODO: There needs to be unchecked versions of sector_size() and other similar
+		// functions since we're already checking the input parameters here.
+		data_buffer.resize(get_sector_size(
+			disk_head,
+			disk_track,
+			head_id,
+			track_id,
+			sector_id));
+
+		stream_.clear();
+		stream_.read(reinterpret_cast<char*>(data_buffer.data()), data_buffer.size());
+		if (stream_.bad())
+		{
+			// TODO: This should throw
+			::std::fill(data_buffer.begin(), data_buffer.end(), 0xff);
+		}
+	}
+
+	void generic_disk_image::write_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id,
+		const buffer_type& data_buffer)
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot write sector. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot write sector. Specified drive track is invalid.");
+		}
+
+		if (!is_valid_sector_record(disk_head, disk_track, head_id, track_id, sector_id))
+		{
+			throw std::invalid_argument("Cannot write sector. Specified sector id is invalid.");
+		}
+
+		const auto sector_size(get_sector_size(disk_head, disk_track, head_id, track_id, sector_id));
+		if (sector_size > data_buffer.size())
+		{
+			// TODO: Determine if we should write a partial sector here or if a write_partial_sector
+			// should be added and used by the client.
+			throw buffer_size_error("Cannot write sector. Sector buffer is smaller than the sector.");
+		}
+
+		if (!seek(calculate_sector_offset_unchecked(disk_head, disk_track, head_id, track_id, sector_id)))
+		{
+			throw fatal_io_error("Cannot write sector. Fatal IO error encountered while seeking to sector position.");
+		}
+
+		if (is_write_protected())
+		{
+			throw write_protect_error("Cannot write sector. Disk is write protected.");
+		}
+
+		stream_.write(reinterpret_cast<const char*>(data_buffer.data()), sector_size);
+		stream_.flush();
+		if (stream_.bad())
+		{
+			throw fatal_io_error("Cannot write sector. Fatal IO error encountered while writing sector.");
+		}
+	}
+
+
+	generic_disk_image::sector_record_vector generic_disk_image::read_track(
+		size_type disk_head,
+		size_type disk_track)
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot read track. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot read track. Specified drive track is invalid.");
+		}
+
+		throw std::runtime_error("Cannot read track. Functionality is not implemented.");
+	}
+
+	void generic_disk_image::write_track(
+		size_type disk_head,
+		size_type disk_track,
+		const sector_record_vector& sectors)
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot write track. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot write track. Specified drive track is invalid.");
+		}
+
+		if (is_write_protected())
+		{
+			throw write_protect_error("Cannot write track. Disk is write protected.");
+		}
+
+		// TODO: This needs a more robust solution in order to support derived disk images
+		// that manage sector record details in their format. We should
+		//  - check for valid sector id's
+		//  - check for sequential sector id's
+		for (const auto& sector : sectors)
+		{
+			if (sector.header.sector_length != sector_size_)
+			{
+				throw sector_record_error("Cannot write track. One or more sector records have an unsupported or incorrect size.");
+			}
+		}
+
+		for (const auto& sector : sectors)
+		{
+			// TODO: This is a placeholder. A more robust solution is needed to support other disk
+			// formats
+			write_sector(
+				disk_head,
+				disk_track,
+				sector.header.head_id,
+				sector.header.track_id,
+				sector.header.sector_id,
+				sector.data);
+		}
+	}
+
+
+	generic_disk_image::size_type generic_disk_image::get_sector_count_unchecked(
+		size_type disk_head,
+		size_type disk_track) const noexcept
+	{
+		return sector_count_;
+	}
+
+
+	bool generic_disk_image::seek(const position_type& position)
+	{
+		stream_.clear();
+		return !stream_.seekg(position, std::ios::beg).bad()
+			&& !stream_.seekp(position, std::ios::beg).bad();
+	}
+
+
+	generic_disk_image::position_type generic_disk_image::calculate_sector_offset_unchecked(
+		size_type disk_head,
+		size_type disk_track,
+		[[maybe_unused]] size_type head_id,
+		[[maybe_unused]] size_type track_id,
+		size_type sector_id) const noexcept
+	{
+		const auto head_offset(disk_head * track_size_ * track_count());
+		const auto track_offset(disk_track * track_size_);
+		const auto sector_offset((sector_id - first_valid_sector_id()) * sector_size_);
+
+		return track_data_offset_ + position_type(head_offset + track_offset + sector_offset);
+	}
+
+}

--- a/libcommon/src/media/disk_images/placeholder_disk_image.cpp
+++ b/libcommon/src/media/disk_images/placeholder_disk_image.cpp
@@ -1,0 +1,157 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include <vcc/media/disk_images/placeholder_disk_image.h>
+#include <vcc/media/exceptions.h>
+#include <vcc/utils/streams.h>
+#include <fstream>
+
+
+namespace vcc::media::disk_images
+{
+
+	placeholder_disk_image::placeholder_disk_image(
+		const geometry_type& geometry,
+		size_type first_valid_sector_id,
+		bool write_protected)
+		:
+		disk_image(geometry, first_valid_sector_id, write_protected),
+		geometry_(geometry)
+	{}
+
+
+	bool placeholder_disk_image::is_valid_sector_record(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id) const noexcept
+	{
+		if (disk_head != head_id || disk_track != track_id)
+		{
+			return false;
+		}
+
+		if (sector_id < first_valid_sector_id())
+		{
+			return false;
+		}
+
+		// TODO: add get_sector_count_unchecked() since this function shouldn't throw and
+		// sector_count does.
+		return sector_id - first_valid_sector_id() < get_sector_count(disk_head, disk_track);
+	}
+
+
+	placeholder_disk_image::size_type placeholder_disk_image::get_sector_size(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id) const
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot retrieve the size of a sector. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot retrieve the size of a sector. Specified drive track is invalid.");
+		}
+
+		if (!is_valid_sector_record(disk_head, disk_track, head_id, track_id, sector_id))
+		{
+			throw std::invalid_argument("Cannot retrieve the size of a sector. Specified sector id is invalid.");
+		}
+
+		return geometry_.sector_size;
+	}
+
+	std::optional<placeholder_disk_image::sector_record_header_type> placeholder_disk_image::query_sector_header_by_index(
+		size_type disk_head,
+		size_type disk_track,
+		size_type disk_sector) const
+	{
+		if (!is_valid_disk_head(disk_head))
+		{
+			throw std::invalid_argument("Cannot retrieve the record header by index. Specified drive head is invalid.");
+		}
+
+		if (!is_valid_disk_track(disk_track))
+		{
+			throw std::invalid_argument("Cannot retrieve the record header by index. Specified drive track is invalid.");
+		}
+
+		if (disk_sector >= get_sector_count(disk_head, disk_track) + first_valid_sector_id())
+		{
+			throw std::invalid_argument("Cannot retrieve the record header by index. Specified drive sector is invalid.");
+		}
+
+		return sector_record_header_type{
+			disk_head,
+			disk_track,
+			disk_sector,
+			geometry_.sector_size
+		};
+	}
+
+	void placeholder_disk_image::read_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id,
+		buffer_type& data_buffer)
+	{
+		throw fatal_io_error("Cannot read sector. Disk does not exist.");
+	}
+
+	void placeholder_disk_image::write_sector(
+		size_type disk_head,
+		size_type disk_track,
+		size_type head_id,
+		size_type track_id,
+		size_type sector_id,
+		const buffer_type& data_buffer)
+	{
+		throw fatal_io_error("Cannot write sector. Disk does not exist.");
+	}
+
+	placeholder_disk_image::sector_record_vector placeholder_disk_image::read_track(
+		size_type disk_head,
+		size_type disk_track)
+	{
+		throw fatal_io_error("Cannot read track. Disk does not exist.");
+	}
+
+	void placeholder_disk_image::write_track(
+		size_type disk_head,
+		size_type disk_track,
+		const sector_record_vector& sectors)
+	{
+		throw fatal_io_error("Cannot write track. Disk does not exist.");
+	}
+
+	placeholder_disk_image::size_type placeholder_disk_image::get_sector_count_unchecked(
+		size_type disk_head,
+		size_type disk_track) const noexcept
+	{
+		return geometry_.sector_count;
+	}
+
+}

--- a/libcommon/src/utils/streams.cpp
+++ b/libcommon/src/utils/streams.cpp
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+//	Copyright 2015 by Joseph Forgione
+//	This file is part of VCC (Virtual Color Computer).
+//	
+//	VCC (Virtual Color Computer) is free software: you can redistribute itand/or
+//	modify it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation, either version 3 of the License, or (at your
+//	option) any later version.
+//	
+//	VCC (Virtual Color Computer) is distributed in the hope that it will be
+//	useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//	Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License along with
+//	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////////////
+#include <vcc/utils/streams.h>
+
+
+namespace vcc::utils
+{
+
+	std::iostream::pos_type get_stream_size(std::iostream& stream)
+	{
+		const auto current_position(stream.tellg());
+		if (current_position < 0)
+		{
+			return {};
+		}
+
+		stream.seekg(0, std::ios::end);
+		const auto file_size(stream.tellg());
+		if (file_size < 0)
+		{
+			return {};
+		}
+
+		stream.seekg(current_position);
+
+		return file_size;
+	}
+
+}


### PR DESCRIPTION
- add `disk_image`, `basic_disk_image`, and associated classes to handle reading and writing generic virtual disk images.
- add unit test project for `libcommon` called `libcommon-test`.
- add unit tests for `basic_disk_image`.
- update build scripts to download required packages