### PR TITLE
Interface2

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -57,8 +57,7 @@ static unsigned char RGBDiskRom[EXTROMSIZE];
 static char FloppyPath[MAX_PATH];
 static char RomFileName[MAX_PATH]="";
 static char TempRomFileName[MAX_PATH]="";
-static void* gCallbackContextPtr = nullptr;
-void* const& gCallbackContext(gCallbackContextPtr);
+slot_id_type gSlotId {};
 PakAssertInteruptHostCallback AssertInt = nullptr;
 static PakAppendCartridgeMenuHostCallback CartMenuCallback = nullptr;
 unsigned char PhysicalDriveA=0,PhysicalDriveB=0,OldPhysicalDriveA=0,OldPhysicalDriveB=0;
@@ -120,13 +119,13 @@ extern "C"
 	}
 
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
 		DLOG_C("FDC %p %p %p %p %p\n",*callbacks);
-		gCallbackContextPtr = callback_context;
+		gSlotId = SlotId;
 		CartMenuCallback = callbacks->add_menu_item;
 		AssertInt = callbacks->assert_interrupt;
 		strcpy(IniFile, configuration_path);
@@ -452,43 +451,43 @@ void BuildCartridgeMenu()
 	if (CartMenuCallback ==nullptr)
 		MessageBox(g_hConfDlg,"No good","Ok",0);
 
-	CartMenuCallback(gCallbackContext, "", MID_BEGIN, MIT_Head);
-	CartMenuCallback(gCallbackContext, "", MID_ENTRY, MIT_Seperator);
+	CartMenuCallback(gSlotId, "", MID_BEGIN, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_ENTRY, MIT_Seperator);
 
-	CartMenuCallback(gCallbackContext, "FD-502 Drive 0",MID_ENTRY,MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert",ControlId(10),MIT_Slave);
+	CartMenuCallback(gSlotId, "FD-502 Drive 0",MID_ENTRY,MIT_Head);
+	CartMenuCallback(gSlotId, "Insert",ControlId(10),MIT_Slave);
 	strncpy(TempMsg,"Eject: ",MAX_PATH);
 	strncpy(TempBuf,gVirtualDrive[0].ImageName,MAX_PATH);
 	PathStripPath(TempBuf);
 	strncat(TempMsg,TempBuf,MAX_PATH);
-	CartMenuCallback(gCallbackContext, TempMsg,ControlId(11),MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg,ControlId(11),MIT_Slave);
 
-	CartMenuCallback(gCallbackContext, "FD-502 Drive 1",MID_ENTRY,MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert",ControlId(12),MIT_Slave);
+	CartMenuCallback(gSlotId, "FD-502 Drive 1",MID_ENTRY,MIT_Head);
+	CartMenuCallback(gSlotId, "Insert",ControlId(12),MIT_Slave);
 	strncpy(TempMsg,"Eject: ",MAX_PATH);
 	strncpy(TempBuf,gVirtualDrive[1].ImageName,MAX_PATH);
 	PathStripPath(TempBuf);
 	strncat(TempMsg,TempBuf,MAX_PATH);
-	CartMenuCallback(gCallbackContext, TempMsg,ControlId(13),MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg,ControlId(13),MIT_Slave);
 
-	CartMenuCallback(gCallbackContext, "FD-502 Drive 2",MID_ENTRY,MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert",ControlId(14),MIT_Slave);
+	CartMenuCallback(gSlotId, "FD-502 Drive 2",MID_ENTRY,MIT_Head);
+	CartMenuCallback(gSlotId, "Insert",ControlId(14),MIT_Slave);
 	strncpy(TempMsg,"Eject: ",MAX_PATH);
 	strncpy(TempBuf,gVirtualDrive[2].ImageName,MAX_PATH);
 	PathStripPath(TempBuf);
 	strncat(TempMsg,TempBuf,MAX_PATH);
-	CartMenuCallback(gCallbackContext, TempMsg,ControlId(15),MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg,ControlId(15),MIT_Slave);
 
-	CartMenuCallback(gCallbackContext, "FD-502 Drive 3",MID_ENTRY,MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert",ControlId(17),MIT_Slave);
+	CartMenuCallback(gSlotId, "FD-502 Drive 3",MID_ENTRY,MIT_Head);
+	CartMenuCallback(gSlotId, "Insert",ControlId(17),MIT_Slave);
 	strncpy(TempMsg,"Eject: ",MAX_PATH);
 	strncpy(TempBuf,gVirtualDrive[3].ImageName,MAX_PATH);
 	PathStripPath(TempBuf);
 	strncat(TempMsg,TempBuf,MAX_PATH);
-	CartMenuCallback(gCallbackContext, TempMsg,ControlId(18),MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg,ControlId(18),MIT_Slave);
 
-	CartMenuCallback(gCallbackContext, "FD-502 Config",ControlId(16),MIT_StandAlone);
-	CartMenuCallback(gCallbackContext,"", MID_FINISH, MIT_Head);
+	CartMenuCallback(gSlotId, "FD-502 Config",ControlId(16),MIT_StandAlone);
+	CartMenuCallback(gSlotId,"", MID_FINISH, MIT_Head);
 }
 
 long CreateDisk (unsigned char Disk)

--- a/FD502/fd502.h
+++ b/FD502/fd502.h
@@ -19,7 +19,7 @@ This file is part of VCC (Virtual Color Computer).
 */
 #include <vcc/bus/cpak_cartridge_definitions.h>
 
-extern void*const& gCallbackContext;
+extern slot_id_type gSlotId;
 extern PakAssertInteruptHostCallback AssertInt;
 void BuildCartridgeMenu();
 

--- a/FD502/wd1793.cpp
+++ b/FD502/wd1793.cpp
@@ -964,7 +964,7 @@ void DispatchCommand(unsigned char Tmp)
 			StatusReg=READY;
 			ExecTimeWaiter=1;
 			if ((Tmp & 15) != 0)
-				AssertInt(gCallbackContext, INT_NMI,IS_NMI);
+				AssertInt(gSlotId, INT_NMI,IS_NMI);
 //			WriteLog("FORCEINTERUPT",0);
 			break;
 
@@ -1309,7 +1309,7 @@ long GetSectorInfo (SectorInfo *Sector,const unsigned char *TempBuffer)
 void CommandDone()
 {
 	if (InteruptEnable)
-		AssertInt(gCallbackContext, INT_NMI,IS_NMI);
+		AssertInt(gSlotId, INT_NMI,IS_NMI);
 	TransferBufferSize=0;
 	CurrentCommand=IDLE;
 }

--- a/GMC/Cartridge.cpp
+++ b/GMC/Cartridge.cpp
@@ -21,8 +21,8 @@
 
 namespace detail
 {
-	void NullAssetCartridgeLine(void*, bool) {}
-	void NullAddMenuItem(void*, const char *, int, MenuItemType) {}
+	void NullAssetCartridgeLine(slot_id_type, bool) {}
+	void NullAddMenuItem(slot_id_type, const char *, int, MenuItemType) {}
 }
 
 
@@ -47,8 +47,6 @@ Cartridge::~Cartridge()
 }
 
 
-
-
 void Cartridge::LoadConfiguration(const std::string& /*filename*/)
 {
 }
@@ -59,10 +57,9 @@ void Cartridge::LoadMenuItems()
 }
 
 
-
-void Cartridge::SetCallbackContext(void* key)
+void Cartridge::SetSlotId(slot_id_type SlotId)
 {
-	m_CallbackContext = key;
+	m_SlotId = SlotId;
 }
 
 

--- a/GMC/Cartridge.h
+++ b/GMC/Cartridge.h
@@ -4,8 +4,8 @@
 
 namespace detail
 {
-	void NullAssetCartridgeLine(void*, bool);
-	void NullAddMenuItem(void*, const char*, int, MenuItemType);
+	void NullAssetCartridgeLine(slot_id_type, bool);
+	void NullAddMenuItem(slot_id_type, const char*, int, MenuItemType);
 }
 
 class Cartridge
@@ -20,7 +20,7 @@ public:
 	virtual ~Cartridge();
 
 
-	virtual void SetCallbackContext(void* key);
+	virtual void SetSlotId(slot_id_type SlotId);
 	virtual void SetCartLineAssertCallback(PakAssertCartridgeLineHostCallback callback);
 	virtual void SetMenuBuilderCallback(PakAppendCartridgeMenuHostCallback addMenuCallback);
 	virtual void SetConfigurationPath(std::string path);
@@ -39,12 +39,12 @@ protected:
 
 	void AssetCartridgeLine(bool state) const
 	{
-		AssetCartridgeLinePtr(m_CallbackContext, state);
+		AssetCartridgeLinePtr(m_SlotId, state);
 	}
 
 	void AddMenuItem(const char * name, int id, MenuItemType type)
 	{
-		AddMenuItemPtr(m_CallbackContext, name, id, type);
+		AddMenuItemPtr(m_SlotId, name, id, type);
 	}
 
 	virtual void LoadConfiguration(const std::string& filename);
@@ -55,7 +55,7 @@ private:
 	friend const char* PakGetName();
 	friend const char* PakGetCatalogId();
 	friend void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks);
