### PR TITLE
Rename context variables to be more meaningfull

### DIFF
--- a/libcommon/include/vcc/bus/cartridge_callbacks.h
+++ b/libcommon/include/vcc/bus/cartridge_callbacks.h
@@ -23,11 +23,11 @@ enum MenuItemType;
 
 namespace VCC::Core
 {
-	struct cartridge_context
+	struct cartridge_callbacks
 	{
 		using path_type = std::string;
 
-		virtual ~cartridge_context() = default;
+		virtual ~cartridge_callbacks() = default;
 		virtual path_type configuration_path() const = 0;
 
 		virtual void assert_cartridge_line(bool line_state) = 0;

--- a/libcommon/include/vcc/bus/cartridge_loader.h
+++ b/libcommon/include/vcc/bus/cartridge_loader.h
@@ -61,25 +61,34 @@ namespace VCC::Core
 
 	cartridge_file_type determine_cartridge_type(const std::string& filename);
 
-	cartridge_loader_result load_rom_cartridge(
-		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context);
+//-------------------------------------------------------------------------------
+//  Cartridge Loader. Determine type and call appropriate loader, rom or cpak
+//	cartridge_callbacks is the host to cartridge API used by the cartridge class.
+//	SlotID is the 0-4 slot id; 0 is the side slot and 1-4 are MPI slots.
+//	iniPath is the name of the ini file (typically vcc.ini)
+//	hVccWnd is the VCC main window handle, used for messaging
+//	cpak_callbacks is the cartridge to host API used by the cartridge DLL.
+//-------------------------------------------------------------------------------
 
-	cartridge_loader_result load_cpak_cartridge(
+	cartridge_loader_result load_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<cartridge_callbacks> cartridge_callbacks,
 		slot_id_type SlotId,
 		const std::string& iniPath,
 		HWND hVccWnd,
 		const cpak_callbacks& cpak_callbacks);
 
-	cartridge_loader_result load_cartridge(
-		const std::string& filename,                          // Cartridge filename
-		std::unique_ptr<cartridge_context> cartridge_context, // Loader context
+	cartridge_loader_result load_cpak_cartridge(
+		const std::string& filename,
+		std::unique_ptr<cartridge_callbacks> cartridge_callbacks,
 		slot_id_type SlotId,
-		const std::string& iniPath,                           // Path of ini file
-		HWND hVccWnd,                                         // handle to main window 
-		const cpak_callbacks& cpak_callbacks);                // Callbacks
+		const std::string& iniPath,
+		HWND hVccWnd,
+		const cpak_callbacks& cpak_callbacks);
+
+	cartridge_loader_result load_rom_cartridge(
+		const std::string& filename,
+		std::unique_ptr<cartridge_callbacks> cartridge_callbacks);
 
 	// Return load error string per cartridge load status
 	std::string cartridge_load_error_string(

--- a/libcommon/include/vcc/bus/rom_cartridge.h
+++ b/libcommon/include/vcc/bus/rom_cartridge.h
@@ -21,26 +21,20 @@
 #include <vector>
 #include <memory>
 
-// TODO:  This could be alot simpler
 namespace VCC::Core
 {
-
 	class rom_cartridge : public basic_cartridge
 	{
 	public:
-
-		using context_type = ::VCC::Core::cartridge_context;
+		using callbacks_type = ::VCC::Core::cartridge_callbacks;
 		using buffer_type = std::vector<uint8_t>;
 		using size_type = std::size_t;
 
-
 	public:
-
 		using basic_cartridge::basic_cartridge;
 
-
 		rom_cartridge(
-			std::unique_ptr<context_type> context,
+			std::unique_ptr<callbacks_type> callbacks,
 			name_type name,
 			catalog_id_type catalog_id,
 			buffer_type buffer,
@@ -54,20 +48,15 @@ namespace VCC::Core
 		void write_port(unsigned char port_id, unsigned char value) override;
 		unsigned char read_memory_byte(unsigned short memory_address) override;
 
-
 	protected:
-
 		void initialize_bus() override;
 
-
 	private:
-
-		const std::unique_ptr<context_type> context_;
+		const std::unique_ptr<callbacks_type> callbacks_;
 		const name_type name_;
 		const catalog_id_type catalog_id_;
 		const buffer_type buffer_;
 		const bool enable_bank_switching_;
 		size_type bank_offset_;
 	};
-
 }

--- a/libcommon/src/bus/cartridge_loader.cpp
+++ b/libcommon/src/bus/cartridge_loader.cpp
@@ -71,7 +71,7 @@ namespace VCC::Core
 
 	// Load a ROM cartridge
 	cartridge_loader_result load_rom_cartridge(
-		std::unique_ptr<cartridge_context> context,
+		std::unique_ptr<cartridge_callbacks> parent_callbacks,
 		const std::string& filename)
 	{
 		DLOG_C("cartridge_loader load rom\n");
@@ -105,7 +105,7 @@ namespace VCC::Core
 		constexpr bool enable_bank_switching = true;
 
 		auto rom = std::make_unique<VCC::Core::rom_cartridge>(
-			std::move(context),
+			std::move(parent_callbacks),
 			extract_filename(filename),
 			"",
 			std::move(romImage),
@@ -121,10 +121,10 @@ namespace VCC::Core
 		return result;
 	}
 
-	// Load a legacy cartridge
+	// Load a dll cartridge
 	cartridge_loader_result load_cpak_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<cartridge_callbacks> parent_callbacks,
 		slot_id_type SlotId,
 		const std::string& iniPath,
 		HWND hVccWnd,
@@ -165,14 +165,14 @@ namespace VCC::Core
     // Load a cartridge; either a ROM image or a pak dll. Load cartridge is called
 	// by both mpi/multipak_cartridge.cpp and pakinterface.cpp.
 	// cartridge_loader_result is defined in libcommon/include/vcc/bus/cartridge_loader.h
-	// cartridge_context is defined in libcommon/include/vcc/bus/cartridge_context.h
+	// cartridge_callbacks is defined in libcommon/include/vcc/bus/cartridge_callbacks.h
 	// SlotId is size_t 0-4, 0 = boot slot (side slot), 1-4 = MPI slots.  SlotId is
 	// passed to cpak cart DLLs and is returned as first argment of callbacks
 	// cpak_callbacks is used by all hardware paks and is defined in
 	// libcommon/include/vcc/bus/cpak_cartridge_definitions.h.
 	cartridge_loader_result load_cartridge(
 		const std::string& filename,
-		std::unique_ptr<cartridge_context> cartridge_context,
+		std::unique_ptr<cartridge_callbacks> parent_callbacks,
 		slot_id_type SlotId,
 		const std::string& iniPath,
 		HWND hVccWnd,
@@ -186,16 +186,16 @@ namespace VCC::Core
 			return { nullptr, nullptr, cartridge_loader_status::cannot_open };
 
 		case cartridge_file_type::rom_image:	//	File is a ROM image
-			return VCC::Core::load_rom_cartridge(move(cartridge_context), filename);
+			return VCC::Core::load_rom_cartridge(move(parent_callbacks), filename);
 
 		case cartridge_file_type::library:		//	File is a DLL
 			return VCC::Core::load_cpak_cartridge(
 				filename,
-				move(cartridge_context),
-				SlotId,							// Where cart is inserted
-				iniPath,						// Path to vcc ini file
-				hVccWnd,						// MainVcc window handle
-				cpak_callbacks);				// Callbacks in here
+				move(parent_callbacks), // parent callback interface
+				SlotId,                 // Where cart is inserted
+				iniPath,                // Path to vcc ini file
+				hVccWnd,                // MainVcc window handle
+				cpak_callbacks);        // DLL callbacks in here
 		}
 	}
 

--- a/libcommon/src/bus/rom_cartridge.cpp
+++ b/libcommon/src/bus/rom_cartridge.cpp
@@ -23,13 +23,13 @@ namespace VCC::Core
 {
 
 	rom_cartridge::rom_cartridge(
-		std::unique_ptr<context_type> context,
+		std::unique_ptr<callbacks_type> callbacks,
 		name_type name,
 		catalog_id_type catalog_id,
 		buffer_type buffer,
 		bool enable_bank_switching)
 		:
-		context_(move(context)),
+		callbacks_(move(callbacks)),
 		name_(move(name)),
 		catalog_id_(move(catalog_id)),
 		buffer_(move(buffer)),
@@ -77,8 +77,8 @@ namespace VCC::Core
 
 	void rom_cartridge::initialize_bus()
 	{
-		DLOG_C("rom_cartridge::initialize_bus: this=%p context=%p\n",this,context_.get());
-		context_->assert_cartridge_line(true);
+		DLOG_C("rom_cartridge::initialize_bus: this=%p callbacks=%p\n",this,callbacks_.get());
+		callbacks_->assert_cartridge_line(true);
 	}
 
 }

--- a/mpi/cartridge_slot.h
+++ b/mpi/cartridge_slot.h
@@ -35,7 +35,7 @@ namespace VCC::Core
 		using label_type = std::string;
 		using handle_type = ::VCC::Core::cartridge_loader_result::handle_type;
 		using cartridge_ptr_type = std::unique_ptr<::VCC::Core::cartridge>;
-		using context_type = ::VCC::Core::cartridge_context;
+		using callbacks_type = ::VCC::Core::cartridge_callbacks;
 
 	public:
 

--- a/mpi/cartridge_slot_adapter.h
+++ b/mpi/cartridge_slot_adapter.h
@@ -18,32 +18,35 @@
 #pragma once
 #include "multipak_cartridge.h"
 
-
-class multipak_cartridge_context : public ::VCC::Core::cartridge_context
+class cartridge_slot_adapter : public ::VCC::Core::cartridge_callbacks
 {
 public:
 
-	multipak_cartridge_context
-		(size_t slot_id, ::VCC::Core::cartridge_context& parent_context, multipak_cartridge& multipak)
+	cartridge_slot_adapter
+		(
+			size_t slot_id, 
+			::VCC::Core::cartridge_callbacks& mpi_callbacks,
+			multipak_cartridge& multipak
+		)
 		:
 		slot_id_(slot_id),
-		parent_context_(parent_context),
+		mpi_callbacks_(mpi_callbacks),
 		multipak_(multipak)
 	{}
 
 	path_type configuration_path() const override
 	{
-		return parent_context_.configuration_path();
+		return mpi_callbacks_.configuration_path();
 	}
 
 	void write_memory_byte(unsigned char value, unsigned short address) override
 	{
-		parent_context_.write_memory_byte(value, address);
+		mpi_callbacks_.write_memory_byte(value, address);
 	}
 
 	unsigned char read_memory_byte(unsigned short address) override
 	{
-		return parent_context_.read_memory_byte(address);
+		return mpi_callbacks_.read_memory_byte(address);
 	}
 
 	void assert_cartridge_line(bool line_state) override
@@ -53,13 +56,13 @@ public:
 
 	void assert_interrupt(Interrupt interrupt, InterruptSource interrupt_source) override
 	{
-		parent_context_.assert_interrupt(interrupt, interrupt_source);
+		mpi_callbacks_.assert_interrupt(interrupt, interrupt_source);
 	}
 
 
 private:
 
 	const size_t slot_id_;
-	::VCC::Core::cartridge_context& parent_context_;
+	::VCC::Core::cartridge_callbacks& mpi_callbacks_;
 	multipak_cartridge& multipak_;
 };

--- a/mpi/host_cartridge_callbacks.h
+++ b/mpi/host_cartridge_callbacks.h
@@ -18,16 +18,13 @@
 #pragma once
 #include <vcc/bus/cpak_cartridge_definitions.h>
 
-// Define the CPAK interface in yet another place but call it something else.
-
 extern "C" __declspec(dllexport) void PakInitialize(
 	slot_id_type SlotId,
 	const char* const configuration_path,
 	HWND hVccWnd,
 	const cpak_callbacks* const callbacks);
 
-// FIXME: this should be unnecessary here. VCC (or the 'host') should provide it
-class host_cartridge_context : public ::VCC::Core::cartridge_context
+class host_cartridge_callbacks : public ::VCC::Core::cartridge_callbacks
 {
 public:
 
@@ -35,7 +32,7 @@ public:
 
 public:
 
-	explicit host_cartridge_context(slot_id_type SlotId, const path_type& configuration_filename)
+	explicit host_cartridge_callbacks(slot_id_type SlotId, const path_type& configuration_filename)
 		:
 		SlotId_(SlotId),
 		configuration_filename_(configuration_filename)

--- a/mpi/mpi.cpp
+++ b/mpi/mpi.cpp
@@ -30,8 +30,8 @@ static std::string gConfigurationFilename;
 HWND gVccWnd;
 
 slot_id_type SlotId = 0;
-const std::shared_ptr<host_cartridge_context>
-	gHostCallbacks(std::make_shared<host_cartridge_context>(SlotId, gConfigurationFilename));
+const std::shared_ptr<host_cartridge_callbacks>
+	gHostCallbacks(std::make_shared<host_cartridge_callbacks>(SlotId, gConfigurationFilename));
 
 // mpi configuration object
 multipak_configuration gMultiPakConfiguration("MPI");

--- a/mpi/mpi.h
+++ b/mpi/mpi.h
@@ -16,12 +16,12 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #include "multipak_cartridge.h"
-#include "host_cartridge_context.h"
+#include "host_cartridge_callbacks.h"
 #include "configuration_dialog.h"
 #include <Windows.h>
 
 extern HWND	gVccWnd;
-extern const std::shared_ptr<host_cartridge_context> gHostCallbacks;
+extern const std::shared_ptr<host_cartridge_callbacks> gHostCallbacks;
 extern multipak_cartridge gMultiPakInterface;
 extern configuration_dialog gConfigurationDialog;
 extern std::string gLastAccessedPath;

--- a/mpi/mpi.vcxproj
+++ b/mpi/mpi.vcxproj
@@ -101,11 +101,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cartridge_slot.h" />
-    <ClInclude Include="host_cartridge_context.h" />
+    <ClInclude Include="cartridge_slot_adapter.h" />
+    <ClInclude Include="host_cartridge_callbacks.h" />
     <ClInclude Include="mpi.h" />
     <ClInclude Include="multipak_cartridge.h" />
     <ClInclude Include="configuration_dialog.h" />
-    <ClInclude Include="multipak_cartridge_context.h" />
     <ClInclude Include="multipak_configuration.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -17,7 +17,7 @@
 //	VCC (Virtual Color Computer). If not, see <http://www.gnu.org/licenses/>.
 ////////////////////////////////////////////////////////////////////////////////
 #include "multipak_cartridge.h"
-#include "multipak_cartridge_context.h"
+#include "cartridge_slot_adapter.h"
 #include "mpi.h"
 #include "resource.h"
 #include <vcc/util/winapi.h>
@@ -45,10 +45,10 @@ namespace
 
 multipak_cartridge::multipak_cartridge(
 	multipak_configuration& configuration,
-	std::shared_ptr<context_type> context)
+	std::shared_ptr<callbacks_type> callbacks)
 	:
 	configuration_(configuration),
-	context_(move(context))
+	callbacks_(move(callbacks))
 { }
 
 multipak_cartridge::name_type multipak_cartridge::name() const
@@ -113,7 +113,7 @@ void multipak_cartridge::reset()
 		cartridge_slot.reset();
 	}
 
-	context_->assert_cartridge_line(slots_[cached_scs_slot_].line_state());
+	callbacks_->assert_cartridge_line(slots_[cached_scs_slot_].line_state());
 }
 
 void multipak_cartridge::process_horizontal_sync()
@@ -139,7 +139,7 @@ void multipak_cartridge::write_port(unsigned char port_id, unsigned char value)
 		cached_cts_slot_ = (value >> 4) & 3;
 		slot_register_ = value;
 
-		context_->assert_cartridge_line(slots_[cached_scs_slot_].line_state());
+		callbacks_->assert_cartridge_line(slots_[cached_scs_slot_].line_state());
 
 		return;
 	}
