### PR TITLE
Update VCC version to 2.1.10.0 pre 1

### DIFF
--- a/Vcc.rc
+++ b/Vcc.rc
@@ -151,7 +151,7 @@ FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
     CONTROL         IDB_VCC,IDC_STATIC,"Static",SS_BITMAP | SS_REALSIZEIMAGE,8,5,217,45
     CONTROL         IDB_3GUYS,IDC_STATIC,"Static",SS_BITMAP | SS_CENTERIMAGE,16,53,77,57,WS_EX_DLGMODALFRAME
-    LTEXT           "VCC Version 2.1.9.3",IDC_STATIC,114,65,85,10
+    LTEXT           "VCC Version 2.1.10.0",IDC_STATIC,114,65,85,10
     LTEXT           "Another classic computer canceled before it's time!",IDC_STATIC,114,80,85,20
     LTEXT           "Copyright 2015 By Joseph Forgione",IDC_STATIC,8,120,120,15
     LTEXT           "VCC (Virtual Color Computer) is free software: you can redistribute and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",IDC_STATIC,8,135,210,35
@@ -703,8 +703,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,1,9,3
- PRODUCTVERSION 2,1,9,3
+ FILEVERSION 2,1,10,0
+ PRODUCTVERSION 2,1,10,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x29L
@@ -722,7 +722,7 @@ BEGIN
             VALUE "Comments", "How bored are you that your reading this?"
             VALUE "CompanyName", "Not Radio Shack"
             VALUE "FileDescription", "Vcc"
-            VALUE "FileVersion", "2.1.9.3"
+            VALUE "FileVersion", "2.1.10.0"
             VALUE "InternalName", "Poco"
             VALUE "LegalCopyright", "Copyright 2015 by BitRot Software"
             VALUE "LegalTrademarks", "BLAZEMONGER!"
@@ -832,7 +832,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_APP_TITLE           "VCC 2.1.9.3 Tandy Color Computer 3 Emulator"
+    IDS_APP_TITLE           "VCC 2.1.10.0pre1 Tandy Color Computer 3 Emulator"
     IDS_CATNUMBER           "26-3334"
     // TODO:  The following should not be used
     IDS_MODULE_ALREADY_LOADED "Module is already loaded."


### PR DESCRIPTION
VCC main version (development) is now 2.1.10.0 pre 1 
VCC store version will remain at 2.1.9.3 until 2.1.10.0 is released