### PR TITLE
Use the default palette for SG4 memory window

### DIFF
--- a/MemoryMap.cpp
+++ b/MemoryMap.cpp
@@ -1427,10 +1427,11 @@ bool MemoryWindow::DrawMemory(HDC hdc, LPCRECT clientRect)
 
 	memGpu.GimeReset();
 	memGpu.SetCompatMode(1);
+	memGpu.SetDefaultPalette();
 	memGpu.SetMonitorType(1);
 
 	// if palette changes pixels will need rewriting
-	if (memGpu.CopyPalette(gGimeGpu))
+	if (viewMode != VM_SG4 && memGpu.CopyPalette(gGimeGpu))
 		ResetMemoryCache();
 
 	auto pmode = [this](int mode, int mode2) 

--- a/tcc1014graphics.cpp
+++ b/tcc1014graphics.cpp
@@ -9842,6 +9842,12 @@ void GimeGpu::SetVideoBank(unsigned char data)
 	SetupDisplay();
 }
 
+void GimeGpu::SetDefaultPalette()
+{
+	static uint8_t pal[16] = {18,36,11,7,63,31,9,38,0,18,0,63,0,18,0,38};
+	for (size_t i = 0; i < 16; ++i)
+		SetGimePalette((uint8_t)i, pal[i]);
+}
 
 void GimeGpu::MakeRGBPalette()
 {

--- a/tcc1014graphics.h
+++ b/tcc1014graphics.h
@@ -101,6 +101,7 @@ struct GimeGpu
 	void SetVideoBank(unsigned char data);
 	void SetVidMask(unsigned int data);
 	bool CopyPalette(const GimeGpu& other);
+	void SetDefaultPalette();
 
 	void DrawTopBoarder8(SystemState* DTState) const;
 	void DrawTopBoarder16(SystemState* DTState) const;


### PR DESCRIPTION
- Uses the default palette for SG4 memory window display rather than current palette.