### PR TITLE
Rename cartridge_context to callbacks

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -131,11 +131,12 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context)
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
 		gHostKeyPtr = host_key;
-		CartMenuCallback = context->add_menu_item;
-		AssertInt = context->assert_interrupt;
+		CartMenuCallback = callbacks->add_menu_item;
+		AssertInt = callbacks->assert_interrupt;
 		strcpy(IniFile, configuration_path);
 
 		RealDisks = InitController();

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -52,7 +52,8 @@ private:
 	friend void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context);
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks);
 	friend void PakGetStatus(char* text_buffer, size_t buffer_size);
 	friend void PakMenuItemClicked(unsigned char menuId);
 	friend void PakReset();

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -35,11 +35,12 @@ GMC_EXPORT const char* PakGetDescription()
 GMC_EXPORT void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,
-	const cpak_cartridge_context* const context)
+	HWND hVccWnd,
+	const cpak_callbacks* const callbacks)
 {
 	Cartridge::m_Singleton->SetHostKey(host_key);
-	Cartridge::m_Singleton->SetMenuBuilderCallback(context->add_menu_item);
-	Cartridge::m_Singleton->SetCartLineAssertCallback(context->assert_cartridge_line);
+	Cartridge::m_Singleton->SetMenuBuilderCallback(callbacks->add_menu_item);
+	Cartridge::m_Singleton->SetCartLineAssertCallback(callbacks->assert_cartridge_line);
 	Cartridge::m_Singleton->SetConfigurationPath(configuration_path);
 }
 

--- a/GMC/CartridgeTrampolines.h
+++ b/GMC/CartridgeTrampolines.h
@@ -6,7 +6,8 @@ GMC_EXPORT const char* PakGetCatalogId();
 GMC_EXPORT void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,
-	const cpak_cartridge_context* const context);
+	HWND hVccWnd,
+	const cpak_callbacks* const callbacks);
 
 GMC_EXPORT void PakGetStatus(char* text_buffer, size_t buffer_size);
 GMC_EXPORT void PakMenuItemClicked(unsigned char /*menuId*/);

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -118,12 +118,13 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context)
+        HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
 		gHostKey = host_key;
-		CartMenuCallback = context->add_menu_item;
-		MemRead8 = context->read_memory_byte;
-		MemWrite8 = context->write_memory_byte;
+		CartMenuCallback = callbacks->add_menu_item;
+		MemRead8 = callbacks->read_memory_byte;
+		MemWrite8 = callbacks->write_memory_byte;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/Ramdisk/Ramdisk.cpp
+++ b/Ramdisk/Ramdisk.cpp
@@ -70,7 +70,8 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const /*host_key*/,
 		const char* const /*configuration_path*/,
-		const cpak_cartridge_context* const /*context*/)
+		HWND hVccWnd,
+		const cpak_callbacks* const /*context*/)
 	{
 		InitMemBoard();
 	}

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -100,10 +100,11 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context)
+        HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
 		gHostKeyPtr = host_key;
-		CartMenuCallback = context->add_menu_item;
+		CartMenuCallback = callbacks->add_menu_item;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -121,11 +121,12 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context)
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
 		gHostKeyPtr = host_key;
-		CartMenuCallback = context->add_menu_item;
-		AssertInt = context->assert_interrupt;
+		CartMenuCallback = callbacks->add_menu_item;
+		AssertInt = callbacks->assert_interrupt;
 		strcpy(IniFile, configuration_path);
 
 		LoadConfig();

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -415,11 +415,12 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context)
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
 		gHostKey = host_key;
-		CartMenuCallback = context->add_menu_item;
-		PakSetCart = context->assert_cartridge_line;
+		CartMenuCallback = callbacks->add_menu_item;
+		PakSetCart = callbacks->assert_cartridge_line;
 		strcpy(IniFile, configuration_path);
 
 		LastStats = GetTickCount();

--- a/libcommon/include/vcc/core/cartridge_callbacks.h
+++ b/libcommon/include/vcc/core/cartridge_callbacks.h
@@ -23,6 +23,7 @@
 enum MenuItemType;
 
 // TODO:  Where cartridge_context is used make it explicit;  It should not be passed as void *;
+// Defines the callbacks a cartridge can make
 namespace vcc::core
 {
 

--- a/libcommon/include/vcc/core/cartridge_loader.h
+++ b/libcommon/include/vcc/core/cartridge_loader.h
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <vcc/core/cartridge.h>
-#include <vcc/core/cartridge_context.h>
+#include <vcc/core/cartridge_callbacks.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
 #include <vcc/core/utils/dll_deleter.h>
 #include <string>
@@ -59,7 +59,8 @@ namespace vcc::core
 		cartridge_loader_status load_result = cartridge_loader_status::not_loaded;
 	};
 
