### PR TITLE
Convert Cartridge messages from WM_COMMAND to WM_APP messages

### DIFF
--- a/FD502/fd502.cpp
+++ b/FD502/fd502.cpp
@@ -141,7 +141,7 @@ extern "C"
 		gpSettings = new VCC::Util::settings(configuration_path);
 		RealDisks = InitController();
 		LoadConfig();
-		SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+		SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 	}
 
 	__declspec(dllexport) void PakReset()
@@ -419,7 +419,7 @@ VCC::Util::settings& Setting()
 
 void Unload_Disk(unsigned char disk) {
 	unmount_disk_image(disk);
-	SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 	SaveConfig();
 }
 
@@ -453,7 +453,7 @@ void Load_Disk(unsigned char disk)
 				MessageBox(g_hConfDlg,"Can't open file","Error",0);
 			} else {
 				dlg.getdir(FloppyPath);
-				SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+				SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 				SaveConfig();
 			}
 		}
@@ -724,7 +724,7 @@ void LoadConfig()  // Called on SetIniPath
 	ClockEnabled=Setting().read(ModName,"ClkEnable",1);
 	SetTurboDisk(Setting().read(ModName, "TurboDisk", 1));
 
-	SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 
 	return;
 }

--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -132,7 +132,7 @@ extern "C"
 		cloud9_rtc.set_read_only(ClockReadOnly);
 		VhdReset(); // Selects drive zero
 		// Request menu rebuild
-		SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	    SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 	}
 
 	__declspec(dllexport) bool PakGetMenuItem(menu_item_entry* item, size_t index)
@@ -184,7 +184,7 @@ extern "C"
         }
         SaveConfig();
         // FIXME should only rebuild menus if drive is changed
-		SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	    SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
         return;
     }
 }
@@ -366,7 +366,7 @@ void LoadConfig()
     ClockReadOnly = Setting().read(ModName,"ClkRdOnly",1);
 
     // Create config menu
-	SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
     return;
 }
 

--- a/SuperIDE/SuperIDE.cpp
+++ b/SuperIDE/SuperIDE.cpp
@@ -182,25 +182,25 @@ extern "C"
 		case 10:
 			Select_Disk(MASTER);
 			SaveConfig();
-		    SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+			SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 			break;
 
 		case 11:
 			DropDisk(MASTER);
 			SaveConfig();
-		    SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+			SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 			break;
 
 		case 12:
 			Select_Disk(SLAVE);
 			SaveConfig();
-		    SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+			SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 			break;
 
 		case 13:
 			DropDisk(SLAVE);
 			SaveConfig();
-		    SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+			SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 			break;
 
 		case 14:
@@ -377,6 +377,6 @@ void LoadConfig()
 	BaseAddress=BaseTable[BaseAddr];
 	cloud9_rtc.set_read_only(ClockReadOnly);
 	MountDisk(FileName ,SLAVE);