@@ -71,7 +71,7 @@ private:
 
 	static Cartridge*	m_Singleton;
 
-	void*				m_CallbackContext = nullptr;
+	slot_id_type		m_SlotId {};
 	std::string			m_Name;
 	std::string			m_CatalogId;
 	std::string			m_ConfigurationPath;

--- a/GMC/CartridgeTrampolines.cpp
+++ b/GMC/CartridgeTrampolines.cpp
@@ -35,7 +35,7 @@ GMC_EXPORT const char* PakGetDescription()
 
 
 GMC_EXPORT void PakInitialize(
-	void* const callback_context,
+	slot_id_type SlotId,
 	const char* const configuration_path,
 	HWND hVccWnd,
 	const cpak_callbacks* const callbacks)
@@ -47,7 +47,7 @@ GMC_EXPORT void PakInitialize(
             callbacks->read_memory_byte,
             callbacks->add_menu_item);
 
-	Cartridge::m_Singleton->SetCallbackContext(callback_context);
+	Cartridge::m_Singleton->SetSlotId(SlotId);
 	Cartridge::m_Singleton->SetMenuBuilderCallback(callbacks->add_menu_item);
 	Cartridge::m_Singleton->SetCartLineAssertCallback(callbacks->assert_cartridge_line);
 	Cartridge::m_Singleton->SetConfigurationPath(configuration_path);

--- a/GMC/CartridgeTrampolines.h
+++ b/GMC/CartridgeTrampolines.h
@@ -4,7 +4,7 @@
 GMC_EXPORT const char* PakGetName();
 GMC_EXPORT const char* PakGetCatalogId();
 GMC_EXPORT void PakInitialize(
-	void* const callback_context,
+	slot_id_type SlotId,
 	const char* const configuration_path,
 	HWND hVccWnd,
 	const cpak_callbacks* const callbacks);

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -41,7 +41,7 @@ static char IniFile[MAX_PATH]  { 0 };
 static char HardDiskPath[MAX_PATH];
 static ::VCC::Device::rtc::cloud9 cloud9_rtc;
 
-static void* gCallbackContext = nullptr;
+static slot_id_type gSlotId {};
 static PakReadMemoryByteHostCallback MemRead8 = nullptr;
 static PakWriteMemoryByteHostCallback MemWrite8 = nullptr;
 static PakAppendCartridgeMenuHostCallback CartMenuCallback = nullptr;
@@ -64,12 +64,12 @@ using namespace std;
 
 void MemWrite(unsigned char Data, unsigned short Address)
 {
-	MemWrite8(gCallbackContext, Data, Address);
+	MemWrite8(gSlotId, Data, Address);
 }
 
 unsigned char MemRead(unsigned short Address)
 {
-	return MemRead8(gCallbackContext, Address);
+	return MemRead8(gSlotId, Address);
 }
 
 
@@ -104,12 +104,12 @@ extern "C"
 	}
 
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
         HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
-		gCallbackContext = callback_context;
+		gSlotId = SlotId;
 		CartMenuCallback = callbacks->add_menu_item;
 		MemRead8 = callbacks->read_memory_byte;
 		MemWrite8 = callbacks->write_memory_byte;
@@ -378,27 +378,27 @@ void BuildCartridgeMenu()
 	char TempMsg[512] = "";
 	char TempBuf[MAX_PATH] = "";
 
-	CartMenuCallback(gCallbackContext, "", MID_BEGIN, MIT_Head);
-	CartMenuCallback(gCallbackContext, "", MID_ENTRY, MIT_Seperator);
+	CartMenuCallback(gSlotId, "", MID_BEGIN, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_ENTRY, MIT_Seperator);
 
-	CartMenuCallback(gCallbackContext, "HD Drive 0", MID_ENTRY, MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert", ControlId(10), MIT_Slave);
+	CartMenuCallback(gSlotId, "HD Drive 0", MID_ENTRY, MIT_Head);
+	CartMenuCallback(gSlotId, "Insert", ControlId(10), MIT_Slave);
 	strcpy(TempMsg, "Eject: ");
 	strcpy(TempBuf, VHDfile0);
 	PathStripPath(TempBuf);
 	strcat(TempMsg, TempBuf);
-	CartMenuCallback(gCallbackContext, TempMsg, ControlId(11), MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg, ControlId(11), MIT_Slave);
 
-	CartMenuCallback(gCallbackContext, "HD Drive 1", MID_ENTRY, MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert", ControlId(12), MIT_Slave);
+	CartMenuCallback(gSlotId, "HD Drive 1", MID_ENTRY, MIT_Head);
+	CartMenuCallback(gSlotId, "Insert", ControlId(12), MIT_Slave);
 	strcpy(TempMsg, "Eject: ");
 	strcpy(TempBuf, VHDfile1);
 	PathStripPath(TempBuf);
 	strcat(TempMsg, TempBuf);
-	CartMenuCallback(gCallbackContext, TempMsg, ControlId(13), MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg, ControlId(13), MIT_Slave);
 
-	CartMenuCallback(gCallbackContext, "HD Config", ControlId(14), MIT_StandAlone);
-	CartMenuCallback(gCallbackContext, "", MID_FINISH, MIT_Head);
+	CartMenuCallback(gSlotId, "HD Config", ControlId(14), MIT_StandAlone);
+	CartMenuCallback(gSlotId, "", MID_FINISH, MIT_Head);
 }
 
 // Dialog for creating a new hard disk

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -50,8 +50,7 @@ static bool ClockReadOnly = true;
 static unsigned char DataLatch=0;
 static HINSTANCE gModuleInstance;
 static HWND hConfDlg = nullptr;
-static void* gCallbackContextPtr = nullptr;
-static void* const& gCallbackContext(gCallbackContextPtr);
+static slot_id_type gSlotId {};
 
 using namespace std;
 
@@ -87,12 +86,12 @@ extern "C"
 	}
 
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
         HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