-	struct cartridge_loader_context
+	// TODO: Are these really needed - callbacks are defined in cartridge_callbacks.h
+/*	struct cartridge_loader_context
 	{
 		const PakAssertInteruptHostCallback pak_assert_interrupt;
 		const PakAssertCartridgeLineHostCallback pak_assert_cartridge_line;
@@ -67,9 +68,10 @@ namespace vcc::core
 		const PakReadMemoryByteHostCallback pak_read_memory_byte;
 		const PakAppendCartridgeMenuHostCallback pak_add_menu_item;
 	};
-
+*/
 	LIBCOMMON_EXPORT cartridge_file_type determine_cartridge_type(const std::string& filename);
 
+	// TODO: Eliminate the redundant overloads of loader result
 	LIBCOMMON_EXPORT cartridge_loader_result load_rom_cartridge(
 		const std::string& filename,
 		std::unique_ptr<cartridge_context> cartridge_context);
@@ -79,14 +81,16 @@ namespace vcc::core
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const cpak_cartridge_context& cpak_context);
+		HWND hVccWnd,
+		const cpak_callbacks& cpak_callbacks);
 
 	LIBCOMMON_EXPORT cartridge_loader_result load_cartridge(
-		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
-		void* const host_context,
-		const std::string& iniPath,
-		const cpak_cartridge_context& cpak_context);
+		const std::string& filename,                          // Cartridge filename
+		std::unique_ptr<cartridge_context> cartridge_context, // Yet another cartridge context
+		void* const host_context,                             // Even more context
+		const std::string& iniPath,                           // Path of ini file
+		HWND hVccWnd,                                         // handle to main VCC window proc
+		const cpak_callbacks& cpak_callbacks);                // Callbacks AKA context
 
 	// Return load error string per cartridge load status
 	LIBCOMMON_EXPORT std::string cartridge_load_error_string(

--- a/libcommon/include/vcc/core/cartridges/basic_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/basic_cartridge.h
@@ -18,7 +18,7 @@
 #pragma once
 #include <vcc/core/cartridge.h>
 
-
+//TODO: Stomp this bad boy out. It has no purpose
 namespace vcc::core::cartridges
 {
 

--- a/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/legacy_cartridge.h
@@ -35,10 +35,11 @@ namespace vcc::core::cartridges
 	public:
 
 		LIBCOMMON_EXPORT legacy_cartridge(
-			HMODULE module_handle,
-			void* const host_context,
-			path_type configuration_path,
-			const cpak_cartridge_context& cpak_context);
+			HMODULE module_handle,                        // Cartridge filename
+			void* const host_context,                     // Yet another cartridge context
+			path_type configuration_path,                 // Path of ini file
+			HWND hVccWnd,                                 // Handle to main VCC window proc 
+			const cpak_callbacks& cpak_callbacks);  // Callbacks AKA context
 
 		LIBCOMMON_EXPORT name_type name() const override;
 		LIBCOMMON_EXPORT catalog_id_type catalog_id() const override;
@@ -61,8 +62,9 @@ namespace vcc::core::cartridges
 
 		const HMODULE handle_;
 		void* const host_context_;
+		const HWND hVccWnd_;
 		const path_type configuration_path_;
-		const cpak_cartridge_context cpak_context_;
+		const cpak_callbacks cpak_callbacks_;
 
 		// imported module functions
 		const PakInitializeModuleFunction initialize_;

--- a/libcommon/include/vcc/core/cartridges/null_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/null_cartridge.h
@@ -18,7 +18,7 @@
 #pragma once
 #include <vcc/core/cartridges/basic_cartridge.h>
 
-
+// Basically not a cartridge but by another name
 namespace vcc::core::cartridges
 {
 

--- a/libcommon/include/vcc/core/cartridges/rom_cartridge.h
+++ b/libcommon/include/vcc/core/cartridges/rom_cartridge.h
@@ -17,11 +17,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <vcc/core/cartridges/basic_cartridge.h>
-#include <vcc/core/cartridge_context.h>
+#include <vcc/core/cartridge_callbacks.h>
 #include <vector>
 #include <memory>
 
-
+// TODO:  This could be alot simpler
 namespace vcc::core::cartridges
 {
 

--- a/libcommon/include/vcc/core/legacy_cartridge_definitions.h
+++ b/libcommon/include/vcc/core/legacy_cartridge_definitions.h
@@ -17,12 +17,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <vcc/core/interrupts.h>
+#include <windows.h>
 
 // This is included by all hardware packs
+// TODO: Rename this to cpak_cartridge_definitions.h  (legacy_cartridge --> cpak_cartridge)
 extern "C"
 {
-	// TODO: Rename this to cpak_cartridge_definitions.h  (legacy_cartridge --> cpak_cartridge)
-	// TODO: The host_key should be strongly typed and refer to the loaded cart.
 	enum MenuItemType;
 
 	using PakWriteMemoryByteHostCallback = void (*)(void* host_key, unsigned char value, unsigned short address);
@@ -32,10 +32,8 @@ extern "C"
 	using PakAppendCartridgeMenuHostCallback = void (*)(void* host_key, const char* menu_name, int menu_id, MenuItemType menu_type);
 	using PakResetHostCallback = void (*)(void* host_key);
 
-	// TODO: rename cpak_cartridge_context to cpak_callbacks
-	struct cpak_cartridge_context
+	struct cpak_callbacks
 	{
-		// TODO: This needs a reset callback for mpi
 		const PakAssertInteruptHostCallback assert_interrupt;
 		const PakAssertCartridgeLineHostCallback assert_cartridge_line;
 		const PakWriteMemoryByteHostCallback write_memory_byte;
@@ -44,11 +42,13 @@ extern "C"
 		const PakResetHostCallback reset;
 	};
 
-	// Hardware carts access reset callbacks here
+	// Hardware carts access reset callbacks on Initialize
 	using PakInitializeModuleFunction = void (*)(
-		void* host_key,                                  // HMODULE of dll??
-		const char* const configuration_path,            // Path of ini file
-		const cpak_cartridge_context* const context);    // Callbacks
+		void* host_key,                          // Mysterious master key
+		const char* const configuration_path,    // Path of ini file
+		HWND hVccWnd,                            // VCC Main window HWND
+		const cpak_callbacks* const context);    // Callbacks
+
 	using PakTerminateModuleFunction = void (*)();
 	using PakGetNameModuleFunction = const char* (*)();
 	using PakGetCatalogIdModuleFunction = const char* (*)();

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -130,7 +130,7 @@
     <ClInclude Include="include\vcc\core\cartridges\legacy_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\null_cartridge.h" />
     <ClInclude Include="include\vcc\core\cartridges\rom_cartridge.h" />
-    <ClInclude Include="include\vcc\core\cartridge_context.h" />
+    <ClInclude Include="include\vcc\core\cartridge_callbacks.h" />
     <ClInclude Include="include\vcc\core\cartridge_loader.h" />
     <ClInclude Include="include\vcc\core\detail\exports.h" />
     <ClInclude Include="include\vcc\core\interrupts.h" />

--- a/libcommon/libcommon.vcxproj.filters
+++ b/libcommon/libcommon.vcxproj.filters
@@ -152,7 +152,7 @@
     <ClInclude Include="include\vcc\core\cartridges\basic_cartridge.h">
       <Filter>Header Files\core\cartridges</Filter>
     </ClInclude>
-    <ClInclude Include="include\vcc\core\cartridge_context.h">
+    <ClInclude Include="include\vcc\core\cartridge_callbacks.h">
       <Filter>Header Files\core</Filter>
     </ClInclude>
     <ClInclude Include="include\vcc\core\rom_image.h">

--- a/libcommon/src/core/cartridge_loader.cpp
+++ b/libcommon/src/core/cartridge_loader.cpp
@@ -113,7 +113,8 @@ namespace vcc::core
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const cpak_cartridge_context& cpak_context)
+		HWND hVccWnd,
+		const cpak_callbacks& cpak_callbacks)
 	{
 		if (GetModuleHandle(filename.c_str()) != nullptr)
 		{
@@ -134,7 +135,8 @@ namespace vcc::core
 				details.handle.get(),
 				host_context,
 				iniPath,
-				cpak_context);
+				hVccWnd,
+				cpak_callbacks);
 			details.load_result = cartridge_loader_status::success;
 
 			return details;
@@ -148,7 +150,7 @@ namespace vcc::core
 	// in libcommon/include/vcc/core/cartridge_context.h.  host_context is a generic 
 	// pointer explicitly cast to multipak_cartridge in mpi/multipak_cartridge.cpp.
 	// mutlipak_cartridge refers specifically to a cart loaded by the multipak.
-	// cpak_cartridge_context is used by all hardware paks and is defined in 
+	// cpak_callbacks is used by all hardware paks and is defined in 
 	// libcommon/include/vcc/core/legacy_cartridge_definitions.h.  cartridge_loader_result
 	// is defined in libcommon/include/vcc/core/cartridge_loader.h
 	// TODO: Fix the context insanity
@@ -157,7 +159,8 @@ namespace vcc::core
 		std::unique_ptr<cartridge_context> cartridge_context,
 		void* const host_context,
 		const std::string& iniPath,
-		const cpak_cartridge_context& cpak_context)
+		HWND hVccWnd,
+		const cpak_callbacks& cpak_callbacks)
 	{
 		switch (vcc::core::determine_cartridge_type(filename))
 		{
@@ -174,12 +177,14 @@ namespace vcc::core
 				move(cartridge_context),
 				host_context,
 				iniPath,
-				cpak_context);
+				hVccWnd,
+				cpak_callbacks);					// Callbacks hidden in here
 		}
 	}
 
 	// Return error string per cartridge load status.  This abandons loading the strings
 	// from Vcc.rc resources so mpi does not need to either access or duplicate them.
