### PR TITLE
Fix memory window display with old NTSC mode

### DIFF
--- a/MemoryMap.cpp
+++ b/MemoryMap.cpp
@@ -239,7 +239,7 @@ struct MemoryWindow::Measurements
 		}
 
 		if (mem->viewMode == MemoryWindow::VM_PMODE4_NTSC)
-			viewOffset = 4;
+			viewOffset = GetPaletteType() == 2 ? 4 : 0;
 
 		// reposition view so hex is always visible
 		const float rounding = 0.000001f; // adjust for rounding

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -8273,12 +8273,15 @@ case 192+2:	//Bpp=0 Sr=2
 						break;
 					case 3:
 						Pcolor = 3;
-						szSurface32[YStride - 1] = Afacts32[ColorInvert][3];
-						if (!ScanLines)
-							szSurface32[YStride + Xpitch - 1] = Afacts32[ColorInvert][3];
-						szSurface32[YStride] = Afacts32[ColorInvert][3];
-						if (!ScanLines)
-							szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][3];
+						if ((int)YStride > 0)
+						{
+							szSurface32[YStride - 1] = Afacts32[ColorInvert][3];
+							if (!ScanLines)
+								szSurface32[YStride + Xpitch - 1] = Afacts32[ColorInvert][3];
+							szSurface32[YStride] = Afacts32[ColorInvert][3];
+							if (!ScanLines)
+								szSurface32[YStride + Xpitch] = Afacts32[ColorInvert][3];
+						}
 						break;
 					case 7:
 						Pcolor = 3;


### PR DESCRIPTION
- When using the old NTSC colors, fix memory window display to handle this mode.