-		gCallbackContextPtr = callback_context;
+		gSlotId = SlotId;
 		CartMenuCallback = callbacks->add_menu_item;
 		strcpy(IniFile, configuration_path);
 
@@ -221,24 +220,24 @@ void BuildCartridgeMenu()
 {
 	char TempMsg[512]="";
 	char TempBuf[MAX_PATH]="";
-	CartMenuCallback(gCallbackContext, "", MID_BEGIN, MIT_Head);
-	CartMenuCallback(gCallbackContext, "", MID_ENTRY, MIT_Seperator);
-	CartMenuCallback(gCallbackContext, "IDE Master",MID_ENTRY,MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert",ControlId(10),MIT_Slave);
+	CartMenuCallback(gSlotId, "", MID_BEGIN, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_ENTRY, MIT_Seperator);
+	CartMenuCallback(gSlotId, "IDE Master",MID_ENTRY,MIT_Head);
+	CartMenuCallback(gSlotId, "Insert",ControlId(10),MIT_Slave);
 	QueryDisk(MASTER,TempBuf);
 	strcpy(TempMsg,"Eject: ");
 	PathStripPath (TempBuf);
 	strcat(TempMsg,TempBuf);
-	CartMenuCallback(gCallbackContext, TempMsg,ControlId(11),MIT_Slave);
-	CartMenuCallback(gCallbackContext, "IDE Slave",MID_ENTRY,MIT_Head);
-	CartMenuCallback(gCallbackContext, "Insert",ControlId(12),MIT_Slave);
+	CartMenuCallback(gSlotId, TempMsg,ControlId(11),MIT_Slave);
+	CartMenuCallback(gSlotId, "IDE Slave",MID_ENTRY,MIT_Head);
+	CartMenuCallback(gSlotId, "Insert",ControlId(12),MIT_Slave);
 	QueryDisk(SLAVE,TempBuf);
 	strcpy(TempMsg,"Eject: ");
 	PathStripPath (TempBuf);
 	strcat(TempMsg,TempBuf);
-	CartMenuCallback(gCallbackContext, TempMsg,ControlId(13),MIT_Slave);
-	CartMenuCallback(gCallbackContext, "IDE Config",ControlId(14),MIT_StandAlone);
-	CartMenuCallback(gCallbackContext, "", MID_FINISH, MIT_Head);
+	CartMenuCallback(gSlotId, TempMsg,ControlId(13),MIT_Slave);
+	CartMenuCallback(gSlotId, "IDE Config",ControlId(14),MIT_StandAlone);
+	CartMenuCallback(gSlotId, "", MID_FINISH, MIT_Head);
 }
 
 LRESULT CALLBACK IDE_Config(HWND hDlg, UINT message, WPARAM wParam, LPARAM /*lParam*/)

--- a/acia/acia.cpp
+++ b/acia/acia.cpp
@@ -40,8 +40,8 @@ void SaveConfig();
 //------------------------------------------------------------------------
 // Pak host
 //------------------------------------------------------------------------
-static void* gCallbackContextPtr = nullptr;
-void* const& gCallbackContext(gCallbackContextPtr);
+slot_id_type gSlotId;
+
 static PakAppendCartridgeMenuHostCallback CartMenuCallback = nullptr;
 PakAssertInteruptHostCallback AssertInt = nullptr;
 
@@ -119,12 +119,12 @@ extern "C"
 	}
 
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
-		gCallbackContextPtr = callback_context;
+		gSlotId = SlotId;
 		CartMenuCallback = callbacks->add_menu_item;
 		AssertInt = callbacks->assert_interrupt;
 		strcpy(IniFile, configuration_path);
@@ -140,7 +140,6 @@ extern "C"
 		sc6551_close();
 		AciaStat[0]='\0';
 	}
-	
 
 }
 
@@ -243,10 +242,10 @@ __declspec(dllexport) void PakMenuItemClicked(unsigned char /*MenuID*/)
 //----------------------------------------------------------------------
 void BuildCartridgeMenu()
 {
-	CartMenuCallback(gCallbackContext, "", MID_BEGIN, MIT_Head);
-	CartMenuCallback(gCallbackContext, "", MID_ENTRY, MIT_Seperator);
-	CartMenuCallback(gCallbackContext, "ACIA Config", ControlId(16), MIT_StandAlone);
-	CartMenuCallback(gCallbackContext, "", MID_FINISH, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_BEGIN, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_ENTRY, MIT_Seperator);
+	CartMenuCallback(gSlotId, "ACIA Config", ControlId(16), MIT_StandAlone);
+	CartMenuCallback(gSlotId, "", MID_FINISH, MIT_Head);
 }
 
 //-----------------------------------------------------------------------

--- a/acia/acia.h
+++ b/acia/acia.h
@@ -69,7 +69,7 @@ extern char AciaFileRdPath[MAX_PATH]; // Path for file reads
 extern char AciaFileWrPath[MAX_PATH]; // Path for file writes
 
 extern PakAssertInteruptHostCallback AssertInt;
-extern void* const& gCallbackContext;
+extern slot_id_type gSlotId;
 
 // Device
 extern void sc6551_init();

--- a/acia/sc6551.cpp
+++ b/acia/sc6551.cpp
@@ -250,7 +250,7 @@ void sc6551_heartbeat()
             StatReg |= StatRxF;
             // Assert CART if interrupts not disabled or already asserted.
             if (!((CmdReg & CmdRxI) || (StatReg & StatIRQ))) {
-                AssertInt(gCallbackContext, INT_CART, IS_NMI);
+                AssertInt(gSlotId, INT_CART, IS_NMI);
                 StatReg |= StatIRQ;
             }
         }

--- a/becker/becker.cpp
+++ b/becker/becker.cpp
@@ -18,7 +18,7 @@ static SOCKET dwSocket = 0;
 
 // vcc stuff
 static HINSTANCE gModuleInstance;
-static void* gCallbackContext = nullptr;
+slot_id_type gSlotId {}; 
 static PakAppendCartridgeMenuHostCallback CartMenuCallback = nullptr;
 static PakAssertCartridgeLineHostCallback PakSetCart = nullptr;
 LRESULT CALLBACK Config(HWND, UINT, WPARAM, LPARAM);