-	SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 	return;
 }

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -296,6 +296,18 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 	switch (message)
 	{
+		// Hard reset VC
+		case WM_VCC_CPU_RESET:
+			if (EmuState.EmulationRunning)
+				EmuState.ResetPending=2;
+			break;
+
+		// Rebuild dynamic menus
+		case WM_VCC_UPD_MENU:
+			BuildCartMenu();
+			DrawCartMenu(hWnd);
+			break;
+
 		case WM_SYSCOMMAND:
 			// Disable windows seeing Left ALT. (ALT-TAB can not be disabled)
 			if(wParam==SC_KEYMENU) {
@@ -362,7 +374,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					break;
 
 				case ID_FILE_RESET:
-				case IDC_MSG_CPU_RESET:
 					if (EmuState.EmulationRunning)
 						EmuState.ResetPending=2;
 					break;
@@ -375,11 +386,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				case ID_FILE_RESET_SFT:
 					if (EmuState.EmulationRunning)
 						EmuState.ResetPending=1;
-
-				case IDC_MSG_UPD_MENU:
-					BuildCartMenu();
-					DrawCartMenu(hWnd);
-					break;
 
 				case ID_FILE_LOAD:
 					LoadIniFile();

--- a/libcommon/include/vcc/bus/cartridge_messages.h
+++ b/libcommon/include/vcc/bus/cartridge_messages.h
@@ -1,9 +1,7 @@
-// Messages sent to VCC main message loop
+// Application Windows Messages sent to VCC main message loop
 
-//-----------------------------------------------------
-// ID 5000 - 5249 are reserved for cartridge menus
-// ID 5250 - 5299 are reseverd for cartridge messaging
-//-----------------------------------------------------
+#include <Winuser.h>
 
-#define IDC_MSG_CPU_RESET    5260 
-#define IDC_MSG_UPD_MENU     5261
+#define WM_VCC_CPU_RESET    WM_APP+101
+#define WM_VCC_UPD_MENU     WM_APP+102
+

--- a/libcommon/src/bus/CartridgeMenuSystem.txt
+++ b/libcommon/src/bus/CartridgeMenuSystem.txt
@@ -22,7 +22,7 @@ Concept:
 
 ## Cartridge DLL
 
-- Sends IDC_MSG_UPD_MENU to the host on internal state changes that affect its menu.
+- Sends WM_VCC_UPD_MENU to the host on internal state changes that affect its menu.
 - Keeps a static list of menu items that represents it's internal state.
 - Implements a GetMenuItemList(item,index) export that:
   - Updates the list as required (see note)
@@ -60,12 +60,12 @@ MPI:
 
 ---
 
-## PakInterface (Host)
+## VCC
 
 The host:
 
 - Creates the master menu item list from which the cartridge menu is drawn
-- Listens for IDC_MSG_UPD_MENU from any DLL including the MPI.
+- Listens for WM_VCC_UPD_MENU from any DLL including the MPI.
 - On receiving the message, updates it's list using calls to the boot slot's
   (slot 0) export and rebuilds the menu.
 

--- a/mpi/configuration_dialog.cpp
+++ b/mpi/configuration_dialog.cpp
@@ -23,6 +23,7 @@
 #include <vcc/util/critical_section.h>
 #include <vcc/util/filesystem.h>
 #include <vcc/util/logger.h>
+#include <vcc/bus/cartridge_messages.h>
 
 namespace
 {
@@ -295,7 +296,7 @@ INT_PTR configuration_dialog::process_message(
 			select_new_cartridge(button);
 			return TRUE;
 		case IDC_RESET:
-			SendMessage(gVccWnd,WM_COMMAND,(WPARAM) ID_FILE_RESET,(LPARAM) 0);
+			SendMessage(gVccWnd,WM_VCC_CPU_RESET,(WPARAM) 0,(LPARAM) 0);
 			close();
 			return TRUE;
 		case IDOK:

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -323,8 +323,8 @@ void multipak_cartridge::eject_cartridge(slot_id_type mpi_slot)
 	slots_[mpi_slot].stop();
 	slots_[mpi_slot] = {};
 	if (mpi_slot == cached_cts_slot_ || mpi_slot == switch_slot_)
-		SendMessage(gVccWnd,WM_COMMAND,(WPARAM) ID_FILE_RESET,(LPARAM) 0);
-	SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+		SendMessage(gVccWnd,WM_VCC_CPU_RESET,(WPARAM) 0,(LPARAM) 0);
+	SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 }
 
 // create cartridge object and load cart DLL
@@ -400,7 +400,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 	slots_[mpi_slot].start();
 	slots_[mpi_slot].reset();
 
-	SendMessage(gVccWnd,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(gVccWnd,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 	return loadedCartridge.load_result;
 }
 

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -301,9 +301,9 @@ static cartridge_loader_status load_any_cartridge(const char *filename, const ch
 	strcpy(DllPath, filename);
 	gActiveCartrige = move(loadedCartridge.cartridge);
 	gActiveModule = move(loadedCartridge.handle);
-	SendMessage(EmuState.WindowHandle,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(EmuState.WindowHandle,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 
-	// initialize the cartridge and reset the CPU
+	// initialize the cartridge and reset the CPU *now*
 	gActiveCartrige->start();
 	EmuState.ResetPending = 2;
 
@@ -320,7 +320,7 @@ void UnloadDll()
 	gActiveCartrige = std::make_unique<VCC::Core::null_cartridge>();
 	gActiveModule.reset();
 
-	SendMessage(EmuState.WindowHandle,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(EmuState.WindowHandle,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 	gActiveCartrige->start();
 }
 

--- a/sdc/sdc.cpp
+++ b/sdc/sdc.cpp
@@ -382,7 +382,7 @@ extern "C"
             break;
         case 11:
             SDCMountNext (0);
-            SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	        SendMessage(gVccWindow,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
             break;
         }
         return;
@@ -1895,7 +1895,8 @@ void SDCMountDisk (int drive, const char * path, int raw)
         DLOG_C("SDCMountDisk unload %d %s\n",drive,path);
         IFace.status = STA_NORMAL;
         if (drive == 0)
-            SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	        SendMessage(gVccWindow,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
+            //SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
         return;
     }
 
@@ -2082,7 +2083,8 @@ void SDCOpenFound (int drive,int raw)
         if (SDCInitiateDir(pattern.c_str())) {
             SDCOpenFound(drive, 0);
             if (drive == 0)
-                SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	            SendMessage(gVccWindow,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
+                //SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
         }
         return;
     }
@@ -2214,7 +2216,7 @@ void SDCOpenFound (int drive,int raw)
     }
 
     if (drive == 0)
-            SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	        SendMessage(gVccWindow,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
 
     IFace.status = STA_NORMAL;
     return;
@@ -2540,7 +2542,7 @@ bool SearchFile(const std::string& pat)
     // Fill gFileList with files found.
     GetFileList(pat);
     // Update menu to show next disk status
-    SendMessage(gVccWindow,WM_COMMAND,(WPARAM) IDC_MSG_UPD_MENU,(LPARAM) 0);
+	SendMessage(gVccWindow,WM_VCC_UPD_MENU,(WPARAM) 0,(LPARAM) 0);
     // Return true if something found
     return (gFileList.files.size() > 0);
 }


### PR DESCRIPTION
Frees both wParam and lParam for sending context to VCC main.

So in a future VCC version slot tracking can be moved from MPI to VCC MPI would then use app messages to request carts be loaded/unloaded For example, wParam could be a slot number and lParam a pointer to the cartridge to load.