+	// TODO: Move and make this generic so it also can be used elsewhere in the project
 	std::string cartridge_load_error_string(const cartridge_loader_status error_status)
 	{
 		switch (error_status)

--- a/libcommon/src/core/cartridges/legacy_cartridge.cpp
+++ b/libcommon/src/core/cartridges/legacy_cartridge.cpp
@@ -16,7 +16,7 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO: Rename this to hardware_cartridge
+// TODO: Rename this to hardware_cartridge (cpak_cartridge?)
 
 #include <vcc/core/cartridges/legacy_cartridge.h>
 #include <stdexcept>
@@ -82,12 +82,14 @@ namespace vcc::core::cartridges
 		HMODULE module_handle,
 		void* const host_context,
 		path_type configuration_path,
-		const cpak_cartridge_context& cpak_context)
+		const HWND hVccWnd,
+		const cpak_callbacks& cpak_callbacks)
 		:
 		handle_(module_handle),
 		host_context_(host_context),
 		configuration_path_(move(configuration_path)),
-		cpak_context_(cpak_context),
+		hVccWnd_(hVccWnd),
+		cpak_callbacks_(cpak_callbacks),
 		initialize_(GetImportedProcAddress<PakInitializeModuleFunction>(module_handle, "PakInitialize", nullptr)),
 		terminate_(GetImportedProcAddress(module_handle, "PakTerminate", default_stop)),
 		get_name_(GetImportedProcAddress(module_handle, "PakGetName", default_get_empty_string)),
