### PR TITLE
Fix CC flags display order in Processor State debugger window

### DIFF
--- a/ProcessorState.cpp
+++ b/ProcessorState.cpp
@@ -156,13 +156,13 @@ namespace {
         }
         // Condition Code bits
         int x = 35;
-        for (int n = 0; n < 8; n++) {
-            if (regs.CC & 1 << n) {
-                DrawCntrTxt(hdc,rect,"1",x,60,25,18);
-            } else {
-                DrawCntrTxt(hdc,rect,"-",x,60,25,18);
-            }
-            x += 25;
+        for (int n = 7; n >= 0; n--) {
+          if (regs.CC & 1 << n) {
+            DrawCntrTxt(hdc, rect, "1", x, 60, 25, 18);
+          } else {
+            DrawCntrTxt(hdc, rect, "-", x, 60, 25, 18);
+          }
+          x += 25;
         }
         // Instruction
         VCC::CPUTrace trace = {};


### PR DESCRIPTION
**Bug**: Processor State window displays CC flags in wrong order. The loop iterates from bit 0 to bit 7 but the UI labels run E F H I N Z V C (bit 7 to bit 0), causing every flag to display in the wrong column.

**Fix**: Reverse the loop iteration from n = 7 down to n = 0.

**Verified**: MAME displays correct CC flags for the same code; VCC displayed them all shifted, confirmed by cross-referencing emulation results with memory-based flag tests.