### PR TITLE
MPI Disable scs slot change when startup slot is changed

### DIFF
--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -103,7 +103,7 @@ void configuration_dialog::select_new_cartridge(size_t slot)
 		if (mpi_.mount_cartridge(slot, dlg.path()) == cartridge_loader_status::success)
 		{
 			configuration_.slot_cartridge_path(slot, dlg.path());
-			if ( (dlg.gettype()=="dll") || (dlg.gettype() == "DLL") ) {  // DLL?
+			if ( (dlg.gettype()==".dll") || (dlg.gettype() == ".DLL") ) {  // DLL?
 				configuration_.last_accessed_dll_path(dlg.getdir());
 				configuration_.last_accessed_module_type("dll");
 			} else {

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -84,6 +84,7 @@ extern "C"
 		return string_buffer;
 	}
 
+	//See cartridge_loader.h to know what these are actually doing
 	EXPORT_PUBLIC_API void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,

--- a/mpi/mpi.rc
+++ b/mpi/mpi.rc
@@ -50,7 +50,7 @@ END
 // Dialog
 //
 
-IDD_DIALOG1 DIALOGEX 0, 0, 300, 145
+IDD_DIALOG1 DIALOGEX 0, 0, 300, 155
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Multi-Pak Interface 2.1.9.3"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -80,6 +80,7 @@ BEGIN
     LTEXT "Radio button selects startup slot.", IDC_STATIC, 10,128,105,10
     LTEXT ">  Mount cartridge.", IDC_STATIC, 125,128,90,10
     LTEXT "X  Eject cartridge.", IDC_STATIC, 215,128,60,10
+    LTEXT "Do a hard reset or restart VCC for selected slot changes to take effect", IDC_STATIC, 10,140,250,10
 
 //    CHECKBOX        "Persistent ProgramPak Images",IDC_PERSIST_PAK,   15,165,110,10
 //    CHECKBOX        "Disable Cart Select Signal",IDC_SCS_DISABLE,    140,165,100,10


### PR DESCRIPTION
This prevent known VCC crashes when selecting startup slot (Issue #512)

After this change user is required to hard reset after selecting a new startup slot for the slot change to take effect.

This matches a real CoCo where startup slot select does nothing until the coco is restarted.