### PR TITLE
Add reset button to mpi config screen

### DIFF
--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -22,7 +22,6 @@
 #include <vcc/core/utils/critical_section.h>
 #include <vcc/core/utils/filesystem.h>
 
-
 namespace
 {
 
@@ -136,7 +135,7 @@ void configuration_dialog::set_selected_slot(size_t slot)
 			0);
 	}
 
-	// FIXME: Maube move this to the callsite or when the dialog closes or at least make it optional?
+	// FIXME: Maybe move this to the callsite or when the dialog closes or at least make it optional?
 	mpi_.switch_to_slot(slot);
 	configuration_.selected_slot(slot);
 }
@@ -257,6 +256,9 @@ INT_PTR configuration_dialog::process_message(
 			return TRUE;
 		case IDC_INSERT4:
 			eject_or_select_new_cartridge(3);
+			return TRUE;
+		case IDC_RESET:
+			SendMessage(gVccWnd,WM_COMMAND,(WPARAM) ID_FILE_RESET,(LPARAM) 0);
 			return TRUE;
 		} // End switch LOWORD
 		break;

--- a/mpi/mpi.h
+++ b/mpi/mpi.h
@@ -20,7 +20,7 @@
 #include "configuration_dialog.h"
 #include <Windows.h>
 
-extern HINSTANCE gModuleInstance;
+extern HWND	gVccWnd;
 extern const std::shared_ptr<host_cartridge_context> gHostContext;
 extern multipak_cartridge gMultiPakInterface;
 extern configuration_dialog gConfigurationDialog;

--- a/mpi/mpi.rc
+++ b/mpi/mpi.rc
@@ -50,7 +50,7 @@ END
 // Dialog
 //
 
-IDD_DIALOG1 DIALOGEX 0, 0, 300, 155
+IDD_DIALOG1 DIALOGEX 0, 0, 300, 165
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Multi-Pak Interface 2.1.9.3"
 FONT 8, "MS Sans Serif", 0, 0, 0x1
@@ -77,16 +77,17 @@ BEGIN
 
     EDITTEXT        IDC_MODINFO,        175,8,118,115, ES_MULTILINE|ES_READONLY|ES_WANTRETURN
 
-    LTEXT "Radio button selects startup slot.", IDC_STATIC, 10,128,105,10
-    LTEXT ">  Mount cartridge.", IDC_STATIC, 125,128,90,10
-    LTEXT "X  Eject cartridge.", IDC_STATIC, 215,128,60,10
-    LTEXT "Do a hard reset or restart VCC for selected slot changes to take effect", IDC_STATIC, 10,140,250,10
+    LTEXT           "Radio button selects startup slot.", IDC_STATIC, 12,128,105,10
+    LTEXT           ">  Mount cartridge.", IDC_STATIC, 124,128,60,10
+    LTEXT           "X  Eject cartridge.", IDC_STATIC, 194,128,60,10
+
+    LTEXT           "Reset VCC for selected slot changes to take effect", IDC_STATIC, 74,144,230,10
+    PUSHBUTTON      "Reset VCC",IDC_RESET, 10,142,58,14
 
 //    CHECKBOX        "Persistent ProgramPak Images",IDC_PERSIST_PAK,   15,165,110,10
 //    CHECKBOX        "Disable Cart Select Signal",IDC_SCS_DISABLE,    140,165,100,10
 //    DEFPUSHBUTTON   "OK",IDOK,                                       245,163, 40,14
 END
-
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/mpi/resource.h
+++ b/mpi/resource.h
@@ -27,13 +27,17 @@
 #define IDC_MODINFO                     1100
 #define IDC_PERSIST_PAK                 1101
 #define IDC_SCS_DISABLE                 1102
+#define IDC_RESET                       1103
 
+#define ID_FILE_RESET                   40005 // From vcc/resource.h
+
+extern HINSTANCE gModuleInstance;
 // Next default values for new objects
 //
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        103
-#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_COMMAND_VALUE         40006
 #define _APS_NEXT_CONTROL_VALUE         1105
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
A previous commit added requirement that changes to selected mpi slots require a hard reset or restart to take effect.  This solved a longstanding issue where the dialog allowed roms to be deselected or removed while code was still executing in them which caused undefined behaviour and sometimes memory access violations.

To make things easier for users a VCC reset button is added to the mpi config.  Users can press the button for their changes to take immediate effect.

Alternative idea was a "auto reset" checkbox that when checked permitted the mpi to automatically reset when a change is made to a selected cart, this was rejected because it was felt users might want to use the dialog to make multiple changes before resetting.