### PR TITLE
Added default no UAC access manifiest

### DIFF
--- a/vcc-base.props
+++ b/vcc-base.props
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- This is included first in every VCC project -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <!-- Add a default Manifest to keep defender happy -->
+    <ItemDefinitionGroup>
+    <Link>
+      <GenerateManifest>true</GenerateManifest>
+       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+        <UACUIAccess>false</UACUIAccess>
+    </Link>
+   </ItemDefinitionGroup>
+
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -11,6 +21,7 @@
     <IntDir>$(SolutionDir)__obj\$(Platform)\$(Configuration)\$(ProjectName)\int\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+
   <ItemDefinitionGroup Condition="'$(LinkageType)' == 'Dynamic'">
     <ClCompile>
       <LanguageStandard>stdcpp17</LanguageStandard>


### PR DESCRIPTION
MS defender started flagging VCC as a possible trojan.  Adding a NOUACACCESS flag in the manifest has removed the flag according to virustotal.   Potential fix for issue #565