### PR TITLE
Standardize namespace

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -30,7 +30,7 @@ namespace VCC::Debugger
 
 	void Debugger::Reset()
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		ExecutionMode_ = ExecutionMode::Run;
 		PendingCommand_ = ExecutionMode::Halt;
@@ -50,7 +50,7 @@ namespace VCC::Debugger
 
 	void Debugger::RegisterClient(HWND window, std::unique_ptr<Client> client)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		if (!client)
 		{
@@ -68,7 +68,7 @@ namespace VCC::Debugger
 	
 	void Debugger::RemoveClient(HWND window)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		if (RegisteredClients_.find(window) == RegisteredClients_.end())
 		{
@@ -99,7 +99,7 @@ namespace VCC::Debugger
 		}
 
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			VCC::Util::section_locker lock(Section_);
 			returnPc = ProcessorState_.PC;
 		}
 
@@ -116,7 +116,7 @@ namespace VCC::Debugger
 
 	CPUState Debugger::GetProcessorStateCopy() const
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		return ProcessorState_;
 	}
@@ -142,7 +142,7 @@ namespace VCC::Debugger
 
 	void Debugger::SetBreakpoints(breakpointsbuffer_type breakpoints)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		Breakpoints_ = move(breakpoints);
 		BreakpointsChanged_ = true;
@@ -279,14 +279,14 @@ namespace VCC::Debugger
 		TraceEnabled_ = false;
 		TraceRunning_ = false;
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			VCC::Util::section_locker lock(Section_);
 			Decoder_->Reset(TraceMaxSamples_);
 		}
 	}
 
 	void Debugger::SetTraceMaxSamples(long samples)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		TraceMaxSamples_ = samples;
 		Decoder_->Reset(TraceMaxSamples_);
@@ -294,7 +294,7 @@ namespace VCC::Debugger
 
 	void Debugger::SetTraceStartTriggers(triggerbuffer_type startTriggers)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		TraceStartTriggers_ = move(startTriggers);
 		TraceTriggerChanged_ = true;
@@ -302,7 +302,7 @@ namespace VCC::Debugger
 
 	void Debugger::SetTraceStopTriggers(triggerbuffer_type stopTriggers)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		TraceStopTriggers_ = move(stopTriggers);
 		TraceTriggerChanged_ = true;
@@ -310,7 +310,7 @@ namespace VCC::Debugger
 
 	void Debugger::SetTraceOptions(bool screen, bool emulation)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		TraceScreen_ = screen;
 		TraceEmulation_ = emulation;
@@ -318,7 +318,7 @@ namespace VCC::Debugger
 
 	long Debugger::GetTraceSamples() const
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		return Decoder_->GetSampleCount();
 	}
@@ -330,7 +330,7 @@ namespace VCC::Debugger
 
 	void Debugger::SetTraceMark(int mark, long sample)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		TraceMarks_[mark] = sample;
 	}
@@ -338,14 +338,14 @@ namespace VCC::Debugger
 
 	void Debugger::ClearTraceMarks()
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		TraceMarks_.clear();
 	}
 
 	void Debugger::GetTraceMarkSamples(tracebuffer_type &result) const
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		result.clear();
 