@@ -415,12 +415,12 @@ extern "C"
 	}
 
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
-		gCallbackContext = callback_context;
+		gSlotId = SlotId;
 		CartMenuCallback = callbacks->add_menu_item;
 		PakSetCart = callbacks->assert_cartridge_line;
 		strcpy(IniFile, configuration_path);
@@ -536,10 +536,10 @@ extern "C" __declspec(dllexport) void PakGetStatus(char* text_buffer, size_t buf
 
 void BuildCartridgeMenu()
 {
-	CartMenuCallback(gCallbackContext, "", MID_BEGIN, MIT_Head);
-	CartMenuCallback(gCallbackContext, "", MID_ENTRY, MIT_Seperator);
-	CartMenuCallback(gCallbackContext, "DriveWire Server..", ControlId(16), MIT_StandAlone);
-	CartMenuCallback(gCallbackContext, "", MID_FINISH, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_BEGIN, MIT_Head);
+	CartMenuCallback(gSlotId, "", MID_ENTRY, MIT_Seperator);
+	CartMenuCallback(gSlotId, "DriveWire Server..", ControlId(16), MIT_StandAlone);
+	CartMenuCallback(gSlotId, "", MID_FINISH, MIT_Head);
 }
 
 extern "C" __declspec(dllexport) void PakMenuItemClicked(unsigned char MenuID)

--- a/libcommon/include/vcc/bus/cartridge_loader.h
+++ b/libcommon/include/vcc/bus/cartridge_loader.h
@@ -68,7 +68,8 @@ namespace VCC::Core
 	LIBCOMMON_EXPORT cartridge_loader_result load_cpak_cartridge(
 		const std::string& filename,
 		std::unique_ptr<cartridge_context> cartridge_context,
-		void* const pakContainer,
+//		void* const pakContainer,
+		slot_id_type SlotId,
 		const std::string& iniPath,
 		HWND hVccWnd,
 		const cpak_callbacks& cpak_callbacks);
@@ -76,7 +77,8 @@ namespace VCC::Core
 	LIBCOMMON_EXPORT cartridge_loader_result load_cartridge(
 		const std::string& filename,                          // Cartridge filename
 		std::unique_ptr<cartridge_context> cartridge_context, // Loader context
-		void* const pakContainer,                             // Pak container object 
+//		void* const pakContainer,                             // Pak container object 
+		slot_id_type SlotId,
 		const std::string& iniPath,                           // Path of ini file
 		HWND hVccWnd,                                         // handle to main window 
 		const cpak_callbacks& cpak_callbacks);                // Callbacks

--- a/libcommon/include/vcc/bus/cpak_cartridge.h
+++ b/libcommon/include/vcc/bus/cpak_cartridge.h
@@ -31,12 +31,11 @@ namespace VCC::Core
 
 		using path_type = std::string;
 
-
 	public:
 
 		LIBCOMMON_EXPORT cpak_cartridge(
 			HMODULE module_handle,                   // Cartridge filename
-			void* const pakContainer,                // pointer to container object
+			slot_id_type const SlotId,               // Slot id
 			path_type configuration_path,            // Path of ini file
 			HWND hVccWnd,                            // Handle to main VCC window proc 
 			const cpak_callbacks& cpak_callbacks);   // Callbacks
@@ -61,7 +60,7 @@ namespace VCC::Core
 	private:
 
 		const HMODULE handle_;
-		void* const pakContainer_;
+		slot_id_type SlotId_;
 		const HWND hVccWnd_;
 		const path_type configuration_path_;
 		const cpak_callbacks cpak_callbacks_;

--- a/libcommon/include/vcc/bus/cpak_cartridge_definitions.h
+++ b/libcommon/include/vcc/bus/cpak_cartridge_definitions.h
@@ -15,53 +15,64 @@
 //	You should have received a copy of the GNU General Public License along with
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
+
+	//=========================================================//
+	// This defines the binary interface used by all pak DLLs. //
+	//=========================================================//
+
 #pragma once
 #include <vcc/util/interrupts.h>
+#include <cstddef>   // for std::size_t
 #include <windows.h>
 
-// This defines the hardware cartridge interface, it is included by all hardware packs.
+//----------------------------------------------------------------
+// ABI identity is based on SlotId; 0 = Boot Slot, 1-4 = MPI slots
+//----------------------------------------------------------------
+using slot_id_type = std::size_t;
+
 extern "C"
 {
 	enum MenuItemType;
 
 	using PakWriteMemoryByteHostCallback = void (*)
-		(void* callback_context, unsigned char value, unsigned short address);
+		(slot_id_type SlotId, unsigned char value, unsigned short address);
 	using PakReadMemoryByteHostCallback = unsigned char (*)
-		(void* callback_context, unsigned short address);
+		(slot_id_type SlotId, unsigned short address);
 	using PakAssertCartridgeLineHostCallback = void (*)
-		(void* callback_context, bool lineState);
+		(slot_id_type SlotId, bool lineState);
 	using PakAssertInteruptHostCallback = void (*)
-		(void* callback_context, Interrupt interrupt, InterruptSource interrupt_source);
+		(slot_id_type SlotId, Interrupt interrupt, InterruptSource interrupt_source);
 	using PakAppendCartridgeMenuHostCallback = void (*)
-		(void* callback_context, const char* menu_name, int menu_id, MenuItemType menu_type);
+		(slot_id_type SlotId, const char* menu_name, int menu_id, MenuItemType menu_type);
 
 	// Cartridge Callbacks
 	struct cpak_callbacks
 	{
-		const PakAssertInteruptHostCallback assert_interrupt;
+		const PakAssertInteruptHostCallback      assert_interrupt;
 		const PakAssertCartridgeLineHostCallback assert_cartridge_line;
-		const PakWriteMemoryByteHostCallback write_memory_byte;
-		const PakReadMemoryByteHostCallback read_memory_byte;
+		const PakWriteMemoryByteHostCallback     write_memory_byte;
+		const PakReadMemoryByteHostCallback      read_memory_byte;
 		const PakAppendCartridgeMenuHostCallback add_menu_item;
 	};
 
 	// Cartridge exports. At least PakInitilizeModuleFunction must be implimented
 	using PakInitializeModuleFunction = void (*)(
-		void* callback_context,                  // Host or MPI 
-		const char* const configuration_path,    // Path of ini file
-		HWND hVccWnd,                            // VCC Main window HWND
-		const cpak_callbacks* const context);    // Callbacks
-	using PakTerminateModuleFunction = void (*)();
-	using PakGetNameModuleFunction = const char* (*)();
-	using PakGetCatalogIdModuleFunction = const char* (*)();
-	using PakGetDescriptionModuleFunction = const char* (*)();
-	using PakResetModuleFunction = void (*)();
-	using PakHeartBeatModuleFunction = void (*)();
-	using PakGetStatusModuleFunction = void (*)(char* text_buffer, size_t buffer_size);
-	using PakWritePortModuleFunction = void (*)(unsigned char port, unsigned char value);
-	using PakReadMemoryByteModuleFunction = unsigned char (*)(unsigned short address);
-	using PakReadPortModuleFunction = unsigned char (*)(unsigned char port);
-	using PakSampleAudioModuleFunction = unsigned short (*)();
+		slot_id_type SlotId,                   // SlotId 
+		const char* const configuration_path,  // Path of ini file
+		HWND hVccWnd,                          // VCC Main window HWND
+		const cpak_callbacks* const context);  // Callback
+
+	using PakTerminateModuleFunction       = void (*)();
+	using PakGetNameModuleFunction         = const char* (*)();
+	using PakGetCatalogIdModuleFunction    = const char* (*)();
+	using PakGetDescriptionModuleFunction  = const char* (*)();
+	using PakResetModuleFunction           = void (*)();
+	using PakHeartBeatModuleFunction       = void (*)();
+	using PakGetStatusModuleFunction       = void (*)(char* text_buffer, size_t buffer_size);
+	using PakWritePortModuleFunction       = void (*)(unsigned char port, unsigned char value);
+	using PakReadMemoryByteModuleFunction  = unsigned char (*)(unsigned short address);
+	using PakReadPortModuleFunction        = unsigned char (*)(unsigned char port);
+	using PakSampleAudioModuleFunction     = unsigned short (*)();
 	using PakMenuItemClickedModuleFunction = void (*)(unsigned char itemId);
 
 }

