### PR TITLE
Use prefered namespace syntax

### DIFF
--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -20,7 +20,7 @@
 #include <string>
 
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
 	struct LIBCOMMON_EXPORT cartridge
@@ -57,4 +57,4 @@ namespace vcc { namespace core
 		virtual void menu_item_clicked(unsigned char menu_item_id) = 0;
 	};
 
-} }
+}

--- a/libcommon/include/vcc/core/cartridge.h
+++ b/libcommon/include/vcc/core/cartridge.h
@@ -27,9 +27,9 @@ namespace vcc::core
 	{
 	public:
 
-		using name_type = ::std::string;
-		using catalog_id_type = ::std::string;
-		using description_type = ::std::string;
+		using name_type = std::string;
+		using catalog_id_type = std::string;
+		using description_type = std::string;
 
 
 	public:

--- a/libcommon/include/vcc/core/cartridge_context.h
+++ b/libcommon/include/vcc/core/cartridge_context.h
@@ -30,7 +30,7 @@ namespace vcc::core
 
 	struct LIBCOMMON_EXPORT cartridge_context
 	{
-		using path_type = ::std::string;
+		using path_type = std::string;
 
 
 		virtual ~cartridge_context() = default;

--- a/libcommon/include/vcc/core/cartridge_context.h
+++ b/libcommon/include/vcc/core/cartridge_context.h
@@ -25,7 +25,7 @@
 // main vcc app. Update this when it is migrated.
 enum MenuItemType;
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
 	struct LIBCOMMON_EXPORT cartridge_context
@@ -48,4 +48,4 @@ namespace vcc { namespace core
 		virtual void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) = 0;
 	};
 
-} }
+}

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -19,7 +19,7 @@
 #include <vcc/core/cartridge.h>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	struct LIBCOMMON_EXPORT basic_cartridge : public ::vcc::core::cartridge
@@ -57,4 +57,4 @@ namespace vcc { namespace core { namespace cartridges
 		virtual void initialize_bus();
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -22,7 +22,7 @@
 #include <string>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	class legacy_cartridge: public cartridge
@@ -80,4 +80,4 @@ namespace vcc { namespace core { namespace cartridges
 		const PakMenuItemClickedModuleFunction menu_item_clicked_;
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/core/cartridges/null_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/null_cartridge.h
@@ -19,10 +19,10 @@
 #include <vcc/core/cartridges/basic_cartridge.h>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	class LIBCOMMON_EXPORT null_cartridge : public basic_cartridge
 	{};
 
-} } }
+}

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -22,7 +22,7 @@
 #include <memory>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	class rom_cartridge : public basic_cartridge
@@ -70,4 +70,4 @@ namespace vcc { namespace core { namespace cartridges
 		size_type bank_offset_;
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/core/rom_image.h
+++ b/libcommon/include/vcc/core/rom_image.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
 	class rom_image
@@ -73,4 +73,4 @@ namespace vcc { namespace core
 		container_type data_;
 	};
 
-} }
+}

--- a/libcommon/include/vcc/core/utils/critical_section.h
+++ b/libcommon/include/vcc/core/utils/critical_section.h
@@ -3,7 +3,7 @@
 #include <Windows.h>
 
 
-namespace vcc { namespace core { namespace utils
+namespace vcc::core::utils
 {
 
 	class critical_section
@@ -64,4 +64,4 @@ namespace vcc { namespace core { namespace utils
 		const critical_section& section_;
 	};
 
-} } }
+}

--- a/libcommon/include/vcc/core/utils/dll_deleter.h
+++ b/libcommon/include/vcc/core/utils/dll_deleter.h
@@ -19,7 +19,7 @@
 #include <vcc/common/logger.h>
 #include <Windows.h>
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
 	struct LIBCOMMON_EXPORT dll_deleter
@@ -29,9 +29,8 @@ namespace vcc { namespace core
 			if (instance != nullptr)
 			{
 				const auto result(FreeLibrary(instance));
-				DLOG_C("pak:err FreeLibrary %d %d\n", instance, result);
 			}
 		};
 	};
 
-} }
+}

--- a/libcommon/include/vcc/core/utils/filesystem.h
+++ b/libcommon/include/vcc/core/utils/filesystem.h
@@ -21,7 +21,7 @@
 #include <Windows.h>
 
 
