### PR TITLE
Fix debugger/memory window memory access on gime registers

### DIFF
--- a/tcc1014mmu.cpp
+++ b/tcc1014mmu.cpp
@@ -25,6 +25,7 @@ This file is part of VCC (Virtual Color Computer).
 #include "iobus.h"
 #include "config.h"
 #include "tcc1014graphics.h"
+#include "tcc1014registers.h"
 #include "pakinterface.h"
 #include <vcc/util/logger.h>
 #include "hd6309.h"
@@ -260,6 +261,8 @@ unsigned char SafeMemRead8(unsigned short address)
 	if (mem_initializing) return 0;
 	// Filter port reads that are not GIME or SAM
 	if ((address > 0xFEFF) && (address < 0xFF90)) return memory[address];
+	// Return gime registers without state change, e.g. ff92/ff93 change state
+	if (address >= 0xFF90 && address <= 0xFFBF) return SafeGimeRead((uint8_t)(address&0xFF));
 	// Otherwise use normal MMU MemRead8
 	return MemRead8(address);
 }

--- a/tcc1014registers.cpp
+++ b/tcc1014registers.cpp
@@ -162,6 +162,18 @@ void GimeWrite(unsigned char port,unsigned char data)
 	return;
 }
 
+//
+// return gime registers (normally unreadable) for the debugger/memory window
+// and without changing any state.
+//
+unsigned char SafeGimeRead(unsigned char port)
+{
+	// TODO: return last irq state
+	if (port == 0x92) return GimeRegisters[port];
+	if (port == 0x93) return GimeRegisters[port];
+	return GimeRegisters[port];
+}
+
 unsigned char GimeRead(unsigned char port)
 {
 	// iobus sets port range 0x90 to 0xBF

--- a/tcc1014registers.h
+++ b/tcc1014registers.h
@@ -21,6 +21,7 @@ This file is part of VCC (Virtual Color Computer).
 
 void GimeWrite(unsigned char,unsigned char);
 unsigned char GimeRead(unsigned char);
+unsigned char SafeGimeRead(unsigned char port); // for debug only
 void GimeAssertKeyboardInterupt();
 unsigned char GimeGetKeyboardInteruptState();
 void GimeAssertHorzInterupt();


### PR DESCRIPTION
- allow debugger, memory window to see gime registers without affecting the state
- previously the memory window was causing state changes on ff92/ff93
- this is pending #597