--- a/libcommon/src/bus/CartridgeInterface.txt
+++ b/libcommon/src/bus/CartridgeInterface.txt
@@ -1,29 +1,26 @@
 
-This attempts to describe the cartridge interface design for VCC
+This describes the cartridge interface design for VCC
 
 ---
 
 # VCC Cartridge Types
 
-VCC emulates the physical cartridges that could be plugged into the side expansion slot of a CoCo 3
-or into a MultiPak Interface. VCC supports three main categories of cartridges:
+VCC emulates the physical cartridges that could be plugged into the side expansion slot
+of a CoCo 3 or into a MultiPak Interface. VCC supports three main categories of cartridges:
 
 ---
 
 ## 1. ROM Cartridges
 
-ROM cartridges contain only read-only memory and the minimal hardware needed to expose that memory
-to the CoCo 3.
+ROM cartridges contain only read-only memory and the minimal hardware needed to expose that
+memory to the CoCo 3.
 
-**Key characteristics:**
+**Characteristics:**
 
 - Typically contain 6809 or 6309 executable code.
 - The CoCo reads data directly from mapped ROM addresses.  
 - Some cartridges support bank switching by writing to I/O ports.
 - In VCC, all ROM banking logic is implemented inside the emulator itself.
-
-**Implications for VCC:**
-
 - ROM cartridges require no host-side code.  
 - They are stored as simple binary files.
 - Some ROM files include headers or signatures to indicate special mapping or banking behavior.  
@@ -47,7 +44,7 @@ These cartridges require host-side x86 code to emulate their hardware behavior.
 
 - Hardware cartridges are implemented as **Windows DLLs**.  
 - VCC identifies them by checking for the `MZ` signature at the start of the file.
-- Hardware DLL's must export the initCart call to be valid
+- Hardware DLL's must export the PakInitialize call to be valid
 - ROM data for these cartridges is usually stored separately, though this is not required.  
 - Some hardware cartridges can load multiple ROMs and switch between them under program control.  
 - The DLL is responsible for loading and managing these ROMs.  
@@ -59,8 +56,8 @@ These cartridges require host-side x86 code to emulate their hardware behavior.
 
 ## 3. MultiPak Cartridge (MPI)
 
-MultiPak it not a true cartridge, it is a bus expansion that acts as hosts for other hardware
-cartridges.
+MultiPak is a special type of hardware cartridge, not really a true cartridge, it is a
+bus expansion that acts as hosts for other hardware cartridges.
 
 **Capabilities:**
 
@@ -97,18 +94,20 @@ The cartridge loader determines the cartridge type using the following sequence:
 
 5. Continue with loading and initialization
 
-
 ---
 
-Cartridge Exports
+#Cartridge Exports
 
 DLL's can export any of the following calls
 
-  Get cart type and capabilities (required)
-  	Const cart_capabilities* PakGetCapabilities (void);
+  Initiate pack (REQUIRED)
+  	PakInitialize (SLotId, settings_path, hVccWnd, &callbacks);
 
-  Initiate pack (required)
-  	PakInitialize (slot_context, settings_path, hVccWnd_, &callbacks);
+  Retrieve cart menu (NEW)
+    PakGetMenuItems(menu_items, count);
+ 
+  Get cart capabilities (PROPOSED)
+  	PakGetCapabilities (void);
 
   Terminate pack, prepare for DLL unload
   	PakTerminate ()
@@ -137,7 +136,7 @@ DLL's can export any of the following calls
   Read I/O port
   	unsigned char PakReadPort (Port)
 
-  Read ROM byten
+  Read ROM byte
   	unsigned char PakReadMemoryByte (Address)
 
   Sample audio line
@@ -148,57 +147,43 @@ DLL's can export any of the following calls
 
 ---
 
-Callbacks
+#Callbacks
 
-  void assert_cartridge_line(slot_context, bool line_state) = 0;
-  void assert_interrupt(slot_context, Interrupt interrupt, InterruptSource interrupt_source) = 0;
-  void write_memory_byte(slot_context, unsigned char value, unsigned short address) = 0;
-  unsigned char read_memory_byte(slot_context, unsigned short address) = 0;
-  void add_menu_item(slot_context, const char* menu_name, int menu_id, MenuItemType menu_type) = 0;
+Callbacks are used by cartridge DLL's to initiate host (or MPI) actions. The
+following callbacks currently exist:
 
-It has recently been recognized that there are two classes of callbacks:
+  assert_cartridge_line (SlotId, line_state)
 
-- Fast callbacks initiated by events in the CPU loop like asserting interrupts, cart
-lines, or reading and writing memory to handle DMA requests.  These must be syncronous
-and return quickly to not affect emulator timing.  Fast callbacks must use the already
-in place callback mechanisms.  Fast callbacks are determined by Coco's physical bus and
-are not likely to change.
+  assert_interrupt (SlotId, interrupt, interrupt_source)
 
-- Slow callbacks initiated by UI like adding menu items or inserting cartridges in slots.
-These can be asyncronous and can rely on exports to recieve replies. A perfect mechanism
-for slow callbacks already exists for free - the main window message loop.  A cartridge 
-can send a message to the  main window and let VCC main dispatch it.  Enhancements to 
-cartridge UI that require future changes or additions should use these callbacks.
+  write_memory_byte (SlotId, value, address)
 
