### PR TITLE
Fix buffer overflow in PakLoadCartridgeUI

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -1716,7 +1716,7 @@ int SelectFile(char *FileName)
 			MessageBox(EmuState.WindowHandle,"Can't open file.","Error",0);
 		}
 	}
-	dlg.getpath(FileName);
+	dlg.getpath(FileName, MAX_PATH);
 	return 1;
 }
 

--- a/libcommon/include/vcc/util/DialogOps.h
+++ b/libcommon/include/vcc/util/DialogOps.h
@@ -63,14 +63,19 @@ public:
     void setTitle(const char* Title);
     void setpath(const char* File);
 
-    std::string getpath() const;
+    const std::string& getpath() const;
     std::string getdir() const;
     std::string gettype() const;
 
-    void getpath(char* PathCopy, int maxsize = MAX_PATH) const;
-    void getupath(char* PathCopy, int maxsize = MAX_PATH) const;
-    void getdir(char* Dir, int maxsize = MAX_PATH) const;
-    void gettype(char* Type, int maxsize = 16) const;
+    void getpath(char* pathCopy, int maxsize) const;
+    void getupath(char* pathCopy, int maxsize) const;
+    void getdir(char* dir, int maxsize) const;
+    void gettype(char* type, int maxsize) const;
+
+    template <size_t S> void getpath(char (&pathCopy)[S]) const { getpath(pathCopy, S); }
+    template <size_t S> void getupath(char (&pathCopy)[S]) const { getupath(pathCopy, S); }
+    template <size_t S> void getdir(char (&dir)[S]) const { getdir(dir, S); }
+    template <size_t S> void gettype(char (&type)[S]) const { gettype(type, S); }
 
     const char* path() const;
     const char* upath() const;

--- a/libcommon/src/util/DialogOps.cpp
+++ b/libcommon/src/util/DialogOps.cpp
@@ -92,7 +92,7 @@ void FileDialog::setpath(const char* File)
     sFile_.assign(File ? File : "");
 }
 
-std::string FileDialog::getpath() const
+const std::string& FileDialog::getpath() const
 {
     return sFile_;
 }
@@ -113,27 +113,31 @@ std::string FileDialog::gettype() const
 void FileDialog::getpath(char* PathCopy, int maxsize) const
 {
     if (!PathCopy) return;
-    strncpy(PathCopy, sFile_.c_str(), maxsize);
+    strncpy(PathCopy, sFile_.c_str(), maxsize - 1);
+    PathCopy[maxsize - 1] = 0;
 }
 
 void FileDialog::getupath(char* PathCopy, int maxsize) const
 {
     if (!PathCopy) return;
-    strncpy(PathCopy, sFile_.c_str(), maxsize);
+    strncpy(PathCopy, sFile_.c_str(), maxsize - 1);
+    PathCopy[maxsize - 1] = 0;
 }
 
 void FileDialog::getdir(char* Dir, int maxsize) const
 {
     if (!Dir) return;
     std::string d = getdir();
-    strncpy(Dir, d.c_str(), maxsize);
+    strncpy(Dir, d.c_str(), maxsize - 1);
+    Dir[maxsize - 1] = 0;
 }
 
 void FileDialog::gettype(char* Type, int maxsize) const
 {
     if (!Type) return;
     std::string t = gettype();
-    strncpy(Type, t.c_str(), maxsize);
+    strncpy(Type, t.c_str(), maxsize - 1);
+    Type[maxsize - 1] = 0;
 }
 
 const char* FileDialog::path() const


### PR DESCRIPTION
- updated getdir, gettype & friends to use the actual size of buffer to avoid buffer overflow.