-namespace vcc { namespace core { namespace utils
+namespace vcc::core::utils
 {
 
 	LIBCOMMON_EXPORT std::string get_module_path(HMODULE module_handle = nullptr);
@@ -30,4 +30,4 @@ namespace vcc { namespace core { namespace utils
 	LIBCOMMON_EXPORT std::string get_filename(std::string path);
 	LIBCOMMON_EXPORT std::string strip_application_path(std::string path);
 
-} } }
+}

--- a/libcommon/include/vcc/core/utils/initial_settings.h
+++ b/libcommon/include/vcc/core/utils/initial_settings.h
@@ -20,10 +20,10 @@
 #include <string>
 
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
-	class configuration_serializer
+	class initial_settings
 	{
 	public:
 
@@ -32,7 +32,7 @@ namespace vcc { namespace core
 
 	public:
 
-		LIBCOMMON_EXPORT explicit configuration_serializer(path_type path);
+		LIBCOMMON_EXPORT explicit initial_settings(path_type path);
 
 		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, int value) const;
 		LIBCOMMON_EXPORT void write(const string_type& section, const string_type& key, const string_type& value) const;
@@ -45,4 +45,4 @@ namespace vcc { namespace core
 
 		const path_type path_;
 	};
-} }
+}

--- a/libcommon/include/vcc/core/utils/initial_settings.h
+++ b/libcommon/include/vcc/core/utils/initial_settings.h
@@ -27,8 +27,8 @@ namespace vcc::core
 	{
 	public:
 
-		using path_type = ::std::string;
-		using string_type = ::std::string;
+		using path_type = std::string;
+		using string_type = std::string;
 
 	public:
 

--- a/libcommon/include/vcc/core/utils/winapi.h
+++ b/libcommon/include/vcc/core/utils/winapi.h
@@ -20,10 +20,12 @@
 #include <Windows.h>
 #include <string>
 
+// I think winapi is intended to contain windows api calls. Not sure why it
+// was created because that could be any thing used to interact with Windows.
 
-namespace vcc { namespace core { namespace utils
+namespace vcc::core::utils
 {
-
+    // Load resource string
 	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id);
 
-} } }
+}

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -112,7 +112,7 @@
     <ClCompile Include="src\core\cartridges\rom_cartridge.cpp" />
     <ClCompile Include="src\core\cartridge_loader.cpp" />
     <ClCompile Include="src\core\rom_image.cpp" />
-    <ClCompile Include="src\core\utils\configuration_serializer.cpp" />
+    <ClCompile Include="src\core\utils\initial_settings.cpp" />
     <ClCompile Include="src\core\utils\filesystem.cpp" />
     <ClCompile Include="src\core\utils\winapi.cpp" />
     <ClCompile Include="src\devices\rtc\cloud9.cpp" />
@@ -138,7 +138,7 @@
     <ClInclude Include="include\vcc\core\legacy_cartridge_definitions.h" />
     <ClInclude Include="include\vcc\core\limits.h" />
     <ClInclude Include="include\vcc\core\rom_image.h" />
-    <ClInclude Include="include\vcc\core\utils\configuration_serializer.h" />
+    <ClInclude Include="include\vcc\core\utils\initial_settings.h" />
     <ClInclude Include="include\vcc\core\utils\critical_section.h" />
     <ClInclude Include="include\vcc\core\utils\dll_deleter.h" />
     <ClInclude Include="include\vcc\core\utils\filesystem.h" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -75,7 +75,7 @@
     <ClCompile Include="src\core\cartridge_loader.cpp">
       <Filter>Source Files\core</Filter>
     </ClCompile>
-    <ClCompile Include="src\core\utils\configuration_serializer.cpp">
+    <ClCompile Include="src\core\utils\initial_settings.cpp">
       <Filter>Source Files\core\utils</Filter>
     </ClCompile>
     <ClCompile Include="src\core\utils\filesystem.cpp">
@@ -140,7 +140,7 @@
     <ClInclude Include="include\vcc\core\utils\filesystem.h">
       <Filter>Header Files\core\utils</Filter>
     </ClInclude>
-    <ClInclude Include="include\vcc\core\utils\configuration_serializer.h">
+    <ClInclude Include="include\vcc\core\utils\initial_settings.h">
       <Filter>Header Files\core\utils</Filter>
     </ClInclude>
     <ClInclude Include="include\vcc\core\utils\winapi.h">

--- a/libcommon/src/core/cartridges/basic_cartridge.cpp
+++ b/libcommon/src/core/cartridges/basic_cartridge.cpp
@@ -18,7 +18,7 @@
 #include <vcc/core/cartridges/basic_cartridge.h>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	basic_cartridge::name_type basic_cartridge::name() const