-In the current codebase the messaging mechanism is already being used for a callback. When
-the MPI needs to initiate a hard VCC reset is does so by sending a message to WinMain.
+  read_memory_byte (SlotId, unsigned short address)
+
+  add_menu_item (SlotId, menu_name, menu_id, menu_type)  **depreciated**
+
+SlotId is used by the MPI to filter assert_cartridge_line and to bias menu items. 
+
+There are two type of callbacks:
+
+- Fast callbacks initiated by 6x09 code running inside the CPU loop such as asserting
+interrupts, cart lines, or reading and writing memory to handle DMA requests. These
+are syncronous and must return quickly to not affect emulator timing. Fast callbacks
+are determined by Coco3's physical bus and are not likely to change.
+
+- Notifications initiated by cartridge UI events like adding menu items or inserting
+cartridges in slots. These are asyncronous and can rely on DLL exports for details.
+A good mechanism for these is Vcc's main window message loop. The main window handle
+(hVccWnd) has been added to PakInitialize() and a message to it is used by the MPI to
+initiate a VCC reset.
 
 The add_menu_item callback is not tied to the CPU loop and qualifies as a slow callback.
-This callback will be replaced by a Windows message.
+This callback is being replaced by windows menu item change message and a new export.
+See **CartridgeMenuSystem.txt** for a description of this change.               
 
 ---
 
-The dynamic cartridge menu system.
-
-When cartridges are loaded or unloaded the Cartridge menu must be changed to show items for
-controlling the cartridges. Traditionally the Pakinterface generated the first menu item which
-gives users control over which cartridge is plugged into the side of the coco. If that
-cartridge is the MPI additional menu items are added, the first such item brings up a MPI 
-configuration dialog.  That dialog shows the user what carts are in MPI slots, which cart
-is selected at boot (CTS), a description of the cart in that slot, and controls allowing users
-to modify these settings.  After the MPI config menu item additional menu items are added
-for cartridges currently in MPI slots.  These menu items are added by carts as they are
-initialized. Each cartridge, starting with the MPI, then carts in slots 4 through 1, are 
-intialized. When a cart is initialized to generates AddMenuitem callbacks for it's menu item.
-
-Using the cartridge initialization export to initiate the addition of menu items causes an 
-issue if a cart is removed or added after VCC has started up, specifically carts should not
-be initialized a second time after loading. So add menu item messages are saved in a list and
-the cart menu is cleared then the list is traversed to retore the menuitems after each change.
-
----
-
-New Design Philosophy For The MPI  (Not yet implemented)
+#A New Design Philosophy For The MPI  (In progress)
 
 VCC and forks of VCC use run-time loading and unloading of dynamic libraries to simulate
 the inserting and removing of Cartridges.
@@ -211,17 +196,11 @@ call cartridge DLLs directly there are now two modules, VCC and MPI, that need t
 cartridge lifetimes, handles, exports, and inports. All loading and unloading of carts belongs
 in one place and that place is the PakInterface part of VCC main.
 
-When slot management is moved to the Pakinterface the logic that controls the CTS and SCS and
+If slot management is moved to the Pakinterface the logic that controls the CTS and SCS and
 the management of saved slot content settings must move too.  The pakinterface must share this
 information with the MPI DLL which becomes purely a user interface.
 
-Moving cartridge and slot management from the MPI to the Pakinterface would seem to require
-extensive changes to the interface.  This document attemps to explain how such a move can be 
-done with minimal risk.
-
----
-
-To wrap up the pakinterface slot management concept:
+The pakinterface slot management concept:
 
 - The pakinterface maintains a list indexed by slot number of loaded cartridges.
 
@@ -240,18 +219,18 @@ To wrap up the pakinterface slot management concept:
 
 - pakInterface sends MPI changes to CTS/SCS via a new MPI export
 
-- The opaque slot_context is renamed to slot_context and is made transparent. Some carts don't
-  work right if they are not a specific slot. They can use slot_number to verify the slot they
-  are in is valid.
+- The opaque slot_context is renamed to SlotId (0-4) and is made transparent. Some carts
+  don't work right if they are not a specific slot. They can use SlotId to verify the slot
+  they are in is right for them. (This has been completed)
 
-- on request pakInterface sends MPI active cart description via a new MPI export
+- On request pakInterface sends MPI active cart description via a new MPI export
 
-- on request pakInterface sends MPI slot contents
+- On request pakInterface sends MPI slot contents
 
 - Then MPI should never call a cartridge DLL directly. It should always request actions through
   messages to the pakInterface using the WinMain message loop.
 
-- The MPI saves the startup slot setting. Changing this causes no changes to running CPI
+- The MPI saves the startup slot setting. Changing this causes no changes to running CPU
 
 - The MPI requests cartridge loads / unloads by sending messages to WinMain.
 
@@ -267,14 +246,11 @@ To wrap up the pakinterface slot management concept:
 
 Implementation Plan
 
-1. Solidify methods for sending and interpreting messages from DLL's to WinMain message loop.
-   Use the VCC Reset message from MPI Config to prove the methods.
+1. Replace opaque slot_context pointer in init export with transparent SlotId. Cartridges can
+   use SlotId or simply return it in callbacks.  (This is complete)
 
-2. Replace the AddCartMenu callback with a message and modify pakinterface to maintain the cartridge
-   dynamic menus.
+2. Replace the AddCartMenu callback with a message and modify pakinterface to maintain the
+   cartridge dynamic menus. See **CartridgeMenuSystem.txt** for more description.
 
 3. Move slot maintenance, cartridge loading, and cartidge calls from MPI to pakinterface.
-
-4. Cartridges can use slot_id from transparent slot_context, if desired.
-
 

--- a/libcommon/src/bus/CartridgeMenuSystem.txt
+++ b/libcommon/src/bus/CartridgeMenuSystem.txt
@@ -1,0 +1,80 @@
+
+# **VCC Cartridge Export Based Menu System**
+
+This replaces per‑item callbacks with a single export‑based model for exchanging menu
+items between cartridge DLLs, Multipak (MPI), and the PakInterface host.
+
+Concept:
+
+- Each cartridge DLL maintains its own internal list of menu items.  
+- Each DLL exposes **one export** that returns its entire menu list on demand.  
+- MPI aggregates child cartridge menus, applies slot‑based ID biasing, and returns a
+  unified list to the host.  
+- The host rebuilds the UI menu from the aggregated list.  
+- DLLs notify the host of menu changes using a single Windows message.
+
+Benefits:
+
+- Menu state is always derived from a **single export call**, not a sequence of callbacks.  
+- DLLs do not depend on host internals, callback tables, or routing logic.  
+- Clear separation of responsibilities:
+  - DLLs own their menu state.  
+  - MPI aggregates and biases.  
+  - Host renders.  
+- The export signature and struct layout remain stable even if internal implementations change.
+
+---
+
+## **Component Details**
+
+### **Cartridge DLL**
+
+A cartridge DLL:
+
+- Maintains a **static internal list** of its menu items.  
+- Updates this list whenever its internal state changes.  
+- Sends **WM_VCC_MENU_CHANGED** to the host after updating its list.  
+- Implements a single GetMenuItemList export that:
+  - Accepts a pointer to a buffer of menu items (or `nullptr` for size query).  
+  - Accepts a pointer to a count value.  
+  - Interprets the count as:
+    - **Input:** maximum number of items the host can accept.  
+    - **Output:** total number of items the DLL has (or number copied).  
+- Never copies more items than the host indicates.  
+- Returns failure if not all items could be copied.
+- Protects the list from export access while it is being updated.
+
+If the buffer pointer is `nullptr`, the DLL sets count to the number of items it has.
+If the buffer pointer is not `nullptr`, the DLL copies up to the specified count.
+
+---
+
+### **Multipak (MPI)**
+
+MPI acts as an **aggregator** and applies deterministic slot‑based menu ID biasing.
+The MPI is only permitted to be installed in the boot slot. (Coco side slot)
+
+MPI:
+
+- Maintains references to each child cartridge’s menu export.  
+- When its export is called:
+  - Generates MPI’s own menu items.  
+  - Calls each child cartridge’s export to retrieve their items.  
+  - Applies **slot‑based menu ID biasing**:
+    - Each slot receives a unique bias range.  
+    - Biasing is applied only by MPI.  
+    - DLLs remain unaware of slot numbers or bias rules.  
+  - Merges all items into a single unified list.  
+- Returns the unified list to the host using the same export pattern as cartridges.
+
+---
+
+### **PakInterface Host**
+
+The host:
+
+- Listens for **WM_VCC_MENU_CHANGED** from any DLL including the MPI.  
+- On receiving the message, calls the boot slot's export and rebuilds the menu.
+
+The host only sees a flat, final list of menu items.
+

