### PR TITLE
Add support to recover audio when display lost

### DIFF
--- a/Audio.cpp
+++ b/Audio.cpp
@@ -60,6 +60,7 @@ static char AuxBufferPointer=0;
 static int CardCount=0;
 static unsigned int CurrentRate=0;
 static unsigned char AudioPause=0;
+static bool AudioStall = false;
 static SndCardList *Cards=nullptr;
 BOOL CALLBACK DSEnumCallback(LPGUID,LPCSTR,LPCSTR,LPVOID);
 
@@ -150,6 +151,7 @@ int SoundInit (HWND main_window_handle,const _GUID * Guid,unsigned int Rate)
 			return 1;
 		InitPassed=1;
 		AudioPause=0;
+		AudioStall = false;
 	}
 	SetAudioRate(AUDIO_RATE);
 	return 0;
@@ -217,13 +219,38 @@ void FlushAudioBuffer(unsigned int *Abuffer,unsigned int Lenth)
 }
 
 
+void OnMonitorRestored()
+{
+	if (!AudioStall) return;
+	InitSound();
+	AudioStall = false;
+}
+
 int GetFreeBlockCount() //return 0 on full buffer
- {
+{
+	static unsigned long LastPlayCursor = 0;
+	static int LastCount = 0;
+
 	unsigned long WriteCursor=0,PlayCursor=0;
 	long RetVal=0,MaxSize=0;
-	if ((!InitPassed) | AudioPause)
+	if (!InitPassed || AudioPause)
 		return AUDIOBUFFERS;
 	RetVal=lpdsbuffer1->GetCurrentPosition(&PlayCursor,&WriteCursor);
+	if (PlayCursor == LastPlayCursor)
+	{
+		if (++LastCount > 100)
+		{
+			AudioStall = true;
+			LastCount = 0;
+			LastPlayCursor = 0;
+			return AUDIOBUFFERS;
+		}
+	}
+	else
+	{
+		LastPlayCursor = PlayCursor;
+		LastCount = 0;
+	}
 	if (BuffOffset <=PlayCursor)
 		MaxSize= PlayCursor - BuffOffset;
 	else
@@ -234,7 +261,7 @@ int GetFreeBlockCount() //return 0 on full buffer
 
  void PurgeAuxBuffer()
  {
-	if ((!InitPassed) | AudioPause)
+	if (!InitPassed || AudioPause)
 		return;
 	return;
 	AuxBufferPointer--;			//Normally points to next free block Point to last used block

--- a/DirectX.cpp
+++ b/DirectX.cpp
@@ -285,6 +285,15 @@ namespace VCC
                 return Result(ERR_UNKNOWN);
 
             hr = g_pDDS->Blt(&rcDest, g_pDDSBack, &rcSrc, DDBLT_WAIT, nullptr); // DDBLT_WAIT
+            if (hr == DDERR_SURFACELOST)
+            {
+                hr = g_pDDS->Restore();
+                if (hr == DDERR_WRONGMODE) return Result(ERR_WRONGMODE);
+                if (FAILED(hr)) return Result(ERR_UNKNOWN);
+                g_pDDSBack->Restore();
+                hr = g_pDDS->Blt(&rcDest, g_pDDSBack, &rcSrc, DDBLT_WAIT, nullptr); // DDBLT_WAIT
+                if (hr == E_FAIL) return Result(OK);
+            }
             if (FAILED(hr)) return Result(ERR_UNKNOWN);
         }
 
@@ -354,10 +363,8 @@ namespace VCC
 
         // Lock entire surface, wait if it is busy, return surface memory pointer
         hr = g_pDDSBack->Lock(nullptr, &ddsd, DDLOCK_WAIT | DDLOCK_SURFACEMEMORYPTR, nullptr);
-        if (FAILED(hr))
-        {
-            return Result(ERR_UNKNOWN);
-        }
+        if (hr == E_FAIL) return ERR_CANTLOCK;
+        if (FAILED(hr)) return Result(ERR_UNKNOWN);
 
         switch (ddsd.ddpfPixelFormat.dwRGBBitCount)
         {

--- a/DirectX.h
+++ b/DirectX.h
@@ -32,7 +32,9 @@ namespace VCC
         {
             ERR_UNSUPPORTED = 100,          // unsupported command
             ERR_BADOPTION,                  // invalid option being set
-            ERR_UNKNOWN
+            ERR_WRONGMODE,                  // mode has changed
+            ERR_CANTLOCK,
+            ERR_UNKNOWN,
         };
 
 		explicit DirectX(ISystemState* state);

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -25,7 +25,11 @@
 
 // FIXME: This should be defined on the command line
 #define DIRECTINPUT_VERSION 0x0800
+#ifdef _LEGACY_VCC
 #define _WIN32_WINNT 0x0500
+#else
+#define _WIN32_WINNT 0x0601 // Windows 7
+#endif
 #ifndef ABOVE_NORMAL_PRIORITY_CLASS
 //#define ABOVE_NORMAL_PRIORITY_CLASS  32768
 #endif
@@ -43,6 +47,7 @@
 #include "BuildConfig.h"
 #include <objbase.h>
 #include <windowsx.h>
+#include <WinUser.h>
 #include <process.h>
 #include <commdlg.h>
 #include <stdio.h>
@@ -138,6 +143,7 @@ static	HANDLE hEMUQuit;
 static char g_szAppName[MAX_LOADSTRING] = "";
 bool BinaryRunning;
 static unsigned char FlagEmuStop=TH_RUNNING;
+const GUID* PowerGUID;
 
 bool IsShiftKeyDown();
 
@@ -145,7 +151,30 @@ using VCC::Bus::gVccCartMenu;
 
 static bool gHasFocus {};
 
-//static CRITICAL_SECTION  FrameRender;
+#ifndef _LEGACY_VCC
+extern "C" NTSTATUS NTAPI RtlGetVersion(POSVERSIONINFOW);
+#pragma comment(lib, "ntdll")
+
+bool IsWin8_OrLater()
+{
+	OSVERSIONINFOW osvi = { sizeof(osvi) };
+	RtlGetVersion(&osvi);
+	return (osvi.dwMajorVersion > 6) ||
+		(osvi.dwMajorVersion == 6 && osvi.dwMinorVersion >= 2);
+}
+#endif
+
+void RegisterDisplayNotification(HWND hWnd)
+{
+#ifndef _LEGACY_VCC
+	if (IsWin8_OrLater())
+		PowerGUID = &GUID_CONSOLE_DISPLAY_STATE;   // Win 8+
+	else
+		PowerGUID = &GUID_MONITOR_POWER_ON;        // Win 7 fallback
+
+	RegisterPowerSettingNotification(hWnd, PowerGUID, DEVICE_NOTIFY_WINDOW_HANDLE);
+#endif
+}
 
 //--------------------------------------------------------------------------//
 //  Main entry
@@ -190,6 +219,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance,
 		exit(0);
 	}
 
+	RegisterDisplayNotification(EmuState.WindowHandle);
 	InitSound();
 	LoadModule();
 	SetClockSpeed(1);	//Default clock speed .89 MHZ	
@@ -301,6 +331,21 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 	switch (message)
 	{
+#ifndef _LEGACY_VCC
+		case WM_POWERBROADCAST:
+			if (wParam == PBT_POWERSETTINGCHANGE) 
+			{
+				auto p = reinterpret_cast<POWERBROADCAST_SETTING*>(lParam);
+				if (p->PowerSetting == *PowerGUID) 
+				{
+					DWORD state = *reinterpret_cast<LPDWORD>(p->Data);
+					// 0 = off, 1 = on, 2 = dimmed
+					if (state == 1) OnMonitorRestored();
+				}
+			}
+			break;
+#endif
+
 		// Hard reset VCC
 		case WM_VCC_CPU_RESET:
 			if (EmuState.EmulationRunning)

--- a/audio.h
+++ b/audio.h
@@ -35,5 +35,6 @@ struct SndCardList
 const int AUDIO_RATE = 44100;
 
 int GetSoundCardList (SndCardList *);
+void OnMonitorRestored();
 
 #endif

--- a/coco3.cpp
+++ b/coco3.cpp
@@ -153,7 +153,7 @@ void UpdateAudio()
 #endif // USE_DEBUG_AUDIOTAPE
 
 	// keep audio system full by tiny expansion of sound
-	if (AudioFreeBlockCount > 1 && (AudioIndex & 63) == 1)
+	if (AudioFreeBlockCount > 1 && (AudioIndex & 63) == 1 && AudioIndex < 16384-2)
 	{
 		unsigned int last = AudioBuffer[AudioIndex - 1];
 		AudioBuffer[AudioIndex++] = last;
@@ -610,6 +610,11 @@ unsigned int SetAudioRate (unsigned int Rate)
 	}
 	SoundRate=Rate;
 	return 0;
+}
+
+unsigned int GetAudioRate()
+{
+	return SoundRate;
 }
 
 void AudioOut()

--- a/coco3.h
+++ b/coco3.h
@@ -47,5 +47,6 @@ void PasteText();
 void QueueText(const char *);
 void CopyText();
 unsigned int SetAudioRate(unsigned int);
+unsigned int GetAudioRate();
 
 #endif


### PR DESCRIPTION
- recover the audio when it stalls, usually when display is turned off.
- this fixes the large slowdown seen recently in ##vcc chat.