### PR TITLE
Change build output directory for static builds and other fixes

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -132,6 +132,11 @@ extern "C"
 		BuildCartridgeMenu();
 	}
 
+	__declspec(dllexport) void PakReset()
+	{
+		LoadExtRom(External,RomFileName);
+	}
+
 	__declspec(dllexport) void PakTerminate()
 	{
 		CloseCartDialog(g_hConfDlg);
@@ -677,11 +682,11 @@ void LoadConfig()  // Called on SetIniPath
 	GetModuleFileName(nullptr, DiskRomPath, MAX_PATH);
 	PathRemoveFileSpec(DiskRomPath);
 	strcpy(RGBRomPath, DiskRomPath);
-	strcat(DiskRomPath, "disk11.rom"); //Failing silent, Maybe we should throw a warning?
-	strcat(RGBRomPath, "rgbdos.rom");  //Future, Grey out dialog option if can't find file
-	LoadExtRom(TandyDisk, DiskRomPath);
-	LoadExtRom(RGBDisk, RGBRomPath);
-	if (PersistDisks)
+	strcat(DiskRomPath, "disk11.rom");
+	strcat(RGBRomPath, "rgbdos.rom");
+	LoadExtRom(TandyDisk, DiskRomPath); // Why load?
+	LoadExtRom(RGBDisk, RGBRomPath);    // Why load?
+	if (PersistDisks)                   // TODO: Fix this, checkbox was removed
 		for (Index=0;Index<4;Index++)
 		{
 			sprintf(Temp,"Disk#%i",Index);
@@ -738,7 +743,6 @@ void SaveConfig()
 
 unsigned char LoadExtRom( unsigned char RomType,const char *FilePath)	//Returns 1 on if loaded
 {
-
 	FILE *rom_handle=nullptr;
 	unsigned short index=0;
 	unsigned char RetVal=0;
@@ -755,5 +759,6 @@ unsigned char LoadExtRom( unsigned char RomType,const char *FilePath)	//Returns 
 		fclose(rom_handle);
 	}
 
+	DLOG_C("load %s %d %d\n",FilePath,RomType,RetVal);
 	return RetVal;
 }

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -63,9 +63,9 @@
     <ClCompile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <!--<WholeProgramOptimization Condition="'$(LinkageType)' == 'Static'">true</WholeProgramOptimization>
-      <WholeProgramOptimization Condition="'$(LinkageType)' == 'Dynamic'">false</WholeProgramOptimization>-->
+          <WholeProgramOptimization Condition="'$(LinkageType)' == 'Dynamic'">false</WholeProgramOptimization>-->
     </ClCompile>
-    <OutDir>$(SolutionDir)__obj\$(LinkTypeSubDir)\$(Platform)\$(Configuration)\vcc\out\</OutDir>
+    <!--<OutDir>$(SolutionDir)__obj\$(LinkTypeSubDir)$(Platform)\$(Configuration)\vcc\out\</OutDir>-->
     <TargetExt Condition="'$(LinkageType)' == 'Dynamic'">.vcc</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Legacy|Win32'">

--- a/orch90/orch90.rc
+++ b/orch90/orch90.rc
@@ -103,7 +103,7 @@ BEGIN
     IDS_MODULE_NAME         "Orchestra-90"
     IDS_CATNUMBER           "26-3143"
     IDS_VERSION             "1.30"
-    IDS_DESCRIPTION         "Emulates Tandy Orchestra-90 CC Stereo Music Synthesizer cart with rom. Supports six octave ranges and up tp five simultaneous voices. Can transfer music to/from tape or from a floppy mounted in FD502 drive one.  FD502 must be inserted in mpi slot 4."
+    IDS_DESCRIPTION         "Emulates Tandy Orchestra-90 CC Stereo Music Synthesizer cart with rom. Supports six octave ranges and up to five simultaneous voices. Can transfer music to/from tape or from a floppy mounted in drive zero.  Either FD502 or SDC must be inserted in mpi slot 4 for floppy support."
 END
 
 #endif    // English (U.S.) resources

--- a/tcc1014mmu.cpp
+++ b/tcc1014mmu.cpp
@@ -58,7 +58,7 @@ void UpdateMmuArray();
 /*****************************************************************************************
 * MmuInit Initilize and allocate memory for RAM Internal and External ROM Images.        *
 * Copy Rom Images to buffer space and reset GIME MMU registers to 0                      *
-* Returns nullptr if any of the above fail.                                                 *
+* Returns nullptr if any of the above fail.                                              *
 *****************************************************************************************/
 unsigned char * MmuInit(unsigned char RamConfig)
 {

--- a/vcc-base.props
+++ b/vcc-base.props
@@ -8,10 +8,10 @@
     <LinkageType>Static</LinkageType>
     <LinkageType Condition="'$(USE_STATIC_LIB)' == 'false'">Dynamic</LinkageType>
     <!-- Output and Intermediate directories -->
-    <LinkTypeSubDir Condition="'$(LinkageType)' == 'Static'">Static</LinkTypeSubDir>
-    <LinkTypeSubDir Condition="'$(LinkageType)' == 'Dynamic'">Dynamic</LinkTypeSubDir>
-    <OutDir>$(SolutionDir)__obj\$(LinkTypeSubDir)\$(Platform)\$(Configuration)\$(ProjectName)\out\</OutDir>
-    <IntDir>$(SolutionDir)__obj\$(LinkTypeSubDir)\$(Platform)\$(Configuration)\$(ProjectName)\int\</IntDir>
+    <LinkTypeSubDir Condition="'$(LinkageType)' == 'Static'"></LinkTypeSubDir>
+    <LinkTypeSubDir Condition="'$(LinkageType)' == 'Dynamic'">Dynamic\</LinkTypeSubDir>
+    <OutDir>$(SolutionDir)__obj\$(LinkTypeSubDir)$(Platform)\$(Configuration)\$(ProjectName)\out\</OutDir>
+    <IntDir>$(SolutionDir)__obj\$(LinkTypeSubDir)$(Platform)\$(Configuration)\$(ProjectName)\int\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(LinkageType)' == 'Dynamic'">


### PR DESCRIPTION
Output directory for static builds is now __obj/Win32/... 
Output directory for dyanmic lib builds  __obj/Dynamic/Win32/... 
Libcommon.lib no longer placed in Vcc output directory
Clean up orch90 description
FD502 reload rom on reset
$FF7F now contains correct value after hard reset