--- a/libcommon/src/bus/cartridge_loader.cpp
+++ b/libcommon/src/bus/cartridge_loader.cpp
@@ -117,7 +117,7 @@ namespace VCC::Core
 	cartridge_loader_result load_cpak_cartridge(
 		const std::string& filename,
 		std::unique_ptr<cartridge_context> cartridge_context,
-		void* const pakContainer,
+		slot_id_type SlotId,
 		const std::string& iniPath,
 		HWND hVccWnd,
 		const cpak_callbacks& cpak_callbacks)
@@ -142,7 +142,7 @@ namespace VCC::Core
 		{
 			details.cartridge = std::make_unique<VCC::Core::cpak_cartridge>(
 				details.handle.get(),
-				pakContainer,
+				SlotId,
 				iniPath,
 				hVccWnd,
 				cpak_callbacks);
@@ -154,18 +154,18 @@ namespace VCC::Core
 		return { nullptr, nullptr, cartridge_loader_status::not_expansion };
 	}
 
-    // Load a cartridge; either a ROM image or a pak dll.  Load cartridge is called
-	// by both mpi/multipak_cartridge.cpp and pakinterface.cpp.  cartridge_context is defined
-	// in libcommon/include/vcc/bus/cartridge_context.h.  pakContainer is a generic 
-	// pointer explicitly cast to multipak_cartridge in mpi/multipak_cartridge.cpp.
-	// mutlipak_cartridge refers specifically to a cart loaded by the multipak.
+    // Load a cartridge; either a ROM image or a pak dll. Load cartridge is called
+	// by both mpi/multipak_cartridge.cpp and pakinterface.cpp.
+	// cartridge_loader_result is defined in libcommon/include/vcc/bus/cartridge_loader.h
+	// cartridge_context is defined in libcommon/include/vcc/bus/cartridge_context.h
+	// SlotId is size_t 0-4, 0 = boot slot (side slot), 1-4 = MPI slots.  SlotId is
+	// passed to cpak cart DLLs and is returned as first argment of callbacks
 	// cpak_callbacks is used by all hardware paks and is defined in 
-	// libcommon/include/vcc/bus/cpak_cartridge_definitions.h.  cartridge_loader_result
-	// is defined in libcommon/include/vcc/bus/cartridge_loader.h
+	// libcommon/include/vcc/bus/cpak_cartridge_definitions.h.
 	cartridge_loader_result load_cartridge(
 		const std::string& filename,
 		std::unique_ptr<cartridge_context> cartridge_context,
-		void* const pakContainer,
+		slot_id_type SlotId,
 		const std::string& iniPath,
 		HWND hVccWnd,
 		const cpak_callbacks& cpak_callbacks)
@@ -184,9 +184,9 @@ namespace VCC::Core
 			return VCC::Core::load_cpak_cartridge(
 				filename,
 				move(cartridge_context),
-				pakContainer,
-				iniPath,
-				hVccWnd,
+				SlotId,							// Where cart is inserted
+				iniPath,						// Path to vcc ini file
+				hVccWnd,						// MainVcc window handle
 				cpak_callbacks);				// Callbacks in here
 		}
 	}

--- a/libcommon/src/bus/cpak_cartridge.cpp
+++ b/libcommon/src/bus/cpak_cartridge.cpp
@@ -80,13 +80,13 @@ namespace VCC::Core
 
 	cpak_cartridge::cpak_cartridge(
 		HMODULE module_handle,
-		void* const pakContainer,
+		slot_id_type SlotId,
 		path_type configuration_path,
 		const HWND hVccWnd,
 		const cpak_callbacks& cpak_callbacks)
 		:
 		handle_(module_handle),
-		pakContainer_(pakContainer),
+		SlotId_(SlotId),
 		configuration_path_(move(configuration_path)),
 		hVccWnd_(hVccWnd),
 		cpak_callbacks_(cpak_callbacks),
@@ -127,7 +127,7 @@ namespace VCC::Core
 
 	void cpak_cartridge::start()
 	{
-		initialize_(pakContainer_, configuration_path_.c_str(), hVccWnd_, &cpak_callbacks_);
+		initialize_(SlotId_, configuration_path_.c_str(), hVccWnd_, &cpak_callbacks_);
 	}
 
 	void cpak_cartridge::stop()

--- a/mpi/host_cartridge_context.h
+++ b/mpi/host_cartridge_context.h
@@ -21,7 +21,7 @@
 // Define the CPAK interface in yet another place but call it something else.
 
 extern "C" __declspec(dllexport) void PakInitialize(
-	void* const callback_context,
+	slot_id_type SlotId,
 	const char* const configuration_path,
 	HWND hVccWnd,
 	const cpak_callbacks* const callbacks);
@@ -37,9 +37,9 @@ public:
 
 public:
 
-	explicit host_cartridge_context(void* callback_context, const path_type& configuration_filename)
+	explicit host_cartridge_context(slot_id_type SlotId, const path_type& configuration_filename)
 		:
-		callback_context_(callback_context),
+		SlotId_(SlotId),
 		configuration_filename_(configuration_filename)
 	{}
 
@@ -55,33 +55,33 @@ public:
 
 	void write_memory_byte(unsigned char value, unsigned short address) override
 	{
-		write_memory_byte_(callback_context_, value, address);
+		write_memory_byte_(SlotId_, value, address);
 	}
 
 	unsigned char read_memory_byte(unsigned short address) override
 	{
-		return read_memory_byte_(callback_context_, address);
+		return read_memory_byte_(SlotId_, address);
 	}
 
 	void assert_cartridge_line(bool line_state) override
 	{
-		assert_cartridge_line_(callback_context_, line_state);
+		assert_cartridge_line_(SlotId_, line_state);
 	}
 
 	void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) override
 	{
-		assert_interrupt_(callback_context_, interrupt, interrupt_source);
+		assert_interrupt_(SlotId_, interrupt, interrupt_source);
 	}
 
 	void add_menu_item(const char* menu_name, int menu_id, MenuItemType menu_type) override
 	{
-		add_menu_item_(callback_context_, menu_name, menu_id, menu_type);
+		add_menu_item_(SlotId_, menu_name, menu_id, menu_type);
 	}
 
 private:
 
 	friend void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const configuration_path,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks);