@@ -344,7 +344,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 	};
 
 	// Build callback table for carts loaded on MPI
-	cpak_callbacks callbacks {
+	cpak_callbacks cpak_callbacks {
 		gHostCallbacks->assert_interrupt_,
 		assert_cartridge_line_thunk,
 		gHostCallbacks->write_memory_byte_,
@@ -356,21 +356,21 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 	std::size_t SlotId = mpi_slot + 1;
 
 	// ctx is passed to the loader but not to cartridge DLL's
-	auto* pakContainer = this;
-	auto ctx = std::make_unique<multipak_cartridge_context>(
+	auto* parent = this;
+	auto slot_adapter = std::make_unique<cartridge_slot_adapter>(
 		mpi_slot,
-		*context_,
-		*pakContainer);  // Why does the loader need this?
+		*callbacks_,
+		*parent );
 
 	DLOG_C("load cart %d  %s\n",mpi_slot,filename);
 
 	auto loadedCartridge = VCC::Core::load_cartridge(
 		filename,
-		std::move(ctx),
+		std::move(slot_adapter),
 		SlotId,
-		context_->configuration_path(),    // ini file name
+		callbacks_->configuration_path(),    // ini file name
 		gVccWnd,
-		callbacks);
+		cpak_callbacks);
 
 	if (loadedCartridge.load_result != mount_status_type::success) {
 		// Tell user why load failed
@@ -428,6 +428,6 @@ void multipak_cartridge::assert_cartridge_line(slot_id_type mpi_slot, bool line_
 	VCC::Util::section_locker lock(mutex_);
 	slots_[mpi_slot].line_state(line_state);
 	if (selected_scs_slot() == mpi_slot) {
-		context_->assert_cartridge_line(slots_[mpi_slot].line_state());
+		callbacks_->assert_cartridge_line(slots_[mpi_slot].line_state());
 	}
 }

--- a/mpi/multipak_cartridge.cpp
+++ b/mpi/multipak_cartridge.cpp
@@ -351,7 +351,7 @@ multipak_cartridge::mount_status_type multipak_cartridge::mount_cartridge(
 		gHostCallbacks->read_memory_byte_//,
 	};
 	
-	DLOG_C("%3d %p %p %p %p %p\n",mpi_slot,callbacks);
+	DLOG_C("%3d %p %p %p %p %p\n",mpi_slot,cpak_callbacks);
 
 	std::size_t SlotId = mpi_slot + 1;
 

--- a/mpi/multipak_cartridge.h
+++ b/mpi/multipak_cartridge.h
@@ -30,7 +30,7 @@ class multipak_cartridge : public ::VCC::Core::cartridge
 {
 public:
 
-	using context_type = ::VCC::Core::cartridge_context;
+	using callbacks_type = ::VCC::Core::cartridge_callbacks;
 	using mount_status_type = ::VCC::Core::cartridge_loader_status;
 	using slot_id_type = std::size_t;
 	using path_type = std::string;
@@ -41,7 +41,7 @@ public:
 
 	multipak_cartridge(
 		multipak_configuration& configuration,
-		std::shared_ptr<context_type> context);
+		std::shared_ptr<callbacks_type> callbacks);
 	multipak_cartridge(const multipak_cartridge&) = delete;
 	multipak_cartridge(multipak_cartridge&&) = delete;
 
@@ -90,7 +90,7 @@ private:
 
 	VCC::Util::critical_section mutex_;
 	multipak_configuration& configuration_;
-	std::shared_ptr<context_type> context_;
+	std::shared_ptr<callbacks_type> callbacks_;
 	std::array<VCC::Core::cartridge_slot, NUMSLOTS> slots_;
 	unsigned char slot_register_ = default_slot_register_value;
 	slot_id_type switch_slot_ = default_switch_slot_value;

--- a/pakinterface.cpp
+++ b/pakinterface.cpp
@@ -56,7 +56,7 @@ void CartMenuCallBack(const char* name, int menu_id, MenuItemType type);
 void PakAssertInterupt(Interrupt interrupt, InterruptSource source);
 
 
-struct vcc_cartridge_context : public ::VCC::Core::cartridge_context
+struct vcc_cartridge_callbacks : public ::VCC::Core::cartridge_callbacks
 {
 
 	path_type configuration_path() const override
@@ -267,9 +267,6 @@ cartridge_loader_status PakLoadCartridge(const char* filename)
 // Insert Module returns 0 on success
 static cartridge_loader_status load_any_cartridge(const char *filename, const char* iniPath)
 {
-	// vccContext is passed to the loader but not to the cart DLL
-	auto vccContext=std::make_unique<vcc_cartridge_context>();
-
 	cpak_callbacks callbacks {
 		PakAssertInterupt,
 		PakAssertCartrigeLine,
@@ -279,10 +276,13 @@ static cartridge_loader_status load_any_cartridge(const char *filename, const ch
 
 	slot_id_type SlotId = 0;
 
+	// pakinterface slot adapter only needs callbacks structure
+	auto boot_slot_adapter=std::make_unique<vcc_cartridge_callbacks>();
+
 	// SlotId, iniPath, WindowHandle, and callbacks are unused for ROM carts
 	auto loadedCartridge = VCC::Core::load_cartridge(
 		filename,
-		std::move(vccContext),
+		std::move(boot_slot_adapter),
 		SlotId, 
 		iniPath,
 		EmuState.WindowHandle,


### PR DESCRIPTION
Too many different things were called context in the cartridge definitions.  Hopefully renaming them makes the code easier to read.