### PR TITLE
Fix issue with ROM loading

### DIFF
--- a/libcommon/src/bus/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/bus/cartridges/rom_cartridge.cpp
@@ -41,12 +41,12 @@ namespace vcc::bus::cartridges
 			throw ::std::invalid_argument("Cannot construct ROM Cartridge. The cartridge context is null.");
 		}
 
-		if (name.empty())
+		if (name_.empty())
 		{
 			throw ::std::invalid_argument("Cannot construct ROM Cartridge. The catalog name is empty.");
 		}
 
-		if (buffer.empty())
+		if (buffer_.empty())
 		{
 			throw ::std::invalid_argument("Cannot construct ROM Cartridge. The ROM buffer is empty.");
 		}


### PR DESCRIPTION
update ROM cartridge to validate the member variable contents instead of the parameters (they have been moved)