@@ -123,10 +125,9 @@ namespace vcc::core::cartridges
 		return get_description_();
 	}
 
-
 	void legacy_cartridge::start()
 	{
-		initialize_(host_context_, configuration_path_.c_str(), &cpak_context_);
+		initialize_(host_context_, configuration_path_.c_str(), hVccWnd_, &cpak_callbacks_);
 	}
 
 	void legacy_cartridge::stop()

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -18,7 +18,6 @@
 #pragma once
 #include <vcc/core/cartridge.h>
 #include <vcc/core/cartridge_loader.h>
-#include <vcc/core/cartridge_context.h>
 #include "../CartridgeMenu.h"
 
 

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -16,13 +16,15 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include <vcc/core/cartridge_context.h>
 #include <vcc/core/legacy_cartridge_definitions.h>
+
+// Define the CPAK interface in yet another place but call it something else.
 
 extern "C" __declspec(dllexport) void PakInitialize(
 	void* const host_key,
 	const char* const configuration_path,
-	const cpak_cartridge_context* const context);
+	HWND hVccWnd,
+	const cpak_callbacks* const callbacks);
 
 // FIXME: this should be unnecessary here. VCC (or the 'host') should provide it
 class host_cartridge_context : public ::vcc::core::cartridge_context
@@ -81,7 +83,8 @@ private:
 	friend void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context);
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks);
 	friend class multipak_cartridge;
 
 

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -22,6 +22,7 @@
 #include "resource.h"
 #include <vcc/common/DialogOps.h>
 #include <vcc/core/limits.h>
+#include <vcc/common/logger.h>
 
 #define EXPORT_PUBLIC_API extern "C" __declspec(dllexport)
 