@@ -84,4 +84,4 @@ namespace vcc { namespace core { namespace cartridges
 	void basic_cartridge::initialize_bus()
 	{}
 
-} } }
+}

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -18,7 +18,7 @@
 #include <vcc/core/cartridges/legacy_cartridge.h>
 #include <stdexcept>
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	namespace
@@ -171,4 +171,4 @@ namespace vcc { namespace core { namespace cartridges
 		menu_item_clicked_(menu_item_id);
 	}
 
-} } }
+}

--- a/libcommon/src/core/cartridges/rom_cartridge.cpp
+++ b/libcommon/src/core/cartridges/rom_cartridge.cpp
@@ -18,7 +18,7 @@
 #include <vcc/core/cartridges/rom_cartridge.h>
 
 
-namespace vcc { namespace core { namespace cartridges
+namespace vcc::core::cartridges
 {
 
 	rom_cartridge::rom_cartridge(
@@ -76,4 +76,4 @@ namespace vcc { namespace core { namespace cartridges
 		context_->assert_cartridge_line(true);
 	}
 
-} } }
+}

--- a/libcommon/src/core/rom_image.cpp
+++ b/libcommon/src/core/rom_image.cpp
@@ -20,7 +20,7 @@
 #include <Windows.h>
 
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
 	bool rom_image::load(path_type filename)
@@ -51,4 +51,4 @@ namespace vcc { namespace core
 		return true;
 	}
 
-} }
+}

--- a/libcommon/src/core/utils/filesystem.cpp
+++ b/libcommon/src/core/utils/filesystem.cpp
@@ -19,7 +19,7 @@
 #include <vcc/core/utils/winapi.h>
 
 
-namespace vcc { namespace core { namespace utils
+namespace vcc::core::utils
 {
 
 
@@ -108,4 +108,4 @@ namespace vcc { namespace core { namespace utils
 		return path;
 	}
 
-} } }
+}

--- a/libcommon/src/core/utils/initial_settings.cpp
+++ b/libcommon/src/core/utils/initial_settings.cpp
@@ -15,19 +15,19 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
-#include <vcc/core/utils/configuration_serializer.h>
+#include <vcc/core/utils/initial_settings.h>
 #include <Windows.h>
 
 