@@ -90,11 +90,11 @@ private:
 
 private:
 
-	void* const							callback_context_;
+	slot_id_type						SlotId_;
 	const path_type&					configuration_filename_;
-	PakWriteMemoryByteHostCallback		write_memory_byte_ = [](void*, unsigned char, unsigned short) {};
-	PakReadMemoryByteHostCallback		read_memory_byte_ = [](void*, unsigned short) -> unsigned char { return 0; };
-	PakAssertCartridgeLineHostCallback	assert_cartridge_line_ = [](void*, bool) {};
-	PakAssertInteruptHostCallback		assert_interrupt_ = [](void*, Interrupt, InterruptSource) {};
-	PakAppendCartridgeMenuHostCallback	add_menu_item_ = [](void*, const char*, int, MenuItemType) {};
+	PakWriteMemoryByteHostCallback		write_memory_byte_ = [](slot_id_type, unsigned char, unsigned short) {};
+	PakReadMemoryByteHostCallback		read_memory_byte_ = [](slot_id_type, unsigned short) -> unsigned char { return 0; };
+	PakAssertCartridgeLineHostCallback	assert_cartridge_line_ = [](slot_id_type, bool) {};
+	PakAssertInteruptHostCallback		assert_interrupt_ = [](slot_id_type, Interrupt, InterruptSource) {};
+	PakAppendCartridgeMenuHostCallback	add_menu_item_ = [](slot_id_type, const char*, int, MenuItemType) {};
 };

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -28,8 +28,9 @@ HINSTANCE gModuleInstance = nullptr;
 static std::string gConfigurationFilename;
 HWND gVccWnd;
 
+slot_id_type SlotId = 0;
 const std::shared_ptr<host_cartridge_context>
-	gHostCallbacks(std::make_shared<host_cartridge_context>(nullptr, gConfigurationFilename));
+	gHostCallbacks(std::make_shared<host_cartridge_context>(SlotId, gConfigurationFilename));
 
 // mpi configuration object
 multipak_configuration gMultiPakConfiguration("MPI");
@@ -59,7 +60,7 @@ extern "C"
 
 	//Initialize MPI -	capture callback addresses and build menus.
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,                   // allways zero
 		const char* const configuration_path,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks)

--- a/mpi/multipak_cartridge_context.h
+++ b/mpi/multipak_cartridge_context.h
@@ -23,7 +23,8 @@ class multipak_cartridge_context : public ::VCC::Core::cartridge_context
 {
 public:
 
-	multipak_cartridge_context(size_t slot_id, ::VCC::Core::cartridge_context& parent_context, multipak_cartridge& multipak)
+	multipak_cartridge_context
+		(size_t slot_id, ::VCC::Core::cartridge_context& parent_context, multipak_cartridge& multipak)
 		:
 		slot_id_(slot_id),
 		parent_context_(parent_context),

--- a/orch90/orch90.cpp
+++ b/orch90/orch90.cpp
@@ -30,7 +30,7 @@ This file is part of VCC (Virtual Color Computer).
 #include <vcc/util/logger.h>
 
 static HINSTANCE gModuleInstance;
-static void* gCallbackContext = nullptr;
+static slot_id_type gSlotId {};
 static PakAssertCartridgeLineHostCallback PakSetCart = nullptr;
 static unsigned char LeftChannel=0,RightChannel=0;
 static unsigned char Rom[8192];
@@ -67,13 +67,13 @@ extern "C"
 	}
 
 	__declspec(dllexport) void PakInitialize(
-		void* const callback_context,
+		slot_id_type SlotId,
 		const char* const /*configuration_path*/,
 		HWND hVccWnd,
 		const cpak_callbacks* const callbacks)
 	{
 		DLOG_C("orch90 init\n");
-		gCallbackContext = callback_context;
+		gSlotId = SlotId;
 		PakSetCart = callbacks->assert_cartridge_line;
 	}
 
@@ -100,7 +100,7 @@ extern "C"
 	__declspec(dllexport) void PakReset()
 	{
 		DLOG_C("orch90 reset\n");
-		if (LoadRom()) PakSetCart(gCallbackContext, 1);
+		if (LoadRom()) PakSetCart(gSlotId, 1);
 	}
 
 	__declspec(dllexport) unsigned char PakReadMemoryByte(unsigned short Address)

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -99,27 +99,27 @@ struct vcc_cartridge_context : public ::VCC::Core::cartridge_context
 	}
 };
 
-static void PakAssertCartrigeLine(void* /*callback_context*/, bool line_state)
+static void PakAssertCartrigeLine(slot_id_type /*SlotId*/, bool line_state)
 {
 	SetCart(line_state);
 }
 
-static void PakWriteMemoryByte(void* /*callback_context*/, unsigned char data, unsigned short address)
+static void PakWriteMemoryByte(slot_id_type /*SlotId*/, unsigned char data, unsigned short address)
 {
 	MemWrite8(data, address);
 }
 
-static unsigned char PakReadMemoryByte(void* /*callback_context*/, unsigned short address)
+static unsigned char PakReadMemoryByte(slot_id_type /*SlotId*/, unsigned short address)
 {
 	return MemRead8(address);
 }
 
-static void PakAssertInterupt(void* /*callback_context*/, Interrupt interrupt, InterruptSource source)
+static void PakAssertInterupt(slot_id_type /*SlotId*/, Interrupt interrupt, InterruptSource source)
 {
 	PakAssertInterupt(interrupt, source);
 }
 
-static void PakAddMenuItem(void* /*callback_context*/, const char* name, int menu_id, MenuItemType type)
+static void PakAddMenuItem(slot_id_type /*SlotId*/, const char* name, int menu_id, MenuItemType type)
 {
 	CartMenuCallBack(name, menu_id, type);
 }
@@ -298,10 +298,12 @@ static cartridge_loader_status load_any_cartridge(const char *filename, const ch
 		PakAddMenuItem
 	};
 
+	slot_id_type SlotId = 0;
+
 	auto loadedCartridge = VCC::Core::load_cartridge(
 		filename,
 		std::move(vccContext),
-		nullptr,                 // pakContainer goes here  
+		SlotId, 
 		iniPath,
 		EmuState.WindowHandle,
 		callbacks);


### PR DESCRIPTION
Update cartridge interface document
- Describes the Vcc to hardware pak dll interfaces
- Outlines a proposed move of slot maintenance to Vcc main

Replace opaque context in PakInitialize exports with transparent SlotId.
- A big step in proposed interface changes.
- Eliminates slot table lookups and simplifies callback routing in MPI
- Allows pak cart dll to know what slot it is in and advise users of issues
with cart location.

Add cartridge menu system document.
- Describes replacement of add_menu_item callbacks with a new export based architecure.