@@ -88,15 +89,22 @@ extern "C"
 	EXPORT_PUBLIC_API void PakInitialize(
 		void* const host_key,
 		const char* const configuration_path,
-		const cpak_cartridge_context* const context)
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
+
+//#define IDM_HELP_ABOUT                  40003
+//#define ID_FILE_RESET                   40005
+//SendMessage(hVccWnd,WM_COMMAND,(WPARAM) ID_FILE_RESET,(LPARAM) 0);
+//SendMessage(hVccWnd,WM_COMMAND,(WPARAM) IDM_HELP_ABOUT,(LPARAM) 0);
+
 		gMultiPakConfiguration.configuration_path(configuration_path);
 		gConfigurationFilename = configuration_path;
-		gHostContext->add_menu_item_ = context->add_menu_item;
-		gHostContext->read_memory_byte_ = context->read_memory_byte;
-		gHostContext->write_memory_byte_ = context->write_memory_byte;
-		gHostContext->assert_interrupt_ = context->assert_interrupt;
-		gHostContext->assert_cartridge_line_ = context->assert_cartridge_line;
+		gHostContext->add_menu_item_ = callbacks->add_menu_item;
+		gHostContext->read_memory_byte_ = callbacks->read_memory_byte;
+		gHostContext->write_memory_byte_ = callbacks->write_memory_byte;
+		gHostContext->assert_interrupt_ = callbacks->assert_interrupt;
+		gHostContext->assert_cartridge_line_ = callbacks->assert_cartridge_line;
 
 		gMultiPakInterface.start();
 	}

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -317,6 +317,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 		std::make_unique<multipak_cartridge_context>(slot, *context_, *this),
 		this,
 		context_->configuration_path(),
+		NULL,  // HWND WinMain not needed by othercarts yet
 		{
 			gHostContext->assert_interrupt_,
 			gSlotCallbacks[slot].set_cartridge_line,

--- a/mpi/multipak_cartridge_context.h
+++ b/mpi/multipak_cartridge_context.h
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include "multipak_cartridge.h"
-#include <vcc/core/cartridge_context.h>
 
 
 class multipak_cartridge_context : public ::vcc::core::cartridge_context

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -78,10 +78,11 @@ extern "C"
 	__declspec(dllexport) void PakInitialize(
 		void* const host_key,
 		const char* const /*configuration_path*/,
-		const cpak_cartridge_context* const context)
+		HWND hVccWnd,
+		const cpak_callbacks* const callbacks)
 	{
 		gHostKey = host_key;
-		PakSetCart = context->assert_cartridge_line;
+		PakSetCart = callbacks->assert_cartridge_line;
 	}
 
 }

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -284,11 +284,12 @@ cartridge_loader_status PakLoadCartridge(const char* filename)
 static cartridge_loader_status load_any_cartridge(const char *filename, const char* iniPath)
 {
 	cartridge_loader_result loadedCartridge(vcc::core::load_cartridge(
-		filename,
-		std::make_unique<vcc_cartridge_context>(),
-		nullptr, // TODO:  Maybe add a VCC host context.
-		iniPath,
-		{
+		filename,                                   // Cartridge filename
+		std::make_unique<vcc_cartridge_context>(),  // Yet another cartridge context
+		nullptr,                                    // Maybe a VCC host context
+		iniPath,                                    // Path of ini file
+		EmuState.WindowHandle,                      // HWND hVccWnd
+		{                                           // Callbacks AKA context
 			PakAssertInterupt,
 			PakAssertCartrigeLine,
 			PakWriteMemoryByte,

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -379,13 +379,14 @@ extern "C"
     __declspec(dllexport) void PakInitialize(
         void* const host_key,
         const char* const configuration_path,
-        const cpak_cartridge_context* const context)
+        HWND hVccWnd,
+        const cpak_callbacks* const callbacks)
     {
         gHostKey = host_key;
-        CartMenuCallback = context->add_menu_item;
-        MemRead8 = context->read_memory_byte;
-        MemWrite8 = context->write_memory_byte;
-        AssertInt = context->assert_interrupt;
+        CartMenuCallback = callbacks->add_menu_item;
+        MemRead8 = callbacks->read_memory_byte;
+        MemWrite8 = callbacks->write_memory_byte;
+        AssertInt = callbacks->assert_interrupt;
         strcpy(IniFile, configuration_path);
 
         LoadConfig();


### PR DESCRIPTION
Code is a bit easier to follow when things are named by what they are instead of what they might become.

Also added HWND hVccWnd to cartridge initialize. This gives DLL's a solid handle to VCC's main window proc.