-namespace vcc { namespace core
+namespace vcc::core
 {
 
-	configuration_serializer::configuration_serializer(path_type path)
+	initial_settings::initial_settings(path_type path)
 		: path_(move(path))
 	{
 	}
 
-	void configuration_serializer::write(
+	void initial_settings::write(
 		const string_type& section,
 		const string_type& key,
 		int value) const
@@ -39,7 +39,7 @@ namespace vcc { namespace core
 			path_.c_str());
 	}
 
-	void configuration_serializer::write(
+	void initial_settings::write(
 		const string_type& section,
 		const string_type& key,
 		const string_type& value) const
@@ -47,12 +47,12 @@ namespace vcc { namespace core
 		WritePrivateProfileString(section.c_str(), key.c_str(), value.c_str(), path_.c_str());
 	}
 
-	int configuration_serializer::read(const string_type& section, const string_type& key, int default_value) const
+	int initial_settings::read(const string_type& section, const string_type& key, int default_value) const
 	{
 		return GetPrivateProfileInt(section.c_str(), key.c_str(), default_value, path_.c_str());
 	}
 
-	configuration_serializer::string_type configuration_serializer::read(
+	initial_settings::string_type initial_settings::read(
 		const string_type& section,
 		const string_type& key,
 		const string_type& default_value) const
@@ -71,4 +71,4 @@ namespace vcc { namespace core
 		return loaded_string;
 	}
 
-} }
+}

--- a/mpi/cartridge_slot.cpp
+++ b/mpi/cartridge_slot.cpp
@@ -19,7 +19,7 @@
 #include <vcc/core/cartridges/null_cartridge.h>
 
 
-namespace vcc { namespace modules { namespace mpi
+namespace vcc::modules::mpi
 {
 
 	cartridge_slot::cartridge_slot()
@@ -66,4 +66,4 @@ namespace vcc { namespace modules { namespace mpi
 		return text;
 	}
 
-} } }
+}

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -22,7 +22,7 @@
 #include "../CartridgeMenu.h"
 
 
-namespace vcc { namespace modules { namespace mpi
+namespace vcc::modules::mpi
 {
 
 	class cartridge_slot
@@ -166,4 +166,4 @@ namespace vcc { namespace modules { namespace mpi
 		bool line_state_ = false;
 	};
 
-} } }
+}

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -32,10 +32,10 @@ namespace vcc::modules::mpi
 		using name_type = ::vcc::core::cartridge::name_type;
 		using catalog_id_type = ::vcc::core::cartridge::catalog_id_type;
 		using description_type = ::vcc::core::cartridge::description_type;
-		using path_type = ::std::string;
-		using label_type = ::std::string;
+		using path_type = std::string;
+		using label_type = std::string;
 		using handle_type = ::vcc::core::cartridge_loader_result::handle_type;
-		using cartridge_ptr_type = ::std::unique_ptr<::vcc::core::cartridge>;
+		using cartridge_ptr_type = std::unique_ptr<::vcc::core::cartridge>;
 		using menu_item_type = CartMenuItem;
 		using menu_item_collection_type = std::vector<menu_item_type>;
 		using context_type = ::vcc::core::cartridge_context;

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -30,7 +30,7 @@ class host_cartridge_context : public ::vcc::core::cartridge_context
 public:
 
 	// FIXME: Remove this when we derive from cartridge_context
-	using path_type = ::std::string;
+	using path_type = std::string;
 
 
 public:

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -33,10 +33,10 @@ public:
 
 	using context_type = ::vcc::core::cartridge_context;
 	using mount_status_type = ::vcc::core::cartridge_loader_status;
-	using slot_id_type = ::std::size_t;
-	using path_type = ::std::string;
-	using label_type = ::std::string;
-	using description_type = ::std::string;
+	using slot_id_type = std::size_t;
+	using path_type = std::string;
+	using label_type = std::string;
+	using description_type = std::string;
 	using menu_item_type = CartMenuItem;
 
 

--- a/mpi/multipak_configuration.cpp
+++ b/mpi/multipak_configuration.cpp
@@ -56,5 +56,5 @@ multipak_configuration::path_type multipak_configuration::slot_cartridge_path(sl
 
 multipak_configuration::string_type multipak_configuration::get_slot_path_key(slot_id_type slot) const
 {
-	return "SLOT" + ::std::to_string(slot + 1);
+	return "SLOT" + std::to_string(slot + 1);
 }

--- a/mpi/multipak_configuration.cpp
+++ b/mpi/multipak_configuration.cpp
@@ -1,8 +1,8 @@
 #include "multipak_configuration.h"
-#include <vcc/core/utils/configuration_serializer.h>
+#include <vcc/core/utils/initial_settings.h>
 
 
-using serializer = ::vcc::core::configuration_serializer;
+using settings = ::vcc::core::initial_settings;
 
 
 multipak_configuration::multipak_configuration(string_type section)
@@ -23,34 +23,34 @@ multipak_configuration::path_type multipak_configuration::configuration_path() c
 
 multipak_configuration::path_type multipak_configuration::last_accessed_module_path() const
 {
-	return serializer(configuration_path()).read("DefaultPaths", "MPIPath");
+	return settings(configuration_path()).read("DefaultPaths", "MPIPath");
 }
 
 void multipak_configuration::last_accessed_module_path(const path_type& path) const
 {
-	serializer(configuration_path()).write("DefaultPaths", "MPIPath", path);
+	settings(configuration_path()).write("DefaultPaths", "MPIPath", path);
 }
 
 
 void multipak_configuration::selected_slot(slot_id_type slot) const
 {
-	serializer(configuration_path()).write(section_, "SWPOSITION", slot);
+	settings(configuration_path()).write(section_, "SWPOSITION", slot);
 }
 
 multipak_configuration::slot_id_type multipak_configuration::selected_slot() const
 {
-	return serializer(configuration_path()).read(section_, "SWPOSITION", 3);
+	return settings(configuration_path()).read(section_, "SWPOSITION", 3);
 }
 
 
 void multipak_configuration::slot_cartridge_path(slot_id_type slot, const path_type& path) const
 {
-	serializer(configuration_path()).write(section_, get_slot_path_key(slot), path);
+	settings(configuration_path()).write(section_, get_slot_path_key(slot), path);
 }
 
 multipak_configuration::path_type multipak_configuration::slot_cartridge_path(slot_id_type slot) const
 {
-	return serializer(configuration_path()).read(section_, get_slot_path_key(slot));
+	return settings(configuration_path()).read(section_, get_slot_path_key(slot));
 }
 
 

--- a/mpi/multipak_configuration.h
+++ b/mpi/multipak_configuration.h
@@ -6,9 +6,9 @@ class multipak_configuration
 {
 public:
 
-	using slot_id_type = ::std::size_t;
-	using path_type = ::std::string;
-	using string_type = ::std::string;
+	using slot_id_type = std::size_t;
+	using path_type = std::string;
+	using string_type = std::string;
 
 
 public:


### PR DESCRIPTION
change
   namespace vcc { namespace core {
to
   namespace vcc::core {

rename configuration_serialzer to intital_settings