@@ -360,7 +360,7 @@ namespace VCC::Debugger
 	void Debugger::QueueRun()
 	{
 		ApplyHaltpoints(true);
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Run;
 		HasPendingCommand_ = true;
@@ -368,7 +368,7 @@ namespace VCC::Debugger
 
 	void Debugger::QueueStep()
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Step;
 		HasPendingCommand_ = true;
@@ -377,7 +377,7 @@ namespace VCC::Debugger
 	void Debugger::QueueHalt()
 	{
 		ApplyHaltpoints(false);
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		PendingCommand_ = ExecutionMode::Halt;
 		HasPendingCommand_ = true;
@@ -397,7 +397,7 @@ namespace VCC::Debugger
 	void Debugger::Update()
 	{
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			VCC::Util::section_locker lock(Section_);
 
 			ProcessorState_ = CPUGetState();
 
@@ -457,7 +457,7 @@ namespace VCC::Debugger
 
 	void Debugger::QueueWrite(unsigned short addr, unsigned char value)
 	{
-		vcc::core::utils::section_locker lock(Section_);
+		VCC::Util::section_locker lock(Section_);
 
 		PendingWrite_ = PendingWrite(addr, value);
 		HasPendingWrite_ = true;

--- a/Debugger.h
+++ b/Debugger.h
@@ -146,7 +146,7 @@ namespace VCC::Debugger
 
 	private:
 
-		mutable vcc::core::utils::critical_section	Section_;
+		mutable VCC::Util::critical_section	Section_;
 		bool							HasPendingCommand_ = false;
 		ExecutionMode					PendingCommand_ = ExecutionMode::Halt;
 		breakpointsbuffer_type			Breakpoints_;

--- a/Disassembler.cpp
+++ b/Disassembler.cpp
@@ -114,7 +114,7 @@ std::string FmtLine(
 /*            Static Variables                    */
 /**************************************************/
 
-vcc::core::utils::critical_section Section_;
+VCC::Util::critical_section Section_;
 
 HINSTANCE hVccInst;
 
@@ -790,7 +790,7 @@ void UnHilitePC()
 /***************************************************/
 void ApplyHaltPoint(Haltpoint &hp,bool flag)
 {
-	vcc::core::utils::section_locker lock(Section_);
+	VCC::Util::section_locker lock(Section_);
     if (flag) {
         if (!hp.placed) {
             // Be sure really not placed

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -39,7 +39,7 @@ static char *VHDfile; // Selected drive file name
 static char NewVHDfile[MAX_PATH];
 static char IniFile[MAX_PATH]  { 0 };
 static char HardDiskPath[MAX_PATH];
-static ::vcc::devices::rtc::cloud9 cloud9_rtc;
+static ::VCC::Device::rtc::cloud9 cloud9_rtc;
 
 static void* gCallbackContext = nullptr;
 static PakReadMemoryByteHostCallback MemRead8 = nullptr;

--- a/MMUMonitor.cpp
+++ b/MMUMonitor.cpp
@@ -31,7 +31,7 @@ namespace {
 	const COLORREF rgbViolet = RGB(100,   0, 170);
 	const COLORREF rgbGray   = RGB(120, 120, 120);
 
-	vcc::core::utils::critical_section Section_;
+	VCC::Util::critical_section Section_;
 	MMUState MMUState_;
 
 	HWND MMUMonitorWindow = nullptr;
@@ -44,7 +44,7 @@ namespace {
 		void OnReset() override {
 		}
 		void OnUpdate() override {
-			vcc::core::utils::section_locker lock(Section_);
+			VCC::Util::section_locker lock(Section_);
 			MMUState_ = GetMMUState();
 		}
 	};
@@ -107,7 +107,7 @@ namespace {
 		// Quick pull out MMU state
 		MMUState regs;
 		{
-			vcc::core::utils::section_locker lock(Section_);
+			VCC::Util::section_locker lock(Section_);
 			regs = MMUState_;
 		}
 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -34,7 +34,7 @@ This file is part of VCC (Virtual Color Computer).
 static char FileName[MAX_PATH] { 0 };
 static char IniFile[MAX_PATH]  { 0 };
 static char SuperIDEPath[MAX_PATH];
-static ::vcc::devices::rtc::cloud9 cloud9_rtc;
+static ::VCC::Device::rtc::cloud9 cloud9_rtc;
 static PakAppendCartridgeMenuHostCallback CartMenuCallback = nullptr;
 static unsigned char BaseAddress=0x50;
 void BuildCartridgeMenu();

--- a/docs/namespaces.txt
+++ b/docs/namespaces.txt
@@ -1,25 +1,26 @@
-We let namspaces get a bit overboard. Namespaces are for preventing
-name collisions, not to fully classify sources or to define directory
+
+We let namspaces get a bit overboard. Namespaces are for loosely
+grouping objects and preventing object name collisions. They
+should not be used to over classify sources or to define directory
 or common library structures.
 
-Also we let the case of the VCC namespace change. This gains nothing
+Also we let the case of the VCC namespace change and we have 
+namespaces the use either VCC:: or vcc::  This gains nothing
 but confusion.  I see two choices here. a) go all lowercase or 
-b) use CamelCase.  Since we already had CamelCase I suggest we stick
-with it:
+b) use CamelCase.  Since we previously had CamelCase I decided
+to return to it.
 
-Valid VCC namespaces 
+After applying CamelCase there is now the following:
 
-VCC                // The VCC core emulator
-VCC::UI            // The VCC core user interface (future)
-VCC::Util          // Generic utilities used by VCC
-VCC::Debugger      // Coco Debugger code
-VCC::Debugger::UI  // Coco Debugger user interface
+VCC::			   // Any VCC object
+VCC::Core          // VCC core objects
+VCC::UI            // VCC user interface objects
+VCC::Util          // VCC utility objects
+VCC::Debugger      // Coco Debugger objects
+VCC::Debugger::UI  // Coco Debugger UI objects
+VCC::Device		   // VCC device objects
 
-The following are invalid and should be changed when touched:
-
-namespace vcc                   -> namespace VCC
-namespace vcc::core             -> namespace VCC
-namespace vcc::core::cartridges -> namespace VCC
-namespace vcc::core::utils      -> namespace VCC::Util
-namespace vcc::devices::rtc     -> namespace VCC
-namespace vcc::modules::mpi     -> namespace VCC
+I used 'sed -i' modify all namespaces to this standard.  If CamelCase
+causes much heartburn it is simple to use sed to make them all
+lowercase.  If done properly renaming the namespaces should cause
+no effect on compiled code.

--- a/libcommon/include/vcc/bus/basic_cartridge.h
+++ b/libcommon/include/vcc/bus/basic_cartridge.h
@@ -19,10 +19,10 @@
 #include <vcc/bus/cartridge.h>
 
 //TODO: Stomp this bad boy out. It has no purpose
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
-	struct LIBCOMMON_EXPORT basic_cartridge : public ::vcc::core::cartridge
+	struct LIBCOMMON_EXPORT basic_cartridge : public ::VCC::Core::cartridge
 	{
 	public:
 

--- a/libcommon/include/vcc/bus/cartridge.h
+++ b/libcommon/include/vcc/bus/cartridge.h
@@ -20,7 +20,7 @@
 #include <string>
 
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	struct LIBCOMMON_EXPORT cartridge

--- a/libcommon/include/vcc/bus/cartridge_callbacks.h
+++ b/libcommon/include/vcc/bus/cartridge_callbacks.h
@@ -24,7 +24,7 @@ enum MenuItemType;
 
 // TODO:  Where cartridge_context is used make it explicit;  It should not be passed as void *;
 // Defines the callbacks a cartridge can make
-namespace vcc::core
+namespace VCC::Core
 {
 
 	struct LIBCOMMON_EXPORT cartridge_context

--- a/libcommon/include/vcc/bus/cartridge_loader.h
+++ b/libcommon/include/vcc/bus/cartridge_loader.h
@@ -25,7 +25,7 @@
 #include <Windows.h>
 
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	enum class cartridge_file_type
@@ -48,8 +48,8 @@ namespace vcc::core
 
 	struct LIBCOMMON_EXPORT cartridge_loader_result
 	{
-		using handle_type = std::unique_ptr<std::remove_pointer_t<HMODULE>, vcc::core::dll_deleter>;
-		using cartridge_ptr_type = std::unique_ptr<vcc::core::cartridge>;
+		using handle_type = std::unique_ptr<std::remove_pointer_t<HMODULE>, VCC::Core::dll_deleter>;
+		using cartridge_ptr_type = std::unique_ptr<VCC::Core::cartridge>;
 
 #pragma warning(push)
 #pragma warning(disable: 4251)

--- a/libcommon/include/vcc/bus/cpak_cartridge.h
+++ b/libcommon/include/vcc/bus/cpak_cartridge.h
@@ -22,7 +22,7 @@
 #include <string>
 
 
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
 	class cpak_cartridge: public cartridge

--- a/libcommon/include/vcc/bus/dll_deleter.h
+++ b/libcommon/include/vcc/bus/dll_deleter.h
@@ -19,7 +19,7 @@
 #include <vcc/util/logger.h>
 #include <Windows.h>
 // How nuts is this?  Just friggen call FreeLibrary at the point that is decided
-namespace vcc::core
+namespace VCC::Core
 {
 	struct LIBCOMMON_EXPORT dll_deleter
 	{

--- a/libcommon/include/vcc/bus/null_cartridge.h
+++ b/libcommon/include/vcc/bus/null_cartridge.h
@@ -19,7 +19,7 @@
 #include <vcc/bus/basic_cartridge.h>
 
 // Basically not a cartridge but by another name
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
 	class LIBCOMMON_EXPORT null_cartridge : public basic_cartridge

--- a/libcommon/include/vcc/bus/rom_cartridge.h
+++ b/libcommon/include/vcc/bus/rom_cartridge.h
@@ -22,14 +22,14 @@
 #include <memory>
 
 // TODO:  This could be alot simpler
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
 	class rom_cartridge : public basic_cartridge
 	{
 	public:
 
-		using context_type = ::vcc::core::cartridge_context;
+		using context_type = ::VCC::Core::cartridge_context;
 		using buffer_type = std::vector<uint8_t>;
 		using size_type = std::size_t;
 

--- a/libcommon/include/vcc/bus/rom_image.h
+++ b/libcommon/include/vcc/bus/rom_image.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	class rom_image

--- a/libcommon/include/vcc/devices/cloud9.h
+++ b/libcommon/include/vcc/devices/cloud9.h
@@ -2,7 +2,7 @@
 #include <vcc/util/exports.h>  // defines LIBCOMMON_EXPORT if libcommon is a DLL
 #include <Windows.h>
 
-namespace vcc::devices::rtc
+namespace VCC::Device::rtc
 {
 
 	class LIBCOMMON_EXPORT cloud9

--- a/libcommon/include/vcc/util/critical_section.h
+++ b/libcommon/include/vcc/util/critical_section.h
@@ -18,7 +18,7 @@
 #pragma once
 #include <Windows.h>
 
-namespace vcc::core::utils
+namespace VCC::Util
 {
 
 	class critical_section

--- a/libcommon/include/vcc/util/filesystem.h
+++ b/libcommon/include/vcc/util/filesystem.h
@@ -4,7 +4,7 @@
 #include <Windows.h>
 
 //TODO: depreciate this - it is used only in mpi/multipak_cartridge.cpp:
-namespace vcc::core::utils
+namespace VCC::Util
 {
 	LIBCOMMON_EXPORT std::string find_pak_module_path(std::string path);
 }

--- a/libcommon/include/vcc/util/initial_settings.h
+++ b/libcommon/include/vcc/util/initial_settings.h
@@ -19,7 +19,7 @@
 #include <vcc/util/exports.h>  // defines LIBCOMMON_EXPORT if libcommon is a DLL
 #include <string>
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	class initial_settings

--- a/libcommon/include/vcc/util/winapi.h
+++ b/libcommon/include/vcc/util/winapi.h
@@ -23,7 +23,7 @@
 // I think winapi is intended to contain windows api calls. Not sure why it
 // was created because that could be any thing used to interact with Windows.
 
-namespace vcc::core::utils
+namespace VCC::Util
 {
     // Load resource string
 	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id);

--- a/libcommon/src/bus/basic_cartridge.cpp
+++ b/libcommon/src/bus/basic_cartridge.cpp
@@ -18,7 +18,7 @@
 #include <vcc/bus/basic_cartridge.h>
 
 
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
 	basic_cartridge::name_type basic_cartridge::name() const

--- a/libcommon/src/bus/cartridge_loader.cpp
+++ b/libcommon/src/bus/cartridge_loader.cpp
@@ -23,7 +23,7 @@
 #include <iterator>
 
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	namespace
@@ -93,7 +93,7 @@ namespace vcc::core
 
 		return {
 			nullptr,
-			std::make_unique<vcc::core::cartridges::rom_cartridge>(
+			std::make_unique<VCC::Core::rom_cartridge>(
 				move(context),
 				extract_filename(filename),
 				"",
@@ -130,7 +130,7 @@ namespace vcc::core
 
 		if (GetProcAddress(details.handle.get(), "PakInitialize") != nullptr)
 		{
-			details.cartridge = std::make_unique<vcc::core::cartridges::cpak_cartridge>(
+			details.cartridge = std::make_unique<VCC::Core::cpak_cartridge>(
 				details.handle.get(),
 				host_context,
 				iniPath,
@@ -160,17 +160,17 @@ namespace vcc::core
 		HWND hVccWnd,
 		const cpak_callbacks& cpak_callbacks)
 	{
-		switch (vcc::core::determine_cartridge_type(filename))
+		switch (VCC::Core::determine_cartridge_type(filename))
 		{
 		default:
 		case cartridge_file_type::not_opened:	//	File doesn't exist or can't be opened
 			return { nullptr, nullptr, cartridge_loader_status::cannot_open };
 
 		case cartridge_file_type::rom_image:	//	File is a ROM image
-			return vcc::core::load_rom_cartridge(move(cartridge_context), filename);
+			return VCC::Core::load_rom_cartridge(move(cartridge_context), filename);
 
 		case cartridge_file_type::library:		//	File is a DLL
-			return vcc::core::load_cpak_cartridge(
+			return VCC::Core::load_cpak_cartridge(
 				filename,
 				move(cartridge_context),
 				host_context,

--- a/libcommon/src/bus/cpak_cartridge.cpp
+++ b/libcommon/src/bus/cpak_cartridge.cpp
@@ -21,7 +21,7 @@
 #include <vcc/bus/cpak_cartridge.h>
 #include <stdexcept>
 
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
 	namespace

--- a/libcommon/src/bus/rom_cartridge.cpp
+++ b/libcommon/src/bus/rom_cartridge.cpp
@@ -18,7 +18,7 @@
 #include <vcc/bus/rom_cartridge.h>
 
 
-namespace vcc::core::cartridges
+namespace VCC::Core
 {
 
 	rom_cartridge::rom_cartridge(

--- a/libcommon/src/bus/rom_image.cpp
+++ b/libcommon/src/bus/rom_image.cpp
@@ -20,7 +20,7 @@
 #include <Windows.h>
 
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	bool rom_image::load(path_type filename)

--- a/libcommon/src/devices/cloud9.cpp
+++ b/libcommon/src/devices/cloud9.cpp
@@ -26,7 +26,7 @@ along with VCC (Virtual Color Computer).  If not, see <http://www.gnu.org/licens
 #include <vcc/devices/cloud9.h>
 #include <Windows.h>
 
-namespace vcc::devices::rtc
+namespace VCC::Device::rtc
 {
 
 	unsigned char cloud9::read_port(unsigned short port)

--- a/libcommon/src/util/filesystem.cpp
+++ b/libcommon/src/util/filesystem.cpp
@@ -4,7 +4,7 @@
 //TODO filesystem.cpp is depreciated
 //TODO move this it is used only in mpi/multipak_cartridge.cpp:
 
-namespace vcc::core::utils
+namespace VCC::Util
 {
 	LIBCOMMON_EXPORT std::string find_pak_module_path(std::string path)
 	{

--- a/libcommon/src/util/initial_settings.cpp
+++ b/libcommon/src/util/initial_settings.cpp
@@ -19,7 +19,7 @@
 #include <Windows.h>
 
 
-namespace vcc::core
+namespace VCC::Core
 {
 
 	initial_settings::initial_settings(path_type path)

--- a/libcommon/src/util/winapi.cpp
+++ b/libcommon/src/util/winapi.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <windows.h>
 
-namespace vcc::core::utils
+namespace VCC::Util
 {
 	LIBCOMMON_EXPORT std::string load_string(HINSTANCE instance, UINT id)
 	{

--- a/mpi/cartridge_slot.cpp
+++ b/mpi/cartridge_slot.cpp
@@ -19,11 +19,11 @@
 #include <vcc/bus/null_cartridge.h>
 
 
-namespace vcc::modules::mpi
+namespace VCC::Core
 {
 
 	cartridge_slot::cartridge_slot()
-		: cartridge_(std::make_unique<::vcc::core::cartridges::null_cartridge>())
+		: cartridge_(std::make_unique<::VCC::Core::null_cartridge>())
 	{}
 
 	cartridge_slot::cartridge_slot(path_type path, handle_type handle, cartridge_ptr_type cartridge)

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -21,23 +21,23 @@
 #include "../CartridgeMenu.h"
 
 
-namespace vcc::modules::mpi
+namespace VCC::Core
 {
 
 	class cartridge_slot
 	{
 	public:
 
-		using name_type = ::vcc::core::cartridge::name_type;
-		using catalog_id_type = ::vcc::core::cartridge::catalog_id_type;
-		using description_type = ::vcc::core::cartridge::description_type;
+		using name_type = ::VCC::Core::cartridge::name_type;
+		using catalog_id_type = ::VCC::Core::cartridge::catalog_id_type;
+		using description_type = ::VCC::Core::cartridge::description_type;
 		using path_type = std::string;
 		using label_type = std::string;
-		using handle_type = ::vcc::core::cartridge_loader_result::handle_type;
-		using cartridge_ptr_type = std::unique_ptr<::vcc::core::cartridge>;
+		using handle_type = ::VCC::Core::cartridge_loader_result::handle_type;
+		using cartridge_ptr_type = std::unique_ptr<::VCC::Core::cartridge>;
 		using menu_item_type = CartMenuItem;
 		using menu_item_collection_type = std::vector<menu_item_type>;
-		using context_type = ::vcc::core::cartridge_context;
+		using context_type = ::VCC::Core::cartridge_context;
 
 
 	public:

--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -27,7 +27,7 @@
 namespace
 {
 
-	using cartridge_loader_status = vcc::core::cartridge_loader_status;
+	using cartridge_loader_status = VCC::Core::cartridge_loader_status;
 
 	struct cartridge_ui_element_identifiers
 	{

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -27,7 +27,7 @@ extern "C" __declspec(dllexport) void PakInitialize(
 	const cpak_callbacks* const callbacks);
 
 // FIXME: this should be unnecessary here. VCC (or the 'host') should provide it
-class host_cartridge_context : public ::vcc::core::cartridge_context
+class host_cartridge_context : public ::VCC::Core::cartridge_context
 {
 public:
 

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -82,17 +82,17 @@ multipak_cartridge::multipak_cartridge(
 
 multipak_cartridge::name_type multipak_cartridge::name() const
 {
-	return ::vcc::core::utils::load_string(gModuleInstance, IDS_MODULE_NAME);
+	return ::VCC::Util::load_string(gModuleInstance, IDS_MODULE_NAME);
 }
 
 multipak_cartridge::catalog_id_type multipak_cartridge::catalog_id() const
 {
-	return ::vcc::core::utils::load_string(gModuleInstance, IDS_CATNUMBER);
+	return ::VCC::Util::load_string(gModuleInstance, IDS_CATNUMBER);
 }
 
 multipak_cartridge::description_type multipak_cartridge:: description() const
 {
-	return ::vcc::core::utils::load_string(gModuleInstance, IDS_CATNUMBER);
+	return ::VCC::Util::load_string(gModuleInstance, IDS_CATNUMBER);
 }
 
 
@@ -106,10 +106,10 @@ void multipak_cartridge::start()
 	// Mount them
 	for (auto slot(0u); slot < slots_.size(); slot++)
 	{
-		const auto path(vcc::core::utils::find_pak_module_path(configuration_.slot_cartridge_path(slot)));
+		const auto path(VCC::Util::find_pak_module_path(configuration_.slot_cartridge_path(slot)));
 		if (!path.empty())
 		{
-			if (mount_cartridge(slot, path) != vcc::core::cartridge_loader_status::success) {
+			if (mount_cartridge(slot, path) != VCC::Core::cartridge_loader_status::success) {
 				DLOG_C("Clearing configured slot path %d\n",slot);
 				configuration_.slot_cartridge_path(slot,"");
 			}
@@ -133,7 +133,7 @@ void multipak_cartridge::stop()
 
 void multipak_cartridge::reset()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	unsigned char slot = switch_slot_ & 3;
 	switch_slot_ = cached_cts_slot_ = cached_scs_slot_ = slot;
@@ -149,7 +149,7 @@ void multipak_cartridge::reset()
 
 void multipak_cartridge::process_horizontal_sync()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	for(const auto& cartridge_slot : slots_)
 	{
@@ -159,7 +159,7 @@ void multipak_cartridge::process_horizontal_sync()
 
 void multipak_cartridge::write_port(unsigned char port_id, unsigned char value)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	// slot_select_port_id is 0x7f
 	if (port_id == slot_select_port_id)
@@ -190,7 +190,7 @@ void multipak_cartridge::write_port(unsigned char port_id, unsigned char value)
 
 unsigned char multipak_cartridge::read_port(unsigned char port_id)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	// slot_select_port_id will ALLWAYS be 0x7f chet
 	if (port_id == slot_select_port_id)	// Self
@@ -223,13 +223,13 @@ unsigned char multipak_cartridge::read_port(unsigned char port_id)
 
 unsigned char multipak_cartridge::read_memory_byte(unsigned short memory_address)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 	return slots_[cached_cts_slot_].read_memory_byte(memory_address);
 }
 
 void multipak_cartridge::status(char* text_buffer, size_t buffer_size)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	char TempStatus[64] = "";
 
@@ -248,7 +248,7 @@ void multipak_cartridge::status(char* text_buffer, size_t buffer_size)
 
 unsigned short multipak_cartridge::sample_audio()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	unsigned short sample = 0;
 	for (const auto& cartridge_slot : slots_)
@@ -266,7 +266,7 @@ void multipak_cartridge::menu_item_clicked(unsigned char menu_item_id)
 		gConfigurationDialog.open();
 	}
 
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	// Menu items for loaded carts. Each slot is allocated 50.
 	if (menu_item_id >= 50 && menu_item_id <= 100)
@@ -293,21 +293,21 @@ void multipak_cartridge::menu_item_clicked(unsigned char menu_item_id)
 
 multipak_cartridge::label_type multipak_cartridge::slot_label(slot_id_type slot) const
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	return slots_[slot].label();
 }
 
 multipak_cartridge::description_type multipak_cartridge::slot_description(slot_id_type slot) const
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	return slots_[slot].description();
 }
 
 bool multipak_cartridge::empty(slot_id_type slot) const
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	return slots_[slot].empty();
 }
@@ -315,7 +315,7 @@ bool multipak_cartridge::empty(slot_id_type slot) const
 void multipak_cartridge::eject_cartridge(slot_id_type slot)
 {
 
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 	slots_[slot].stop();
 	slots_[slot] = {};
 	if (slot == cached_cts_slot_ || slot == switch_slot_)
@@ -347,7 +347,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 
 	DLOG_C("load cart %d  %s\n",slot,filename);
 
-	auto loadedCartridge = vcc::core::load_cartridge(
+	auto loadedCartridge = VCC::Core::load_cartridge(
 		filename,
 		std::move(ctx),
 		multipakHost,
@@ -358,7 +358,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 	if (loadedCartridge.load_result != mount_status_type::success)
 	{
 		// Tell user why load failed
-		auto error_string(vcc::core::cartridge_load_error_string(loadedCartridge.load_result));
+		auto error_string(VCC::Core::cartridge_load_error_string(loadedCartridge.load_result));
 		error_string += "\n\n";
 		error_string += filename;
 		MessageBox(GetForegroundWindow(), error_string.c_str(), "Load Error", MB_OK | MB_ICONERROR);
@@ -367,7 +367,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 
 	// Should we call eject(slot) here?
 
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	slots_[slot] = {
 		filename,
@@ -403,7 +403,7 @@ void multipak_cartridge::append_menu_item(slot_id_type slot, menu_item_type item
 	switch (item.menu_id) {
 	case MID_BEGIN:
 		{
-			vcc::core::utils::section_locker lock(mutex_);
+			VCC::Util::section_locker lock(mutex_);
 			slots_[slot].reset_menu();
 			break;
 		}
@@ -418,7 +418,7 @@ void multipak_cartridge::append_menu_item(slot_id_type slot, menu_item_type item
 			if (item.menu_id >= MID_CONTROL) {
 				item.menu_id += (slot + 1) * 50;
 			}
-			vcc::core::utils::section_locker lock(mutex_);
+			VCC::Util::section_locker lock(mutex_);
 			slots_[slot].append_menu_item(item);
 			break;
 		}
@@ -428,7 +428,7 @@ void multipak_cartridge::append_menu_item(slot_id_type slot, menu_item_type item
 // This gets called any time a cartridge menu is changed. It draws the entire menu.
 void multipak_cartridge::build_menu()
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	// Init the menu, establish MPI config control, build slot menus, then draw it.
 	context_->add_menu_item("", MID_BEGIN, MIT_Head);
@@ -444,7 +444,7 @@ void multipak_cartridge::build_menu()
 
 void multipak_cartridge::assert_cartridge_line(slot_id_type slot, bool line_state)
 {
-	vcc::core::utils::section_locker lock(mutex_);
+	VCC::Util::section_locker lock(mutex_);
 
 	slots_[slot].line_state(line_state);
 	if (selected_scs_slot() == slot)

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -27,12 +27,12 @@
 
 constexpr size_t NUMSLOTS = 4u;
 
-class multipak_cartridge : public ::vcc::core::cartridge
+class multipak_cartridge : public ::VCC::Core::cartridge
 {
 public:
 
-	using context_type = ::vcc::core::cartridge_context;
-	using mount_status_type = ::vcc::core::cartridge_loader_status;
+	using context_type = ::VCC::Core::cartridge_context;
+	using mount_status_type = ::VCC::Core::cartridge_loader_status;
 	using slot_id_type = std::size_t;
 	using path_type = std::string;
 	using label_type = std::string;
@@ -94,10 +94,10 @@ private:
 	static const size_t default_switch_slot_value = 0x03;
 	static const size_t default_slot_register_value = 0xff;
 
-	vcc::core::utils::critical_section mutex_;
+	VCC::Util::critical_section mutex_;
 	multipak_configuration& configuration_;
 	std::shared_ptr<context_type> context_;
-	std::array<vcc::modules::mpi::cartridge_slot, NUMSLOTS> slots_;
+	std::array<VCC::Core::cartridge_slot, NUMSLOTS> slots_;
 	unsigned char slot_register_ = default_slot_register_value;
 	slot_id_type switch_slot_ = default_switch_slot_value;
 	slot_id_type cached_cts_slot_ = default_switch_slot_value;

--- a/mpi/multipak_cartridge_context.h
+++ b/mpi/multipak_cartridge_context.h
@@ -19,11 +19,11 @@
 #include "multipak_cartridge.h"
 
 
-class multipak_cartridge_context : public ::vcc::core::cartridge_context
+class multipak_cartridge_context : public ::VCC::Core::cartridge_context
 {
 public:
 
-	multipak_cartridge_context(size_t slot_id, ::vcc::core::cartridge_context& parent_context, multipak_cartridge& multipak)
+	multipak_cartridge_context(size_t slot_id, ::VCC::Core::cartridge_context& parent_context, multipak_cartridge& multipak)
 		:
 		slot_id_(slot_id),
 		parent_context_(parent_context),
@@ -69,6 +69,6 @@ public:
 private:
 
 	const size_t slot_id_;
-	::vcc::core::cartridge_context& parent_context_;
+	::VCC::Core::cartridge_context& parent_context_;
 	multipak_cartridge& multipak_;
 };

--- a/mpi/multipak_configuration.cpp
+++ b/mpi/multipak_configuration.cpp
@@ -1,7 +1,7 @@
 #include "multipak_configuration.h"
 #include <vcc/util/initial_settings.h>
 
-using settings = ::vcc::core::initial_settings;
+using settings = ::VCC::Core::initial_settings;
 
 // Constructor sets the section
 multipak_configuration::multipak_configuration(string_type section)

--- a/pakinterface.h
+++ b/pakinterface.h
@@ -24,7 +24,7 @@ unsigned char PakReadPort (unsigned char);
 void PakWritePort(unsigned char,unsigned char);
 unsigned char PackMem8Read (unsigned short);
 void GetModuleStatus( SystemState *);
-vcc::core::cartridge_loader_status PakLoadCartridge(const char* filename);
+VCC::Core::cartridge_loader_status PakLoadCartridge(const char* filename);
 void PakLoadCartridgeUI(int);
 unsigned short PackAudioSample();
 void ResetBus();

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -156,7 +156,7 @@
 
 namespace util = VCC::Util;
 
-static ::vcc::devices::rtc::cloud9 cloud9_rtc;
+static ::VCC::Device::rtc::cloud9 cloud9_rtc;
 
 //======================================================================
 // Globals


### PR DESCRIPTION
namespace names changed to CamelCase:

VCC::              Any VCC object
VCC::Core          VCC core objects
VCC::UI            VCC user interface objects
VCC::Util          VCC utility objects
VCC::Debugger      Coco Debugger objects
VCC::Debugger::UI  Coco Debugger UI objects
VCC::Device        VCC device objects