### PR TITLE
Add comments to clarify cart loading arguments

### DIFF
--- a/CartridgeMenu.h
+++ b/CartridgeMenu.h
@@ -22,29 +22,29 @@
 #include <vector>
 #include <string>
 
-// A menu ID is either a small unsigned integer less than 20 used to identify
-// cart menu functions or a control id in the range 5000 - 5019.  Menu ID's map
-// directly to control id's by adding 5000. The ControlId() constexpr should be
-// used to get the control id from a menu id. There are three "special" message
-// IDs as follows:
+// A menu ID is either a small unsigned integer less than or equal to 50 used
+// to identify cart menu functions with control id in the range 5000 - 5050.
+// Menu ID's map directly to control id's by adding 5000. The ControlId()
+// constexpr should be used to get the control id from a menu id. There are three
+// "special" message IDs as follows:
 
 constexpr auto MID_BEGIN  = 0;  // Clears the menu, optionally reserving some entries.
 constexpr auto MID_FINISH = 1;  // Draws the menu
-constexpr auto MID_ENTRY  = 2;  // A menu item with no control ID
+constexpr auto MID_ENTRY  = 2;  // A menu item with no control
 
 //  Menu IDs other than the above special ones must be converted to control IDs
 //  using the ControlId() constexpr. These reference controls that are activated
 //  when the menu item is selected.
 
-//  The MPI adds 20 times the slot number (1-4) to the ID when a cartridge is loaded in
+//  The MPI adds 50 times the slot number (1-4) to the ID when a cartridge is loaded in
 //  an mpi slot, then subtracts this value when the item is activated before using
-//  it to call the control in the cartridge dll. This allows module configs to work
-//  properly regardless of which slot they are in.
+//  it to call the control in the cartridge dll. This allows dynamic cartridge menus to
+//  work properly regardless of which slot they are in.
 
 constexpr auto MID_CONTROL = 5000;
 
 // constexpr to convert menu id number to control id
-constexpr int ControlId(int id) { return MID_CONTROL + id; }; 
+constexpr int ControlId(int id) { return MID_CONTROL + id; };
 
 // Menu item types, one of the following.
 enum MenuItemType
@@ -78,8 +78,8 @@ public:
 //  Title is menu bar title, position is location menu will be placed on the menu bar.
 	void init(const char * title="Cartridge", int position=3);
 
-//  Reserve cartmenu items. The reserve value allows the 'Cartridge' menu item and 
-//  it's submenu to remain intact when DLL's append items to the menu. The reserve 
+//  Reserve cartmenu items. The reserve value allows the 'Cartridge' menu item and
+//  it's submenu to remain intact when DLL's append items to the menu. The reserve
 //  value is only used whwn MID_BEGIN items are encountered.
 	void reserve(const unsigned int count);
 

--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -121,13 +121,7 @@ extern "C"
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
-		DLOG_C("FDC %p %p %p %p %p\n",
-			callbacks->assert_interrupt,
-			callbacks->assert_cartridge_line,
-			callbacks->write_memory_byte,
-			callbacks->read_memory_byte,
-			callbacks->add_menu_item);
-
+		DLOG_C("FDC %p %p %p %p %p\n",*callbacks);
 		gCallbackContextPtr = callback_context;
 		CartMenuCallback = callbacks->add_menu_item;
 		AssertInt = callbacks->assert_interrupt;

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -299,7 +299,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			// Parse the menu selections:
 			
 			// Check if ID is in cartridge menu range
-			if ( (wmId >= MID_CONTROL) & (wmId < MID_CONTROL + 100) )
+			if ( (wmId >= MID_CONTROL) & (wmId < MID_CONTROL + 250) )
 			{
 				CartMenuActivated(wmId-MID_CONTROL);
 				break;

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -28,16 +28,16 @@ HINSTANCE gModuleInstance = nullptr;
 static std::string gConfigurationFilename;
 HWND gVccWnd;
 
-// host_catridge_context (remove someday)
-const std::shared_ptr<host_cartridge_context> gHostContext(std::make_shared<host_cartridge_context>(nullptr, gConfigurationFilename));
+const std::shared_ptr<host_cartridge_context>
+	gHostCallbacks(std::make_shared<host_cartridge_context>(nullptr, gConfigurationFilename));
 
-// Instatiate mpi configuration object (remove someday)
+// mpi configuration object
 multipak_configuration gMultiPakConfiguration("MPI");
 
-// Instatiate mpi cartridge object (remove someday)
-multipak_cartridge gMultiPakInterface(gMultiPakConfiguration, gHostContext);
+// mpi cartridge object
+multipak_cartridge gMultiPakInterface(gMultiPakConfiguration, gHostCallbacks);
 
-// Instatiate the config dialog
+// the config dialog
 configuration_dialog gConfigurationDialog(gMultiPakConfiguration, gMultiPakInterface);
 
 // DLL exports
@@ -67,11 +67,11 @@ extern "C"
 		gMultiPakConfiguration.configuration_path(configuration_path);
 		gConfigurationFilename = configuration_path;
 		gVccWnd = hVccWnd;
-		gHostContext->add_menu_item_ = callbacks->add_menu_item;
-		gHostContext->read_memory_byte_ = callbacks->read_memory_byte;
-		gHostContext->write_memory_byte_ = callbacks->write_memory_byte;
-		gHostContext->assert_interrupt_ = callbacks->assert_interrupt;
-		gHostContext->assert_cartridge_line_ = callbacks->assert_cartridge_line;
+		gHostCallbacks->add_menu_item_ = callbacks->add_menu_item;
+		gHostCallbacks->read_memory_byte_ = callbacks->read_memory_byte;
+		gHostCallbacks->write_memory_byte_ = callbacks->write_memory_byte;
+		gHostCallbacks->assert_interrupt_ = callbacks->assert_interrupt;
+		gHostCallbacks->assert_cartridge_line_ = callbacks->assert_cartridge_line;
 		gMultiPakInterface.start();
 	}
 

--- a/mpi/mpi.h
+++ b/mpi/mpi.h
@@ -21,7 +21,7 @@
 #include <Windows.h>
 
 extern HWND	gVccWnd;
-extern const std::shared_ptr<host_cartridge_context> gHostContext;
+extern const std::shared_ptr<host_cartridge_context> gHostCallbacks;
 extern multipak_cartridge gMultiPakInterface;
 extern configuration_dialog gConfigurationDialog;
 extern std::string gLastAccessedPath;

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -380,12 +380,7 @@ extern "C"
         HWND hVccWnd,
         const cpak_callbacks* const callbacks)
     {
-        DLOG_C("SDC %p %p %p %p %p\n",
-            callbacks->assert_interrupt,
-            callbacks->assert_cartridge_line,
-            callbacks->write_memory_byte,
-            callbacks->read_memory_byte,
-            callbacks->add_menu_item);
+        DLOG_C("SDC %p %p %p %p %p\n",*callbacks);
         gCallbackContext = callback_context;
         CartMenuCallback = callbacks->add_menu_item;
         AssertIntCallback = callbacks->assert_interrupt;


### PR DESCRIPTION
Explicitly define callback_context and add comments to cartridge interface arguments to make their purpose clearer. Increase max menu items per cartridge from 20 to 50