### PR TITLE
PIA0 raise VSYNC IRQ line if HSYNC IRQ line is.

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -151,8 +151,8 @@ namespace VCC
     // delayed flip flop
     struct DFF 
     {
-        uint8_t D{}; // d input
-        uint8_t Q{}; // q output
+        uint8_t D{}; // most recent Clock input
+        uint8_t Q{}; // previous Clock input
 
         void Reset()
         {

--- a/mc6821.cpp
+++ b/mc6821.cpp
@@ -154,6 +154,9 @@ unsigned char pia0_read(unsigned char port)
 			{
 				rega[1]=(rega[1] & 63);
 				CPUDeAssertInterupt(IS_PIA0_HSYNC, INT_IRQ);
+				// FIXME VCC interrupts still basically broken,
+				// following VSYNC kludge fixes some things
+				CPUDeAssertInterupt(IS_PIA0_VSYNC, INT_IRQ);
 				return (vccKeyboardGetScan(rega[2]|~rega_dd[2])); //Read
 			}
 			else


### PR DESCRIPTION
VCC interrupts are still basically broken, this throws another patch at it. Design for proper interrupt emulation is still in the works. Completion timeline is unknown.